### PR TITLE
feat: add post-translation quality fix script and CI step

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -104,6 +104,10 @@ jobs:
           fi
           echo "All $TOTAL files translated successfully"
 
+      - name: Post-translation quality fixes
+        if: steps.detect.outputs.has_changes == 'true'
+        run: npx tsx scripts/fix-doc-quality.ts
+
       - name: Build verification
         if: steps.detect.outputs.has_changes == 'true'
         run: pnpm docs:build

--- a/scripts/fix-doc-quality.ts
+++ b/scripts/fix-doc-quality.ts
@@ -1,0 +1,252 @@
+import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from 'node:fs'
+import { join, relative, dirname } from 'node:path'
+
+// ---------------------------------------------------------------------------
+// fix-doc-quality.ts
+// Post-translation quality fix script for geonicdb-docs.
+// Fixes: (1) bare code blocks, (2) missing frontmatter titles, (3) file parity
+// ---------------------------------------------------------------------------
+
+/**
+ * Infer language identifier from code block content.
+ * Priority order: JSON → bash → SQL → HTTP → text
+ */
+export function inferLanguage(content: string): string {
+  const trimmed = content.trimStart()
+
+  // JSON: starts with { or [
+  if (/^[{\[]/.test(trimmed)) return 'json'
+
+  // bash: line starts with $
+  if (/^\s*\$\s/.test(content)) return 'bash'
+
+  // HTTP: starts with GET/POST/PUT/DELETE/PATCH + URL path
+  // Must check before SQL to avoid DELETE matching SQL pattern
+  if (/^(GET|POST|PUT|DELETE|PATCH)\s+\//i.test(trimmed)) return 'http'
+
+  // SQL: starts with SELECT/INSERT/UPDATE/CREATE/DROP/ALTER (DELETE handled above)
+  if (/^\s*(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)\b/i.test(trimmed)) return 'sql'
+
+  return 'text'
+}
+
+/**
+ * Fix bare code blocks (``` without language) in ja content.
+ * Uses corresponding en content for position-matched language lookup.
+ * Falls back to content-based inference if en has no language either.
+ */
+export function fixBareCodeBlocks(jaContent: string, enContent: string | null): string {
+  // Extract code block language identifiers from en content by order
+  const enLanguages: (string | null)[] = []
+  if (enContent) {
+    const enLines = enContent.split('\n')
+    let inBlock = false
+    for (const line of enLines) {
+      const trimmed = line.trimStart()
+      if (trimmed.startsWith('```')) {
+        if (!inBlock) {
+          const lang = trimmed.slice(3).trim()
+          enLanguages.push(lang || null)
+          inBlock = true
+        } else {
+          inBlock = false
+        }
+      }
+    }
+  }
+
+  const lines = jaContent.split('\n')
+  const result: string[] = []
+  let inBlock = false
+  let blockIndex = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmed = line.trimStart()
+
+    if (trimmed.startsWith('```')) {
+      if (!inBlock) {
+        const lang = trimmed.slice(3).trim()
+        if (!lang) {
+          // Bare code block — collect content to infer language
+          const contentLines: string[] = []
+          let j = i + 1
+          while (j < lines.length) {
+            const nextTrimmed = lines[j].trimStart()
+            if (nextTrimmed.startsWith('```')) break
+            contentLines.push(lines[j])
+            j++
+          }
+
+          // Try position-matched en language first
+          const enLang = enLanguages[blockIndex] ?? null
+          const resolvedLang = enLang ?? inferLanguage(contentLines.join('\n'))
+
+          // Preserve original indentation before the backticks
+          const indent = line.slice(0, line.length - trimmed.length)
+          result.push(`${indent}\`\`\`${resolvedLang}`)
+          inBlock = true
+          blockIndex++
+        } else {
+          result.push(line)
+          inBlock = true
+          blockIndex++
+        }
+      } else {
+        result.push(line)
+        inBlock = false
+      }
+    } else {
+      result.push(line)
+    }
+  }
+
+  return result.join('\n')
+}
+
+/**
+ * Parse frontmatter from markdown content.
+ * Returns null if no frontmatter block found.
+ */
+export function parseFrontmatter(content: string): Record<string, string> | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!match) return null
+  const fm: Record<string, string> = {}
+  for (const line of match[1].split('\n')) {
+    const colonIdx = line.indexOf(':')
+    if (colonIdx > 0) {
+      const key = line.slice(0, colonIdx).trim()
+      const value = line.slice(colonIdx + 1).trim()
+      fm[key] = value
+    }
+  }
+  return fm
+}
+
+/**
+ * Check whether the content already has a title in frontmatter.
+ * layout: home pages are considered to have a title (uses hero.name instead).
+ */
+export function hasFrontmatterTitle(content: string): boolean {
+  const fm = parseFrontmatter(content)
+  if (!fm) return false
+  if (fm['layout'] === 'home') return true
+  return !!fm['title']
+}
+
+/**
+ * Extract title from the first H1 heading in the content.
+ * Returns null if no H1 found.
+ */
+export function extractTitleFromHeading(content: string): string | null {
+  // Skip frontmatter block if present
+  const withoutFm = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '')
+  const match = withoutFm.match(/^#\s+(.+)/m)
+  if (!match) return null
+  return match[1].trim()
+}
+
+/**
+ * Add a title to the frontmatter of the given content.
+ * If frontmatter exists, inserts title as the first field.
+ * If no frontmatter, creates a minimal frontmatter block.
+ */
+export function addFrontmatterTitle(content: string, title: string): string {
+  const hasFm = /^---\r?\n/.test(content)
+  if (hasFm) {
+    // Insert title after opening ---
+    return content.replace(/^---\r?\n/, `---\ntitle: "${title}"\n`)
+  }
+  // No frontmatter — prepend new block
+  return `---\ntitle: "${title}"\n---\n\n${content}`
+}
+
+// ---------------------------------------------------------------------------
+// Main: run all quality fixes
+// ---------------------------------------------------------------------------
+
+function collectMdFiles(dir: string): string[] {
+  const results: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      results.push(...collectMdFiles(fullPath))
+    } else if (entry.name.endsWith('.md')) {
+      results.push(fullPath)
+    }
+  }
+  return results.sort()
+}
+
+function main() {
+  const docsDir = join(process.cwd(), 'docs')
+  const jaDir = join(docsDir, 'ja')
+  const enDir = join(docsDir, 'en')
+
+  if (!existsSync(jaDir)) {
+    console.error(`Error: docs/ja/ not found at ${jaDir}`)
+    process.exit(1)
+  }
+
+  const jaFiles = collectMdFiles(jaDir)
+  let codeBlockFixes = 0
+  let titleFixes = 0
+  let parityFixes = 0
+
+  for (const jaFile of jaFiles) {
+    const relPath = relative(jaDir, jaFile)
+    const enFile = join(enDir, relPath)
+
+    let jaContent = readFileSync(jaFile, 'utf-8')
+    let changed = false
+
+    // (1) Fix bare code blocks
+    const enContent = existsSync(enFile) ? readFileSync(enFile, 'utf-8') : null
+    const fixed = fixBareCodeBlocks(jaContent, enContent)
+    if (fixed !== jaContent) {
+      jaContent = fixed
+      changed = true
+      codeBlockFixes++
+      console.log(`  [code-block] Fixed: ja/${relPath}`)
+    }
+
+    // (2) Fix missing frontmatter title
+    if (!hasFrontmatterTitle(jaContent)) {
+      const title = extractTitleFromHeading(jaContent)
+      if (title) {
+        jaContent = addFrontmatterTitle(jaContent, title)
+        changed = true
+        titleFixes++
+        console.log(`  [frontmatter] Added title "${title}": ja/${relPath}`)
+      } else {
+        console.warn(`  [frontmatter] WARN: no title or H1 found in ja/${relPath}`)
+      }
+    }
+
+    if (changed) {
+      writeFileSync(jaFile, jaContent, 'utf-8')
+    }
+  }
+
+  // (3) File parity: copy ja-only files to en/
+  for (const jaFile of jaFiles) {
+    const relPath = relative(jaDir, jaFile)
+    const enFile = join(enDir, relPath)
+    if (!existsSync(enFile)) {
+      const enDestDir = dirname(enFile)
+      mkdirSync(enDestDir, { recursive: true })
+      const content = readFileSync(jaFile, 'utf-8')
+      writeFileSync(enFile, content, 'utf-8')
+      parityFixes++
+      console.log(`  [parity] Copied to en/: ${relPath}`)
+    }
+  }
+
+  console.log(`\nDone: ${codeBlockFixes} code-block fixes, ${titleFixes} title fixes, ${parityFixes} parity fixes.`)
+}
+
+// Only run main when executed directly (not when imported by tests)
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/tests/unit/fix-doc-quality.test.ts
+++ b/tests/unit/fix-doc-quality.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from 'vitest'
+import {
+  inferLanguage,
+  fixBareCodeBlocks,
+  extractTitleFromHeading,
+  addFrontmatterTitle,
+  hasFrontmatterTitle,
+} from '../../scripts/fix-doc-quality.js'
+
+// ---------------------------------------------------------------------------
+// inferLanguage
+// ---------------------------------------------------------------------------
+describe('inferLanguage', () => {
+  it('detects JSON from curly-brace structure', () => {
+    expect(inferLanguage('{\n  "key": "value"\n}')).toBe('json')
+  })
+
+  it('detects JSON from array structure', () => {
+    expect(inferLanguage('[{"id": 1}, {"id": 2}]')).toBe('json')
+  })
+
+  it('detects bash from $ prefix', () => {
+    expect(inferLanguage('$ npm install')).toBe('bash')
+  })
+
+  it('detects bash from $ prefix with leading whitespace', () => {
+    expect(inferLanguage('  $ curl -X GET http://example.com')).toBe('bash')
+  })
+
+  it('detects sql from SELECT statement', () => {
+    expect(inferLanguage('SELECT * FROM entities')).toBe('sql')
+  })
+
+  it('detects sql from INSERT statement', () => {
+    expect(inferLanguage('INSERT INTO entities (id) VALUES (1)')).toBe('sql')
+  })
+
+  it('detects sql from CREATE TABLE statement', () => {
+    expect(inferLanguage('CREATE TABLE test (id INT)')).toBe('sql')
+  })
+
+  it('detects http from GET request', () => {
+    expect(inferLanguage('GET /api/v1/entities HTTP/1.1')).toBe('http')
+  })
+
+  it('detects http from POST request', () => {
+    expect(inferLanguage('POST /api/v1/entities HTTP/1.1')).toBe('http')
+  })
+
+  it('detects http from PUT request', () => {
+    expect(inferLanguage('PUT /api/v1/entities/1 HTTP/1.1')).toBe('http')
+  })
+
+  it('detects http from DELETE request', () => {
+    expect(inferLanguage('DELETE /api/v1/entities/1 HTTP/1.1')).toBe('http')
+  })
+
+  it('falls back to text for unrecognized content', () => {
+    expect(inferLanguage('some random content here')).toBe('text')
+  })
+
+  it('falls back to text for empty string', () => {
+    expect(inferLanguage('')).toBe('text')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fixBareCodeBlocks
+// ---------------------------------------------------------------------------
+describe('fixBareCodeBlocks', () => {
+  it('adds language from en counterpart at same position', () => {
+    const ja = '# Title\n\n```\n{"key": "value"}\n```\n'
+    const en = '# Title\n\n```json\n{"key": "value"}\n```\n'
+    const result = fixBareCodeBlocks(ja, en)
+    // Opening fence should now have language identifier
+    expect(result).toContain('```json\n{"key": "value"}')
+    // Content should differ from input (was modified)
+    expect(result).not.toBe(ja)
+  })
+
+  it('infers language from content when en has no language either', () => {
+    const ja = '# Title\n\n```\n$ npm install\n```\n'
+    const en = '# Title\n\n```\n$ npm install\n```\n'
+    const result = fixBareCodeBlocks(ja, en)
+    // Opening fence should now have inferred language identifier
+    expect(result).toContain('```bash\n$ npm install')
+    expect(result).not.toBe(ja)
+  })
+
+  it('infers language from content when en is null', () => {
+    const ja = '# Title\n\n```\n SELECT * FROM t\n```\n'
+    const result = fixBareCodeBlocks(ja, null)
+    expect(result).toContain('```sql')
+  })
+
+  it('does not modify code blocks that already have language', () => {
+    const ja = '# Title\n\n```javascript\nconsole.log("hi")\n```\n'
+    const en = '# Title\n\n```javascript\nconsole.log("hi")\n```\n'
+    const result = fixBareCodeBlocks(ja, en)
+    expect(result).toBe(ja)
+  })
+
+  it('handles multiple code blocks, some bare some not', () => {
+    const ja = [
+      '# Title',
+      '',
+      '```json',
+      '{"a": 1}',
+      '```',
+      '',
+      '```',
+      '$ curl example.com',
+      '```',
+    ].join('\n')
+    const en = [
+      '# Title',
+      '',
+      '```json',
+      '{"a": 1}',
+      '```',
+      '',
+      '```bash',
+      '$ curl example.com',
+      '```',
+    ].join('\n')
+    const result = fixBareCodeBlocks(ja, en)
+    // First block already had language — should be preserved
+    expect(result).toContain('```json\n{"a": 1}')
+    // Second block was bare — should be fixed with en's language
+    expect(result).toContain('```bash\n$ curl example.com')
+  })
+
+  it('uses position-matched en language over content inference', () => {
+    // Content looks like JSON but en says yaml
+    const ja = '# Title\n\n```\nkey: value\n```\n'
+    const en = '# Title\n\n```yaml\nkey: value\n```\n'
+    const result = fixBareCodeBlocks(ja, en)
+    expect(result).toContain('```yaml')
+  })
+
+  it('returns original content unchanged when no bare code blocks', () => {
+    const ja = '# Title\n\nSome text without code blocks.\n'
+    const result = fixBareCodeBlocks(ja, null)
+    expect(result).toBe(ja)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractTitleFromHeading
+// ---------------------------------------------------------------------------
+describe('extractTitleFromHeading', () => {
+  it('extracts title from first H1 heading', () => {
+    expect(extractTitleFromHeading('# My Title\n\nSome content')).toBe('My Title')
+  })
+
+  it('extracts title after frontmatter', () => {
+    const content = '---\ndescription: foo\n---\n\n# My Title\n\nContent'
+    expect(extractTitleFromHeading(content)).toBe('My Title')
+  })
+
+  it('returns null when no H1 heading exists', () => {
+    expect(extractTitleFromHeading('## Subtitle\n\nContent')).toBeNull()
+  })
+
+  it('returns null for empty content', () => {
+    expect(extractTitleFromHeading('')).toBeNull()
+  })
+
+  it('trims whitespace from title', () => {
+    expect(extractTitleFromHeading('#   Spaced Title  \n')).toBe('Spaced Title')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// hasFrontmatterTitle
+// ---------------------------------------------------------------------------
+describe('hasFrontmatterTitle', () => {
+  it('returns true when title exists in frontmatter', () => {
+    expect(hasFrontmatterTitle('---\ntitle: My Title\n---\n# Heading')).toBe(true)
+  })
+
+  it('returns false when title missing from frontmatter', () => {
+    expect(hasFrontmatterTitle('---\ndescription: foo\n---\n# Heading')).toBe(false)
+  })
+
+  it('returns false when no frontmatter exists', () => {
+    expect(hasFrontmatterTitle('# Heading\n\nContent')).toBe(false)
+  })
+
+  it('returns true for layout: home pages (no title needed)', () => {
+    expect(hasFrontmatterTitle('---\nlayout: home\nhero:\n  name: Test\n---')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// addFrontmatterTitle
+// ---------------------------------------------------------------------------
+describe('addFrontmatterTitle', () => {
+  it('adds title to existing frontmatter', () => {
+    const content = '---\ndescription: foo\n---\n\n# Heading\n'
+    const result = addFrontmatterTitle(content, 'My Title')
+    expect(result).toContain('title: "My Title"')
+    expect(result).toContain('description: foo')
+  })
+
+  it('creates frontmatter with title when none exists', () => {
+    const content = '# Heading\n\nContent'
+    const result = addFrontmatterTitle(content, 'My Title')
+    expect(result).toMatch(/^---\ntitle: "My Title"\n---/)
+    expect(result).toContain('# Heading')
+  })
+
+  it('preserves other frontmatter fields', () => {
+    const content = '---\ndescription: bar\noutline: deep\n---\n# H'
+    const result = addFrontmatterTitle(content, 'Test')
+    expect(result).toContain('description: bar')
+    expect(result).toContain('outline: deep')
+    expect(result).toContain('title: "Test"')
+  })
+})


### PR DESCRIPTION
## Summary
- `scripts/fix-doc-quality.ts` を新規追加: 翻訳後の3種類の品質問題を自動修正
  - 裸のコードブロック（言語識別子なし ` ``` ` ）の自動補完
  - frontmatter の `title` フィールド欠落の自動補完
  - `docs/ja/` にあって `docs/en/` にないファイルのパリティ修正
- `sync-and-translate.yml` に「Post-translation quality fixes」ステップを追加（翻訳後・ビルド前）
- ユニットテスト32件追加（SKIP=0, 全PASS確認済み）

## Test plan
- [ ] `pnpm test` でユニットテスト32件が全PASS（SKIP=0）であることを確認
- [ ] CI が正常に通過することを確認（sync-and-translate workflow）
- [ ] PR マージ後、次回の翻訳実行時に quality fixes ステップが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)