### PR TITLE
fix: fail workflow on translation errors + fix yuuhitsu install

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -65,6 +65,15 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify yuuhitsu is available
+        if: steps.detect.outputs.has_changes == 'true'
+        run: |
+          if ! npx yuuhitsu --help > /dev/null 2>&1; then
+            echo "::error::yuuhitsu CLI is not available. Check installation."
+            exit 1
+          fi
+          echo "yuuhitsu CLI is available"
+
       - name: Translate changed files
         if: steps.detect.outputs.has_changes == 'true'
         env:
@@ -77,15 +86,23 @@ jobs:
             echo "No docs/ja/ files to translate"
             exit 0
           fi
-          echo "Translating $(echo "$JA_FILES" | wc -l) files..."
+          TOTAL=$(echo "$JA_FILES" | wc -l)
+          FAILED=0
+          echo "Translating $TOTAL files..."
           while IFS= read -r file; do
             if [ -f "$file" ]; then
               echo "Translating: $file"
-              npx yuuhitsu translate --input "$file" --lang ja --output "$file" || {
-                echo "WARNING: Failed to translate $file, keeping English content"
-              }
+              if ! npx yuuhitsu translate --input "$file" --lang ja --output "$file"; then
+                echo "::error::Failed to translate $file"
+                FAILED=$((FAILED + 1))
+              fi
             fi
           done <<< "$JA_FILES"
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED/$TOTAL translations failed"
+            exit 1
+          fi
+          echo "All $TOTAL files translated successfully"
 
       - name: Build verification
         if: steps.detect.outputs.has_changes == 'true'

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "vitepress": "^1.6.4",
     "vitest": "^4.0.18",
     "vue": "^3.5.28",
-    "yuuhitsu": "github:geolonia/yuuhitsu"
+    "@geolonia/yuuhitsu": "^0.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@geolonia/yuuhitsu':
+        specifier: ^0.1.0
+        version: 0.1.0(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -26,9 +29,6 @@ importers:
       vue:
         specifier: ^3.5.28
         version: 3.5.28(typescript@5.9.3)
-      yuuhitsu:
-        specifier: github:geolonia/yuuhitsu
-        version: https://codeload.github.com/geolonia/yuuhitsu/tar.gz/461c5d61aa13f6aa43049d605e9938129e3a2d75(ws@8.19.0)
 
 packages:
 
@@ -444,6 +444,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@geolonia/yuuhitsu@0.1.0':
+    resolution: {integrity: sha512-uAHvrz6fyuRbpYAv3DpKf4NGMbjOnt19YYcG6KUhOtd+yz8b94pjo6q/PI9rXTfF9bb8zBWwreErYdfOtFCoag==}
+    hasBin: true
 
   '@google/genai@0.7.0':
     resolution: {integrity: sha512-r+Fwj/emnXZN5R+4JCxDXboY4AGTmTn7+Wnori5dgyJiStP0P82f9YYL0CVsCnDIumNY2i0UIcZ1zGZdtHJ34w==}
@@ -1458,11 +1462,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yuuhitsu@https://codeload.github.com/geolonia/yuuhitsu/tar.gz/461c5d61aa13f6aa43049d605e9938129e3a2d75:
-    resolution: {tarball: https://codeload.github.com/geolonia/yuuhitsu/tar.gz/461c5d61aa13f6aa43049d605e9938129e3a2d75}
-    version: 0.1.0
-    hasBin: true
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -1775,6 +1774,23 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.3':
     optional: true
+
+  '@geolonia/yuuhitsu@0.1.0(ws@8.19.0)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.39.0
+      '@google/genai': 0.7.0
+      chalk: 5.6.2
+      commander: 13.1.0
+      dotenv: 16.6.1
+      openai: 4.104.0(ws@8.19.0)
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
   '@google/genai@0.7.0':
     dependencies:
@@ -2819,22 +2835,5 @@ snapshots:
   ws@8.19.0: {}
 
   yaml@2.8.2: {}
-
-  yuuhitsu@https://codeload.github.com/geolonia/yuuhitsu/tar.gz/461c5d61aa13f6aa43049d605e9938129e3a2d75(ws@8.19.0):
-    dependencies:
-      '@anthropic-ai/sdk': 0.39.0
-      '@google/genai': 0.7.0
-      chalk: 5.6.2
-      commander: 13.1.0
-      dotenv: 16.6.1
-      openai: 4.104.0(ws@8.19.0)
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- 翻訳失敗時にワークフローが success になる問題を修正
- yuuhitsu が GitHub tarball インストールで dist/ ビルド失敗する問題を修正

## Changes
1. **エラーハンドリング強化**
   - `Verify yuuhitsu is available` ステップ追加（CLI が壊れていたら即 fail）
   - 翻訳失敗をカウントし、1件でも失敗したら workflow を fail にする
   - 以前: `|| { echo WARNING }` でエラーを握り潰していた

2. **yuuhitsu 依存の修正**
   - `github:geolonia/yuuhitsu` → `@geolonia/yuuhitsu@^0.1.0`（npm レジストリ版）
   - GitHub tarball では `prepare` が動かず `dist/cli/index.js` が生成されなかった
   - npm 版はビルド済み dist/ を含むので問題なし

## Test plan
- [ ] PR マージ後、Actions → "Sync and Translate" を workflow_dispatch で手動実行
- [ ] yuuhitsu が正常にインストールされ翻訳が成功することを確認
- [ ] ANTHROPIC_API_KEY secret が未設定の場合は workflow が fail することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 翻訳ワークフローのエラーハンドリングと検証を強化し、処理失敗時の報告精度を向上させました
  * 依存パッケージを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->