### PR TITLE
debug: stack trace for ngsild.md translation failure

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -93,14 +93,20 @@ jobs:
           fi
           TOTAL=$(echo "$EN_FILES" | wc -l)
           FAILED=0
+          # Debug: show Node.js version and stack size info
+          echo "Node.js: $(node --version)"
+          echo "npx tsx location: $(which npx)"
+          echo "yuuhitsu version: $(npx yuuhitsu --version 2>/dev/null || echo 'unknown')"
+
           echo "Translating $TOTAL files to Japanese (with pipeline guards)..."
           while IFS= read -r file; do
             if [ -f "$file" ]; then
               ja_file="${file/docs\/en\//docs\/ja\/}"
               echo "Translating (protected): $file -> $ja_file"
               mkdir -p "$(dirname "$ja_file")"
-              if ! npx tsx scripts/translate-protected.ts \
-                  --input "$file" --lang ja --output "$ja_file"; then
+              if ! node --stack-size=65536 --stack-trace-limit=100 \
+                  ./node_modules/.bin/tsx scripts/translate-protected.ts \
+                  --input "$file" --lang ja --output "$ja_file" 2>&1; then
                 echo "::error::Failed to translate $file to Japanese"
                 FAILED=$((FAILED + 1))
               fi


### PR DESCRIPTION
## Summary
- Add debugging info for `Maximum call stack size exceeded` error on `ngsild.md` translation
- CI-only issue (works locally)

## Changes
- `--stack-size=65536` and `--stack-trace-limit=100` for full stack trace
- Run tsx directly via `node_modules/.bin/tsx` instead of `npx` to reduce stack depth
- Log Node.js version and yuuhitsu version

## Context
- 13/14 translations succeed, only `ngsild.md` fails with stack overflow
- Reproduces consistently across 3 CI runs
- Does NOT reproduce locally

## Test plan
- [ ] Merge and trigger workflow to capture stack trace
- [ ] Use stack trace to identify root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストには、ユーザーに対する可視的な変更はありません。内部の開発ワークフロー処理の最適化が行われました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->