### PR TITLE
fix: add PAT for private geonicdb repo checkout

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: geolonia/geonicdb
+          token: ${{ secrets.GEONICDB_PAT }}
           path: .geonicdb-upstream
           sparse-checkout: docs
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
## Summary
- sparse-checkout of `geolonia/geonicdb` が Private リポのため 404 で失敗していた
- `GEONICDB_PAT` secret を `actions/checkout` に渡すことで認証を通す

## 殿の対応
- geonicdb-docs の GitHub Secrets に `GEONICDB_PAT` を追加（`repo` スコープの PAT）

## Test plan
- [ ] `GEONICDB_PAT` secret を設定後、workflow_dispatch で手動実行して成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)