### PR TITLE
chore(deps): bump @geolonia/yuuhitsu to 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- chore(deps): bump @geolonia/yuuhitsu to 0.1.9 — fixes splitAtPositions infinite recursion (SIGSEGV) on files starting with top-level heading. Resolves CI translation failures across all 14 files. (Closes #76, upstream geolonia/yuuhitsu#38)
+
 ### Added
 - chore: Add diagnostic logging to translate-protected.ts retry loop (Part of #70, Closes #72)
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.8",
+    "@geolonia/yuuhitsu": "^0.1.9",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.5",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.8
-        version: 0.1.8(ws@8.19.0)
+        specifier: ^0.1.9
+        version: 0.1.9(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -448,8 +448,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.8':
-    resolution: {integrity: sha512-NKxOgwN/00cMYhCYgrQ9kJ3Us7EW8SzSDnBVtddhGusHl6My0tWZVr1i6BzEmeJGhas50xWjeMtUwr3KofAx6g==}
+  '@geolonia/yuuhitsu@0.1.9':
+    resolution: {integrity: sha512-pBaJsKezxcEmxwXn+kPPQZTMCq+Bg5KbfaWgGzwpw0GmaoEQX/Eal3skWRSQg/tONA93G0WQaj8+ua+jl0gtdg==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1853,7 +1853,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.8(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.9(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
Closes #76
Upstream: geolonia/yuuhitsu#38

## 概要

yuuhitsu 0.1.9 に依存更新。`splitAtPositions` の無限再帰（SIGSEGV）を修正し、CI の translate workflow で全 14 ファイルが失敗していた問題を解消する。

## 変更内容

- `package.json`: `@geolonia/yuuhitsu` 0.1.8 → 0.1.9
- `pnpm-lock.yaml`: 依存更新
- `CHANGELOG.md`: 更新

## 動作確認

- `npx tsx scripts/translate-protected.ts --input docs/en/api-reference/ngsild.md --lang ja --output /tmp/test.ja.md` — SIGSEGV・スタックオーバーフロー発生なし（API 認証エラーのみで正常終了）
- `npm test`: 109 テスト全 PASS（SKIP ゼロ）
- `tsc --noEmit`: 型エラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 特定のファイル処理における問題を修正し、CI統合の安定性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->