### PR TITLE
fix(glossary): 誤記修正3件 + brand/domain 11用語追加

### DIFF
--- a/glossary.yaml
+++ b/glossary.yaml
@@ -6,12 +6,20 @@ glossary:
       description: Geolonia's geospatial database service built on NGSI-LD standard
     - term: Geolonia
       en: Geolonia
-      ja: ジオリア
+      ja: ジオロニア
       description: Company that develops and operates GeonicDB
     - term: NGSI-LD
       en: NGSI-LD
       ja: NGSI-LD
       description: Next Generation Service Interface with Linked Data — the open standard protocol that GeonicDB implements
+    - term: MapLibre
+      en: MapLibre
+      ja: MapLibre
+      description: Open-source map rendering library used in GeonicDB demo applications
+    - term: FIWARE
+      en: FIWARE
+      ja: FIWARE
+      description: IoT platform standard and open-source ecosystem; GeonicDB implements the NGSI-LD subset
 
   domain:
     - term: entity
@@ -28,11 +36,11 @@ glossary:
       description: A geospatial attribute on a GeonicDB entity (e.g. Point, Polygon) conforming to the NGSI-LD GeoProperty type
     - term: ReactiveCore
       en: ReactiveCore
-      ja: リアクティブコア
+      ja: ReactiveCore
       description: GeonicDB's rule engine that reacts to entity changes and triggers actions (e.g. notifications, data pipelines)
     - term: MCP
       en: MCP
-      ja: モデルコンテキストプロトコル
+      ja: MCP
       description: Model Context Protocol — the AI tool-call interface exposed by GeonicDB, enabling LLMs to operate the database
     - term: tenant
       en: tenant
@@ -50,6 +58,45 @@ glossary:
       en: diff
       ja: 差分
       description: The set of attribute changes between two snapshots of an entity; surfaced in the Temporal Viewer
+    - term: Context Broker
+      en: Context Broker
+      ja: コンテキストブローカー
+      description: The NGSI-LD server component that stores and manages context (entity) data; GeonicDB acts as a Context Broker
+    - term: Subscription
+      en: Subscription
+      ja: サブスクリプション
+      do_not_use: 購読
+      description: An NGSI-LD construct that triggers Notifications when entity data matching a given condition changes
+    - term: ServicePath
+      en: ServicePath
+      ja: ServicePath
+      do_not_use: サービスパス
+      description: A hierarchical path used to partition entities within a tenant; maps to the FIWARE-ServicePath header
+    - term: Attribute
+      en: Attribute
+      ja: 属性
+      do_not_use: アトリビュート
+      description: A named data field on a GeonicDB entity; can be a Property, GeoProperty, or Relationship
+    - term: Property
+      en: Property
+      ja: プロパティ
+      description: An NGSI-LD value-type attribute on an entity; holds scalar or structured data values
+    - term: Relationship
+      en: Relationship
+      ja: リレーションシップ
+      description: An NGSI-LD reference-type attribute on an entity; points to another entity by ID
+    - term: Notification
+      en: Notification
+      ja: 通知
+      description: An event payload delivered to a subscriber endpoint when entity data matching a Subscription condition changes
+    - term: WebSocket
+      en: WebSocket
+      ja: WebSocket
+      description: Real-time bidirectional connection used by GeonicDB to push entity change events to clients
+    - term: API Key
+      en: API Key
+      ja: APIキー
+      description: Authentication credential used to access the GeonicDB REST/MCP API
 
   ui:
     - term: Dashboard


### PR DESCRIPTION
## Summary

- **誤記修正 3件**（殿の直接指摘）:
  - Geolonia: ~~ジオリア~~ → ジオロニア
  - ReactiveCore: ~~リアクティブコア~~ → ReactiveCore（ブランド名は翻訳しない）
  - MCP: ~~モデルコンテキストプロトコル~~ → MCP（略称のまま使用）

- **brand 追加 2件**: MapLibre, FIWARE
- **domain 追加 9件**: Context Broker, Subscription, ServicePath, Attribute, Property, Relationship, Notification, WebSocket, API Key

## Test plan

- [x] `pnpm test` — 46 tests PASS, SKIP 0
- [x] LF 改行コード確認済み

Part of #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * MapLibreおよびFIWAREの用語を用語集に追加しました
  * NGSI-LD関連の用語（Context Broker、Subscription、Attributeなど）を新たに追加しました
  * 既存用語の日本語翻訳を修正しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->