### PR TITLE
chore: update @geolonia/yuuhitsu to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.2",
+    "@geolonia/yuuhitsu": "^0.1.3",
     "@playwright/test": "^1.58.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.2
-        version: 0.1.2(ws@8.19.0)
+        specifier: ^0.1.3
+        version: 0.1.3(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -445,8 +445,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.2':
-    resolution: {integrity: sha512-/+zvQuy7i0qp1QJ7aZhEFvWLT3286ToIWj85qU8UcWU4YhtFd0jVb366ewQ/pxQK6Y7blP2dpC89RI/ZUXAUlg==}
+  '@geolonia/yuuhitsu@0.1.3':
+    resolution: {integrity: sha512-KRce27A56/I1o3cOWFUt5Z07glu3uXxdkHBR9QEHTl8NfF97Piztj3fWACkGmbeDHlXmJiR+87CzpXC0OmmOxg==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1844,7 +1844,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.2(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.3(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary

- `@geolonia/yuuhitsu` を 0.1.2 → 0.1.3 に更新
- Glossary Check の相対URLパス除外修正（fix/glossary-relative-url-cmd213）を取り込み

## Changes

- `package.json`: `^0.1.2` → `^0.1.3`
- `pnpm-lock.yaml`: lockfile 更新

## Test plan

- [ ] CI Glossary Check が PASS することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 開発用依存パッケージを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->