### PR TITLE
Migrate documentation to custom domain docs.vela-os.org

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@
 - **デュアル API サポート**: 単一インスタンスで NGSIv2 と NGSI-LD の両方をサポート
 - **日本標準対応**: CADDE 互換、来歴追跡機能を搭載
 
-🌐 **公開ドキュメント**: https://geolonia.github.io/vela-docs/
+🌐 **公開ドキュメント**: https://docs.vela-os.org/
 
 ## 技術スタック
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository hosts the official documentation for **Vela OS**, a serverless F
 - **Dual API Support**: Both NGSIv2 and NGSI-LD on a single instance
 - **Japan Standards Ready**: CADDE compatible with provenance tracking
 
-🌐 **Live Documentation**: https://geolonia.github.io/vela-docs/
+🌐 **Live Documentation**: https://docs.vela-os.org/
 
 ## Tech Stack
 

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -4,7 +4,7 @@ export const shared = defineConfig({
   title: 'Vela OS',
   description: 'FIWARE Orion-compatible Context Broker on AWS Lambda',
 
-  base: '/vela-docs/',
+  base: '/',
   lastUpdated: true,
   cleanUrls: true,
   ignoreDeadLinks: true,

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+docs.vela-os.org

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:4173/vela-docs/',
+    baseURL: 'http://localhost:4173/',
     trace: 'on-first-retry',
   },
   projects: [
@@ -19,7 +19,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'pnpm docs:preview',
-    url: 'http://localhost:4173/vela-docs/',
+    url: 'http://localhost:4173/',
     reuseExistingServer: !process.env.CI,
     timeout: 30000,
   },

--- a/tests/unit/internal-links.test.ts
+++ b/tests/unit/internal-links.test.ts
@@ -45,8 +45,8 @@ describe('internal link validation', () => {
         // Resolve the link relative to the file or docs root
         let targetPath: string
         if (link.startsWith('/')) {
-          // Absolute path from docs root — strip base path /vela-docs/ if present
-          const cleanLink = link.replace(/^\/vela-docs\//, '/')
+          // Absolute path from docs root
+          const cleanLink = link
           targetPath = join(DOCS_DIR, cleanLink.slice(1))
         } else {
           // Relative path


### PR DESCRIPTION
## Summary
This PR migrates the Vela OS documentation from a GitHub Pages subdirectory (`geolonia.github.io/vela-docs/`) to a custom domain (`docs.vela-os.org`). The changes involve updating the base path configuration, test utilities, and documentation references across the project.

## Key Changes
- **VitePress Configuration**: Updated `base` path from `/vela-docs/` to `/` in `docs/.vitepress/config/shared.ts` to reflect the root-level deployment on the custom domain
- **Playwright Configuration**: Removed `/vela-docs/` path segment from both `baseURL` and `webServer.url` in `playwright.config.ts` to match the new domain structure
- **Test Utilities**: Simplified internal link validation logic in `tests/unit/internal-links.test.ts` by removing the `/vela-docs/` path stripping logic, as links are now relative to the domain root
- **Documentation References**: Updated live documentation URLs in both `README.md` and `README.ja.md` from `https://geolonia.github.io/vela-docs/` to `https://docs.vela-os.org/`
- **DNS Configuration**: Added `CNAME` file pointing to `docs.vela-os.org` for custom domain hosting

## Implementation Details
The migration maintains the same documentation structure and content while simplifying path handling throughout the codebase. All references to the old subdirectory path have been removed, allowing the documentation to be served directly from the root of the custom domain.

https://claude.ai/code/session_01Gxqoxtd2z4cM5T7Eygwn94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * 公式ドキュメンテーションのURLを新しいドメイン(https://docs.vela-os.org/)に更新しました。
  * ドキュメンテーションの基本パス設定を更新しました。

* **テスト**
  * テスト設定とテストロジックをドキュメンテーション環境の変更に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->