### PR TITLE
fix: use DOCS_WRITE_PAT for create-pull-request step

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -112,7 +112,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ secrets.GEONICDB_PAT }}
+          token: ${{ secrets.DOCS_WRITE_PAT }}
           commit-message: "docs: sync and translate from geonicdb/docs (${{ github.event.client_payload.sha || 'manual' }})"
           title: "docs: sync and translate from geonicdb/docs"
           body: |


### PR DESCRIPTION
## 概要

sync-and-translate.yml の create-pull-request ステップで使用するトークンを `GEONICDB_PAT` から `DOCS_WRITE_PAT` に変更。

## 変更内容

- `.github/workflows/sync-and-translate.yml` 115行目: `GEONICDB_PAT` → `DOCS_WRITE_PAT`
- geonicdb checkout 用の GEONICDB_PAT（23行目）は変更なし

## 理由

create-pull-request アクションには geonicdb-docs リポジトリへの書き込み権限が必要。DOCS_WRITE_PAT はその権限を持つ専用 PAT。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Actions ワークフローの認証トークンを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->