### PR TITLE
fix(build): disable lastUpdated to unblock CI + bump yuuhitsu to 0.1.11

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           BLOCK_FAILED=0
           while IFS= read -r -d '' f; do
-            if ! npx --yes @geolonia/yuuhitsu@0.1.10 glossary check \
+            if ! npx --yes @geolonia/yuuhitsu@0.1.11 glossary check \
                 --input "$f" \
                 --glossary glossary.yaml \
                 --lang ja \
@@ -144,7 +144,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         run: |
           while IFS= read -r -d '' f; do
-            npx --yes @geolonia/yuuhitsu@0.1.10 glossary fix \
+            npx --yes @geolonia/yuuhitsu@0.1.11 glossary fix \
               --input "$f" \
               --glossary glossary.yaml \
               --lang ja
@@ -162,7 +162,7 @@ jobs:
         run: |
           WARN_COUNT=0
           while IFS= read -r -d '' f; do
-            if ! npx --yes @geolonia/yuuhitsu@0.1.10 glossary check \
+            if ! npx --yes @geolonia/yuuhitsu@0.1.11 glossary check \
                 --input "$f" \
                 --glossary glossary.yaml \
                 --lang ja \
@@ -181,7 +181,7 @@ jobs:
           mkdir -p /tmp/glossary-sarif
           while IFS= read -r -d '' f; do
             safename=$(echo "$f" | sed 's|/|_|g')
-            npx --yes @geolonia/yuuhitsu@0.1.10 glossary check \
+            npx --yes @geolonia/yuuhitsu@0.1.11 glossary check \
               --input "$f" \
               --glossary glossary.yaml \
               --lang ja \

--- a/docs/.vitepress/config/shared.ts
+++ b/docs/.vitepress/config/shared.ts
@@ -5,7 +5,12 @@ export const shared = defineConfig({
   description: 'FIWARE Orion-compatible Context Broker on AWS Lambda',
 
   base: '/',
-  lastUpdated: true,
+  // CI's sync-and-translate workflow regenerates docs/en/changelog.md from
+  // upstream CHANGELOG.md before build. The regenerated file has no git history
+  // for that revision, which crashes VitePress SSR with
+  // "Cannot read properties of undefined (reading 'sha')".
+  // Disabled until sync flow commits before build, or transformPageData guards.
+  lastUpdated: false,
   cleanUrls: true,
   ignoreDeadLinks: true,
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.9",
+    "@geolonia/yuuhitsu": "^0.1.11",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.5",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.9
-        version: 0.1.9(ws@8.19.0)
+        specifier: ^0.1.11
+        version: 0.1.11(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -448,8 +448,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.9':
-    resolution: {integrity: sha512-pBaJsKezxcEmxwXn+kPPQZTMCq+Bg5KbfaWgGzwpw0GmaoEQX/Eal3skWRSQg/tONA93G0WQaj8+ua+jl0gtdg==}
+  '@geolonia/yuuhitsu@0.1.11':
+    resolution: {integrity: sha512-7woP2DnP2jUFo/nfM91Q9iEgKg68anLP32erfkYejega7m3LT4LMUcJxoHs2XKcxFvRkqV+6+62Wr4mSog36aA==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1375,6 +1375,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-message@4.0.3:
@@ -1853,7 +1854,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.9(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.11(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary

- Sync and Translate CI が直近 4 回連続失敗していた build 段階のクラッシュを止血
- yuuhitsu を 0.1.10 → 0.1.11 に bump（CodeRabbit Actionable 4 件修正含む先日 publish の最新版）

## Root cause

`scripts/sync-geonicdb-docs.ts` が `docs/en/changelog.md` を CI 上で動的生成し、その後 `pnpm docs:build` を実行している。VitePress の `lastUpdated: true` が SSR 時に git history を引きに行くが、生成直後の changelog.md は未コミットゆえ lookup が undefined を返し、SSR で `.sha` 参照クラッシュ。

エラー（actions run 25184446150 より）:

```
TypeError: Cannot read properties of undefined (reading 'sha')
    at _sfc_ssrRender (.../docs/.vitepress/.temp/en_changelog.md.js:7:19758)
```

ローカル `pnpm docs:build` では再現しない（changelog.md が既存 commit に含まれているため）。

## Changes

| File | Change |
|------|--------|
| `docs/.vitepress/config/shared.ts` | `lastUpdated: true` → `false`（理由コメント追加） |
| `package.json` | `@geolonia/yuuhitsu` `^0.1.9` → `^0.1.11` |
| `.github/workflows/sync-and-translate.yml` | yuuhitsu 固定バージョン 0.1.10 → 0.1.11（4 箇所） |
| `pnpm-lock.yaml` | yuuhitsu bump に伴う更新 |

## Test plan

- [x] ローカル `pnpm docs:build` 成功確認（12.4 秒で完走）
- [x] `pnpm install` で lockfile 整合性確認
- [ ] CI: Sync and Translate workflow が build 段階を通り抜けること（マージ後に手動 trigger or 次回 schedule で確認）
- [ ] CI: deploy.yml が docs.geonicdb.com を正常デプロイすること

## Follow-up（別 Issue / PR で対応）

`lastUpdated` 復活方針:
1. `transformPageData` で git history 不在時の fallback
2. sync 後に `git add && git commit` してから build（main 直接 commit 懸念あり）

Closes https://github.com/geolonia/geonicdb-docs/issues/86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発ツールのバージョンを更新しました

* **Configuration**
  * ドキュメント生成設定を調整しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->