### PR TITLE
feat: extend fix-doc-quality.ts to process both docs/ja/ and docs/en/

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -106,7 +106,7 @@ jobs:
           fi
           echo "All $TOTAL files translated successfully"
 
-      - name: Post-translation quality fixes
+      - name: Post-translation quality fixes (docs/ja/ and docs/en/)
         if: steps.detect.outputs.has_changes == 'true'
         run: npx tsx scripts/fix-doc-quality.ts
 


### PR DESCRIPTION
## Summary

Extend quality fix script to process both Japanese and English documentation directories.

Previously only `docs/en/` was processed using `docs/ja/` as reference. Now both directories receive quality fixes:
- **docs/ja/**: Uses content-based language inference (no reference file)
- **docs/en/**: Uses docs/ja/ as reference (existing behavior)

This ensures that bare code blocks and missing frontmatter titles are fixed in the Japanese source files before they're copied or translated to English.

## Changes

1. **scripts/fix-doc-quality.ts**
   - Added ja/ processing loop before en/ processing
   - ja/ files use `fixBareCodeBlocks(content, null)` for content inference
   - Updated comments to reflect both directories

2. **.github/workflows/sync-and-translate.yml**
   - Updated step name to clarify both directories are processed

3. **tests/unit/fix-doc-quality.test.ts**
   - Added 3 new tests for ja/ processing
   - Updated parity test to expect modified ja/ content

## Test Results

✅ 45/45 tests PASS  
✅ SKIP=0  
✅ Code review: P0/P1 clean

## Motivation

cmd_095 changed the translation direction so that `docs/ja/` receives direct copies from the upstream geonicdb repo. However, the quality fix script only processed `docs/en/`, leaving quality issues (bare code blocks, missing titles) in `docs/ja/` files, which caused CI failures.

This PR ensures both directories are quality-checked, fixing issues at the source.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ドキュメント品質改善ツールが日本語と英語の両方のファイルに対応しました。日本語ドキュメントではコンテンツから自動的にコードブロック言語を判定し、メタデータを補完します。英語ドキュメントでも同じプロセスが適用され、ドキュメント全体の一貫性と品質が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->