### PR TITLE
chore: bump @geolonia/yuuhitsu to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.5",
+    "@geolonia/yuuhitsu": "^0.1.6",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.5",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.5
-        version: 0.1.5(ws@8.19.0)
+        specifier: ^0.1.6
+        version: 0.1.6(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -448,8 +448,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.5':
-    resolution: {integrity: sha512-wn3/YjHYuqyBHoHvdCIAhFhxig4r6pQbiktmGHMfqAUWcrJne3Vuwh/PASQKGuxFgfvU4xFiw28zEQxR1Q9DKg==}
+  '@geolonia/yuuhitsu@0.1.6':
+    resolution: {integrity: sha512-O488m0ruEpQNfq2r990JdvRLISxP172qhfwzSFIgLS+OOROXVAU/9XwDlrPuHUI7wezR+guFn78K7tY4AoW1vQ==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1853,7 +1853,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.5(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.6(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary
- Bump `@geolonia/yuuhitsu` from 0.1.5 to 0.1.6
- 0.1.6 includes smart chunking (split by `##` headings instead of byte size) and `max_tokens` increase (4096 → 16384)
- Fixes translation truncation for 7/14 long documents (changelog, cli, faq, compatibility-matrix, etc.)
- Closes #35 (yuuhitsu side)

## Test plan
- [ ] CI passes
- [ ] Re-run Sync and Translate workflow after merge to verify truncation is resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発依存パッケージをアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->