### PR TITLE
fix: use PAT for create-pull-request to trigger CI

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -112,6 +112,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
+          token: ${{ secrets.GEONICDB_PAT }}
           commit-message: "docs: sync and translate from geonicdb/docs (${{ github.event.client_payload.sha || 'manual' }})"
           title: "docs: sync and translate from geonicdb/docs"
           body: |


### PR DESCRIPTION
## Summary
- `create-pull-request` で `token: ${{ secrets.GEONICDB_PAT }}` を使用するよう変更
- `GITHUB_TOKEN` で作成された PR は GitHub のセキュリティポリシーにより他の workflow（Tests）をトリガーしない
- PAT を使うことで自動生成 PR でも CI が正常に実行される

## Test plan
- [ ] このPRマージ後、sync-and-translate を workflow_dispatch で実行
- [ ] 生成された PR に Tests チェックが走ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チャー**
  * GitHub Actionsワークフロー内の認証処理を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->