### PR TITLE
feat(sync): add CLI.md to sync mapping and sidebar

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -90,6 +90,12 @@ function sidebar(): DefaultTheme.Sidebar {
         ],
       },
       {
+        text: 'Reference',
+        items: [
+          { text: 'CLI Reference', link: '/en/reference/cli' },
+        ],
+      },
+      {
         text: 'Security (Coming Soon)',
         items: [
           { text: 'Overview', link: '/en/security/' },

--- a/docs/.vitepress/config/ja.ts
+++ b/docs/.vitepress/config/ja.ts
@@ -103,6 +103,12 @@ function sidebar(): DefaultTheme.Sidebar {
         ],
       },
       {
+        text: 'リファレンス',
+        items: [
+          { text: 'CLI リファレンス', link: '/ja/reference/cli' },
+        ],
+      },
+      {
         text: 'セキュリティ (Coming Soon)',
         items: [
           { text: '概要', link: '/ja/security/' },

--- a/scripts/sync-geonicdb-docs.ts
+++ b/scripts/sync-geonicdb-docs.ts
@@ -131,6 +131,9 @@ const MAPPING_TABLE: Record<string, MappingEntry[]> = {
   'CHANGELOG.md': [
     { dest: 'changelog.md', title: '変更履歴', description: 'GeonicDB の変更履歴' },
   ],
+  'CLI.md': [
+    { dest: 'reference/cli.md', title: 'CLI リファレンス', description: 'GeonicDB CLI (geonic) コマンドリファレンス' },
+  ],
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #49

- Add `CLI.md` → `reference/cli.md` entry to `MAPPING_TABLE` in `sync-geonicdb-docs.ts`
- Add "リファレンス > CLI リファレンス" sidebar section in `ja.ts`
- Add "Reference > CLI Reference" sidebar section in `en.ts`

## How it works

After merge, the next `sync-and-translate` workflow run will:
1. Sync `geonicdb/docs/CLI.md` → `docs/ja/reference/cli.md`
2. Translate via yuuhitsu → `docs/en/reference/cli.md`
3. Auto-create PR with the translated content

## Test plan

- [x] All 46 unit tests pass
- [x] VitePress build succeeds
- [ ] Trigger sync-and-translate workflow after merge to verify CLI.md is synced and translated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * CLI リファレンスドキュメントをナビゲーションに追加しました。
  * 英語と日本語のドキュメントに「リファレンス」セクションを新設し、CLI リファレンスへのアクセスが可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->