### PR TITLE
fix: correct translation direction (Japanese → English)

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Detect changed files
         id: detect
         run: |
-          # sync-docs writes English content to docs/ja/ paths
-          # Check for any .md file changes
+          # sync-docs writes Japanese content into docs/ja/ paths
+          # Check for any .md file changes in docs/ (includes both docs/ja/ and docs/en/)
           CHANGED=$(git diff --name-only -- 'docs/' | grep '\.md$' || true)
           UNTRACKED=$(git ls-files --others --exclude-standard -- 'docs/' | grep '\.md$' || true)
           ALL_CHANGED=$(echo -e "${CHANGED}\n${UNTRACKED}" | sort -u | grep -v '^$' || true)
@@ -79,8 +79,8 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          # sync-docs puts English content into docs/ja/ paths.
-          # Translate each changed ja file from English to Japanese in-place.
+          # sync-docs puts Japanese content into docs/ja/ paths.
+          # Translate each changed ja file from Japanese to English, output to docs/en/.
           JA_FILES=$(grep '^docs/ja/' /tmp/changed_files.txt || true)
           if [ -z "$JA_FILES" ]; then
             echo "No docs/ja/ files to translate"
@@ -91,8 +91,10 @@ jobs:
           echo "Translating $TOTAL files..."
           while IFS= read -r file; do
             if [ -f "$file" ]; then
-              echo "Translating: $file"
-              if ! npx yuuhitsu translate --input "$file" --lang ja --output "$file"; then
+              en_file="${file/docs\/ja\//docs\/en\/}"
+              echo "Translating: $file -> $en_file"
+              mkdir -p "$(dirname "$en_file")"
+              if ! npx yuuhitsu translate --input "$file" --lang en --output "$en_file"; then
                 echo "::error::Failed to translate $file"
                 FAILED=$((FAILED + 1))
               fi
@@ -130,7 +132,7 @@ jobs:
 
             ### Process
             1. Synced docs from geolonia/geonicdb
-            2. Translated changed English docs to Japanese via yuuhitsu
+            2. Translated changed Japanese docs to English via yuuhitsu
             3. Build verification passed
           branch: docs/auto-sync-translate
           base: main


### PR DESCRIPTION
## Summary

- **設計バグ修正**: geonicdb/docs/ は日本語原文なのに「英→日」翻訳していた問題を修正
- sync-docs: geonicdb/docs/ → docs/ja/ はコピーのみ（翻訳不要）
- 翻訳: docs/ja/ → docs/en/ に日→英翻訳（`yuuhitsu --lang en`）
- fix-doc-quality.ts: docs/ja/ ではなく docs/en/ 側のファイルを処理するよう変更
- `runQualityFixes(baseDir)` 関数を export してテスト可能に

## Changes

- `.github/workflows/sync-and-translate.yml` — コメント修正・翻訳ステップ修正・PR本文修正
- `scripts/fix-doc-quality.ts` — `runQualityFixes` export、en/ 側処理に変更、パラメータ名汎用化
- `tests/unit/fix-doc-quality.test.ts` — `runQualityFixes` integration tests 6件追加

## Test plan

- [x] 38テスト全PASS、SKIP=0
- [x] code-review-expert --auto: P0/P1 なし
- [x] main直接commit禁止遵守: fix/translate-direction ブランチ経由

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ドキュメント翻訳ワークフローの最適化。日本語から英語への翻訳処理を改善しました。
  * ドキュメント品質管理機能を強化し、より確実なドキュメント処理が可能になりました。
  * テストカバレッジを拡大し、ドキュメント品質フィックス機能の信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->