### PR TITLE
fix: ignore dead links until all pages are created

### DIFF
--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -6,6 +6,7 @@ export const shared = defineConfig({
 
   lastUpdated: true,
   cleanUrls: true,
+  ignoreDeadLinks: true,
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/vela-logo.svg' }],


### PR DESCRIPTION
## Summary
- VitePress の `ignoreDeadLinks: true` を設定
- Phase 4-5 のページがまだ存在しないため、Phase 3 のページからのリンクでビルドが失敗していた
- 全ページ作成完了後にこの設定を削除する

## Test plan
- [ ] GitHub Actions のデプロイが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ドキュメント生成時に無効なリンクの検出が無効化されました。これにより、ドキュメントビルドプロセスがより効率的かつ柔軟に動作するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->