### PR TITLE
fix: use NODE_OPTIONS for stack size in translation workflow

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -80,6 +80,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          NODE_OPTIONS: "--stack-size=65536 --stack-trace-limit=100"
         run: |
           # sync-docs copies English source docs into docs/en/.
           # translate-protected.ts wraps yuuhitsu with:
@@ -93,9 +94,7 @@ jobs:
           fi
           TOTAL=$(echo "$EN_FILES" | wc -l)
           FAILED=0
-          # Debug: show Node.js version and stack size info
           echo "Node.js: $(node --version)"
-          echo "npx tsx location: $(which npx)"
           echo "yuuhitsu version: $(npx yuuhitsu --version 2>/dev/null || echo 'unknown')"
 
           echo "Translating $TOTAL files to Japanese (with pipeline guards)..."
@@ -104,9 +103,8 @@ jobs:
               ja_file="${file/docs\/en\//docs\/ja\/}"
               echo "Translating (protected): $file -> $ja_file"
               mkdir -p "$(dirname "$ja_file")"
-              if ! node --stack-size=65536 --stack-trace-limit=100 \
-                  ./node_modules/.bin/tsx scripts/translate-protected.ts \
-                  --input "$file" --lang ja --output "$ja_file" 2>&1; then
+              if ! npx tsx scripts/translate-protected.ts \
+                  --input "$file" --lang ja --output "$ja_file"; then
                 echo "::error::Failed to translate $file to Japanese"
                 FAILED=$((FAILED + 1))
               fi


### PR DESCRIPTION
Fix broken translation from PR#62. node_modules/.bin/tsx is a shell script, not JS. Use NODE_OPTIONS env var with npx tsx instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ドキュメント翻訳ワークフローの内部処理を最適化しました。Node.js ランタイムの設定を簡潔にし、ビルドプロセスの効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->