### PR TITLE
docs: add README.md and README.ja.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Geolonia Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -175,6 +175,8 @@ docs/
 
 ## ライセンス
 
-ISC
+MIT License
 
 Copyright (c) 2026 Geolonia Inc.
+
+詳細は [LICENSE](LICENSE) をご覧ください。

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ We welcome contributions! Please follow these guidelines:
 
 ## License
 
-ISC
+MIT License
 
 Copyright (c) 2026 Geolonia Inc.
+
+See [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
     "@playwright/test": "^1.58.2",


### PR DESCRIPTION
## Summary
- Add README.md (English) with project overview, dev setup, testing, translation workflow
- Add README.ja.md (Japanese) with same structure
- Cross-linked between English and Japanese versions

## Content Coverage
✅ Overview and Vela OS description
✅ Tech Stack (VitePress, TypeScript, i18n)
✅ Getting Started (installation, dev, build)
✅ Testing (unit, E2E, all tests)
✅ Translation workflow (planned feature using yuuhitsu)
✅ Project structure
✅ Contributing guidelines
✅ Scripts reference table
✅ License (ISC)

## Test plan
- [ ] README content is accurate
- [ ] All commands listed actually work
- [ ] Links between EN/JA versions work
- [ ] Links to external resources work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * プロジェクト概要、技術スタック、セットアップ、開発・ビルド・テスト手順、翻訳と貢献ワークフローを含む英語・日本語の完全なドキュメントを追加しました。
* **Chores**
  * プロジェクトのライセンス表記をMITに更新し、リポジトリにライセンス文書を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->