### PR TITLE
chore(deps): bump @geolonia/yuuhitsu to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.4",
+    "@geolonia/yuuhitsu": "^0.1.5",
     "@playwright/test": "^1.58.2",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.4
-        version: 0.1.4(ws@8.19.0)
+        specifier: ^0.1.5
+        version: 0.1.5(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -445,8 +445,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.4':
-    resolution: {integrity: sha512-icwO9zUoYuqOKj/kDTP07QNqVqPYTYsG9f6MAiykdCBHn+P0VpD2PX7yPyfxRLxPrsnnDnrq8D7c4f9vWsuI8A==}
+  '@geolonia/yuuhitsu@0.1.5':
+    resolution: {integrity: sha512-wn3/YjHYuqyBHoHvdCIAhFhxig4r6pQbiktmGHMfqAUWcrJne3Vuwh/PASQKGuxFgfvU4xFiw28zEQxR1Q9DKg==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1844,7 +1844,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.4(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.5(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary

- Bump `@geolonia/yuuhitsu` from 0.1.4 to 0.1.5
- v0.1.5 fixes false positives in the glossary compliance checker where forbidden terms inside compound identifiers (e.g., `NGSILD-Warning`, `API_NGSILD.md`) and URN patterns (`urn:ngsi-ld:null`) were incorrectly flagged
- This was blocking the `sync-and-translate` pipeline — all sync runs since 2026-03-03 have failed at the glossary check step

## Context

The sync-and-translate workflow installs yuuhitsu via `pnpm install` (lockfile pinned to 0.1.4), so even though the glossary check step uses `npx --yes @geolonia/yuuhitsu`, the locally-installed version takes precedence. Updating the lockfile is required for the fix to take effect in CI.

## Test plan

- [ ] Merge this PR
- [ ] Trigger `sync-and-translate` workflow (manual or via geonicdb push)
- [ ] Verify glossary compliance check passes (0 violations expected)
- [ ] Verify CLI reference page is generated at `docs/ja/reference/cli.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発用依存パッケージを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->