### PR TITLE
feat: add CLAUDE.md and CI glossary check gate (warn-only)

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -110,6 +110,29 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         run: npx tsx scripts/fix-doc-quality.ts
 
+      - name: Glossary compliance check (warn-only)
+        if: steps.detect.outputs.has_changes == 'true'
+        continue-on-error: true   # warn-only: cmd_206 完了後に削除して strict にする
+        run: |
+          # Check all ja docs after translation
+          FAILED=0
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            TOTAL=$((TOTAL + 1))
+            echo "Checking: $f"
+            if ! npx --yes @geolonia/yuuhitsu glossary check \
+                --input "$f" \
+                --glossary glossary.yaml \
+                --lang ja; then
+              echo "::warning file=$f::Glossary violation detected"
+              FAILED=$((FAILED + 1))
+            fi
+          done < <(find docs/ja -name "*.md" -print0)
+          echo "Glossary compliance check: $FAILED/$TOTAL files have violations"
+          if [ "$FAILED" -gt 0 ]; then
+            exit 1
+          fi
+
       - name: Build verification
         if: steps.detect.outputs.has_changes == 'true'
         run: pnpm docs:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,36 @@ jobs:
 
       - name: Run E2E tests
         run: pnpm test:e2e
+
+  glossary-check:
+    name: Glossary Check (warn-only until cmd_206 complete)
+    runs-on: ubuntu-latest
+    continue-on-error: true   # warn-only: cmd_206 完了後に削除して strict にする
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Glossary check (docs/ja/)
+        run: |
+          FAILED=0
+          TOTAL=0
+          while IFS= read -r -d '' f; do
+            TOTAL=$((TOTAL + 1))
+            echo "Checking: $f"
+            if ! npx --yes @geolonia/yuuhitsu glossary check \
+                --input "$f" \
+                --glossary glossary.yaml \
+                --lang ja; then
+              echo "::warning file=$f::Glossary violation detected"
+              FAILED=$((FAILED + 1))
+            fi
+          done < <(find docs/ja -name "*.md" -print0)
+          echo "Glossary check complete: $FAILED/$TOTAL files have violations"
+          if [ "$FAILED" -gt 0 ]; then
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# GeonicDB Docs — CLAUDE.md
+
+## プロジェクト概要
+
+GeonicDB の公式ドキュメントサイト。[VitePress](https://vitepress.dev/) を使用して構築されており、日本語（`docs/ja/`）と英語（`docs/en/`）の二言語対応。
+
+ドキュメントのソースは `geolonia/geonicdb` リポジトリの `docs/` ディレクトリから自動同期・翻訳される。
+
+## ビルド手順
+
+```bash
+pnpm install
+pnpm docs:build
+```
+
+開発サーバー（ホットリロード付き）:
+
+```bash
+pnpm docs:dev
+```
+
+## テスト
+
+```bash
+# ユニットテスト
+pnpm test:unit
+
+# E2E テスト（Playwright）
+pnpm test:e2e
+```
+
+## 翻訳ルール
+
+### 用語集準拠
+
+翻訳・編集時は必ず `glossary.yaml` に準拠すること。
+
+- **commit 前に glossary check を実行すること**:
+  ```bash
+  npx @geolonia/yuuhitsu glossary check --input <file> --glossary glossary.yaml --lang ja
+  ```
+- 新しい用語を追加した場合は `glossary.yaml` も更新すること
+- コードブロック・URL 内の用語は対象外
+- `type: brand` の用語は翻訳せず原語のまま保持すること
+
+### 翻訳ディレクトリ構成
+
+- `docs/ja/` — 日本語ドキュメント（一次ソース）
+- `docs/en/` — 英語ドキュメント（yuuhitsu による自動翻訳）
+
+## CI（GitHub Actions）
+
+### test.yml
+
+PR / mainへのpushで実行:
+- `unit-tests` — `pnpm test:unit`
+- `e2e-tests` — Playwright E2E テスト
+- `glossary-check` — `docs/ja/` 全ファイルに対して glossary 用語チェック（**warn-only**。cmd_206 完了後に strict に切り替える）
+
+### sync-and-translate.yml
+
+`workflow_dispatch` または `repository_dispatch` で実行:
+1. `geolonia/geonicdb` の `docs/` を同期
+2. 変更された日本語ファイルを英語に翻訳（yuuhitsu）
+3. ドキュメント品質修正
+4. PR 作成
+
+翻訳後に glossary compliance check が走る（warn-only）。
+
+## 重要ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `glossary.yaml` | 用語集（翻訳・表記ゆれチェックの基準） |
+| `yuuhitsu.config.yaml` | yuuhitsu CLI 設定（provider, model, glossary パス） |
+| `.github/workflows/test.yml` | CI テスト + glossary check |
+| `.github/workflows/sync-and-translate.yml` | 自動同期・翻訳パイプライン |
+| `scripts/fix-doc-quality.ts` | ドキュメント品質修正スクリプト |


### PR DESCRIPTION
## Summary

- **CLAUDE.md 作成**: プロジェクト概要、翻訳ルール、ビルド手順、CI 説明を記載
- **test.yml に glossary-check ジョブ追加**: `docs/ja/` 全 .md ファイルに対して `@geolonia/yuuhitsu glossary check` を実行（warn-only）
- **sync-and-translate.yml に glossary compliance check ステップ追加**: 翻訳後・ビルド前に同様のチェックを実施（warn-only）

両ゲートとも `continue-on-error: true` で導入。cmd_206（用語違反修正）完了後に strict モードへ切り替える。

## Test plan

- [ ] CI が warn-only で通ること（既存違反があっても FAIL しない）
- [ ] CLAUDE.md が geonicdb-docs の翻訳ルールを正確に記載していること
- [ ] glossary-check ジョブが test.yml に追加されていること
- [ ] sync-and-translate.yml の翻訳後に glossary check が走ること

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * プロジェクトのセットアップ、ビルド、テストコマンド、翻訳ルール、ディレクトリ構成、CI ワークフロー詳細をまとめたドキュメントを追加しました。

* **Chores**
  * CI パイプラインに用語集準拠性チェックを追加し、自動翻訳品質を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->