### PR TITLE
ci(glossary): strict mode - remove continue-on-error

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -110,9 +110,8 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         run: npx tsx scripts/fix-doc-quality.ts
 
-      - name: Glossary compliance check (warn-only)
+      - name: Glossary compliance check
         if: steps.detect.outputs.has_changes == 'true'
-        continue-on-error: true   # warn-only: cmd_206 完了後に削除して strict にする
         run: |
           # Check all ja docs after translation
           FAILED=0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,9 +60,8 @@ jobs:
         run: pnpm test:e2e
 
   glossary-check:
-    name: Glossary Check (warn-only until cmd_206 complete)
+    name: Glossary Check
     runs-on: ubuntu-latest
-    continue-on-error: true   # warn-only: cmd_206 完了後に削除して strict にする
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## 概要

cmd_206✅・cmd_213✅完了。Glossary Check を warn-only から strict モードへ切り替え。

## 変更内容

### `.github/workflows/test.yml`
- `glossary-check` ジョブ名を `Glossary Check (warn-only until cmd_206 complete)` → `Glossary Check` に変更
- `continue-on-error: true` を削除（warn-only コメント含む）

### `.github/workflows/sync-and-translate.yml`
- `Glossary compliance check (warn-only)` → `Glossary compliance check` に変更
- `continue-on-error: true` を削除（warn-only コメント含む）

## 背景

cmd_206 で全 geonicdb-docs の用語違反を修正済み。
cmd_213 で yuuhitsu を最新版に更新済み。
これにより Glossary Check を strict モードで運用可能となった。

## 確認事項

- [ ] CI `Glossary Check` が PASS することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 用語集コンプライアンスチェックの動作を変更しました。従来は警告のみでワークフローが続行されていましたが、今後はエラーが発生した場合にワークフローが停止するようになります。これにより、品質基準への準拠がより厳密に確保されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->