### PR TITLE
fix: split API endpoint docs into separate pages

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -59,7 +59,9 @@ function sidebar(): DefaultTheme.Sidebar {
         text: 'API Reference',
         items: [
           { text: 'NGSIv2 API', link: '/en/api-reference/ngsiv2' },
+          { text: 'NGSIv2 Endpoints', link: '/en/api-reference/ngsiv2-endpoints' },
           { text: 'NGSI-LD API', link: '/en/api-reference/ngsild' },
+          { text: 'NGSI-LD Endpoints', link: '/en/api-reference/ngsild-endpoints' },
           { text: 'Admin API', link: '/en/api-reference/admin' },
           { text: 'Endpoints', link: '/en/api-reference/endpoints' },
           { text: 'Pagination', link: '/en/api-reference/pagination' },

--- a/docs/.vitepress/config/ja.ts
+++ b/docs/.vitepress/config/ja.ts
@@ -72,7 +72,9 @@ function sidebar(): DefaultTheme.Sidebar {
         text: 'API リファレンス',
         items: [
           { text: 'NGSIv2 API', link: '/ja/api-reference/ngsiv2' },
+          { text: 'NGSIv2 エンドポイント', link: '/ja/api-reference/ngsiv2-endpoints' },
           { text: 'NGSI-LD API', link: '/ja/api-reference/ngsild' },
+          { text: 'NGSI-LD エンドポイント', link: '/ja/api-reference/ngsild-endpoints' },
           { text: '管理 API', link: '/ja/api-reference/admin' },
           { text: 'エンドポイント', link: '/ja/api-reference/endpoints' },
           { text: 'ページネーション', link: '/ja/api-reference/pagination' },

--- a/scripts/sync-geonicdb-docs.ts
+++ b/scripts/sync-geonicdb-docs.ts
@@ -71,10 +71,10 @@ const MAPPING_TABLE: Record<string, MappingEntry[]> = {
     { dest: 'api-reference/endpoints.md', title: 'API Endpoints', description: 'Complete list of API endpoints' },
   ],
   'API_ENDPOINTS_NGSIV2.md': [
-    { dest: 'api-reference/ngsiv2.md', title: 'NGSIv2 Endpoints', description: 'NGSIv2 endpoint details' },
+    { dest: 'api-reference/ngsiv2-endpoints.md', title: 'NGSIv2 Endpoints', description: 'NGSIv2 endpoint details' },
   ],
   'API_ENDPOINTS_NGSILD.md': [
-    { dest: 'api-reference/ngsild.md', title: 'NGSI-LD Endpoints', description: 'NGSI-LD endpoint details' },
+    { dest: 'api-reference/ngsild-endpoints.md', title: 'NGSI-LD Endpoints', description: 'NGSI-LD endpoint details' },
   ],
   'AUTH_SCENARIOS.md': [
     { dest: 'security/auth-scenarios.md', title: 'Authentication Scenarios', description: 'Authentication and authorization scenarios (Coming Soon)' },


### PR DESCRIPTION
## Summary
- Split `API_ENDPOINTS_NGSIV2.md` and `API_ENDPOINTS_NGSILD.md` into their own pages instead of merging into `ngsiv2.md` / `ngsild.md`
- `ngsiv2.md` → API overview only, `ngsiv2-endpoints.md` → endpoint details
- `ngsild.md` → API overview only, `ngsild-endpoints.md` → endpoint details
- Updated sidebar navigation for both EN and JA

## Why
- Combined files were too large, causing translation stack overflow (`Maximum call stack size exceeded` on ngsild.md)
- Long pages are bad UX — users should be able to navigate to specific endpoint docs directly

## Changed files
- `scripts/sync-geonicdb-docs.ts` — mapping table dest paths
- `docs/.vitepress/config/en.ts` — EN sidebar
- `docs/.vitepress/config/ja.ts` — JA sidebar

## Test plan
- [ ] CI passes (build + unit tests)
- [ ] Re-run Sync and Translate workflow after merge to verify 14/14 translations succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * API リファレンスセクションに新しいナビゲーション項目を追加しました
  * NGSIv2 エンドポイント情報へのリンクが利用可能になりました
  * NGSI-LD エンドポイント情報へのリンクが利用可能になりました
  * 英語と日本語ドキュメントの両方に対応しています

<!-- end of auto-generated comment: release notes by coderabbit.ai -->