### PR TITLE
fix: remove --stack-size from NODE_OPTIONS

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -80,7 +80,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          NODE_OPTIONS: "--stack-size=65536 --stack-trace-limit=100"
+          NODE_OPTIONS: "--stack-trace-limit=100"
         run: |
           # sync-docs copies English source docs into docs/en/.
           # translate-protected.ts wraps yuuhitsu with:


### PR DESCRIPTION
## Summary
- Remove `--stack-size=65536` from `NODE_OPTIONS` env var in translation workflow
- `--stack-size=` is not allowed in NODE_OPTIONS (V8 restriction), causing all 14 translations to fail
- Keep `--stack-trace-limit=100` for debugging the remaining ngsild.md stack overflow issue

## Context
PR #63 introduced `NODE_OPTIONS="--stack-size=65536 --stack-trace-limit=100"` to debug the ngsild.md stack overflow. However, `--stack-size` is a V8 flag that cannot be passed via NODE_OPTIONS, breaking all translations.

## Test plan
- [ ] Workflow dispatch succeeds and 13/14 translations complete
- [ ] ngsild.md failure produces a stack trace (via `--stack-trace-limit=100`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 翻訳ワークフローの Node.js ランタイム設定を簡略化しました。翻訳プロセスの安定性を向上させるための最適化です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->