### PR TITLE
chore: translate-protected.ts retry ループに診断ログ追加（Phase 1）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- chore: Add diagnostic logging to translate-protected.ts retry loop (Part of #70, Closes #72)
+
 ### Fixed
 - fix(translate-pipeline): pass `--max-chunk-lines 100` to yuuhitsu to prevent P-A3 table corruption. Without this, files <300 lines (the default maxChunkLines) are sent as a single chunk; the claude provider's max_tokens=4096 then truncates large table output (compatibility-matrix.md: 312→189 rows, 60.6%). Smaller chunks ensure each section fits within the token limit. (Closes #68)
 - fix(translate-pipeline): add P-A3 table corruption to retry conditions. If chunking alone does not fully restore table rows, retries allow stochastic LLM variation to produce a complete translation. (Closes #68)

--- a/scripts/translate-protected.ts
+++ b/scripts/translate-protected.ts
@@ -89,7 +89,7 @@ function getYuuhitsuCliPath(): string | null {
  * Without this, files <300 lines (the default) are sent as a single chunk, and the
  * claude provider's max_tokens=4096 truncates large table output (P-A3 corruption).
  */
-function runYuuhitsu(tmpInput: string, lang: string, tmpOutput: string): number {
+function runYuuhitsu(tmpInput: string, lang: string, tmpOutput: string): { status: number; signal: string | null; stderr: string } {
   const yuuhitsuCli = getYuuhitsuCliPath()
 
   if (yuuhitsuCli) {
@@ -109,15 +109,16 @@ function runYuuhitsu(tmpInput: string, lang: string, tmpOutput: string): number 
       ],
       { stdio: ['inherit', 'inherit', 'pipe'], shell: false },
     )
+    const stderr = result.stderr ? result.stderr.toString() : ''
     // Re-emit stderr to make yuuhitsu errors visible in CI logs.
     if (result.error) {
       process.stderr.write(`spawnSync error: ${result.error.message}\n`)
-      return 1
+      return { status: 1, signal: null, stderr }
     }
-    if (result.stderr && result.stderr.length > 0) {
-      process.stderr.write(result.stderr)
+    if (stderr.length > 0) {
+      process.stderr.write(stderr)
     }
-    return result.status ?? 1
+    return { status: result.status ?? 1, signal: result.signal, stderr }
   }
 
   // Fallback: use npx (may encounter stack overflow on large files)
@@ -126,14 +127,15 @@ function runYuuhitsu(tmpInput: string, lang: string, tmpOutput: string): number 
     ['yuuhitsu', 'translate', '--input', tmpInput, '--lang', lang, '--output', tmpOutput, '--max-chunk-lines', '100'],
     { stdio: ['inherit', 'inherit', 'pipe'], shell: false },
   )
+  const stderr = result.stderr ? result.stderr.toString() : ''
   if (result.error) {
     process.stderr.write(`spawnSync error: ${result.error.message}\n`)
-    return 1
+    return { status: 1, signal: null, stderr }
   }
-  if (result.stderr && result.stderr.length > 0) {
-    process.stderr.write(result.stderr)
+  if (stderr.length > 0) {
+    process.stderr.write(stderr)
   }
-  return result.status ?? 1
+  return { status: result.status ?? 1, signal: result.signal, stderr }
 }
 
 function main(): number {
@@ -169,8 +171,16 @@ function main(): number {
       }
 
       // Run yuuhitsu translate
-      const status = runYuuhitsu(tmpInput, lang, tmpOutput)
+      const { status, signal, stderr } = runYuuhitsu(tmpInput, lang, tmpOutput)
       if (status !== 0) {
+        console.error(
+          `[diag] attempt=${attempt + 1} input=${input} ` +
+          `status=${status} signal=${signal ?? 'none'} ` +
+          `stderr_len=${stderr.length}`,
+        )
+        if (stderr.length === 0) {
+          console.error('[diag] stderr was empty — yuuhitsu may have been killed or aborted silently')
+        }
         if (attempt < MAX_RETRIES) continue
         console.error(`::error::Translation failed for ${input}`)
         return status


### PR DESCRIPTION
Closes #72
Part of #70

## 概要

translate-protected.ts の retry ロジックに `[diag]` プレフィックス付き診断ログを追加。
CI 失敗時の真因（signal kill / API 5xx / 401 / silent exit）を次回 CI 実行で可視化する Phase 1。

## 変更内容

- `runYuuhitsu` の戻り値型を `{ status, signal, stderr }` に拡張
- retry loop で `[diag]` 付き診断ログを毎回 `console.error` に出力
- `stderr` 空 + `status !== 0` の場合は「stderr was empty」警告を追加

## ソースコード変更

`scripts/translate-protected.ts` のみ（retry 回数・yuuhitsu バージョン・NODE_OPTIONS は変更なし）

## 動作確認ログ（bogus API key での実行結果）

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/yuuhitsu - Not found
[diag] attempt=1 input=docs/en/ai-integration/examples.md status=1 signal=none stderr_len=396
Retrying translation (attempt 2/3)...
[diag] attempt=2 input=docs/en/ai-integration/examples.md status=1 signal=none stderr_len=396
Retrying translation (attempt 3/3)...
[diag] attempt=3 input=docs/en/ai-integration/examples.md status=1 signal=none stderr_len=396
::error::Translation failed for docs/en/ai-integration/examples.md
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * エラーハンドリングの改善により、トランスレーション処理の失敗時に詳細な診断情報がログに記録されるようになりました。

* **Chores**
  * CHANGELOGを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->