### PR TITLE
chore(deps): bump @geolonia/yuuhitsu 0.1.11 → 0.1.12

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -125,7 +125,7 @@ jobs:
         run: |
           BLOCK_FAILED=0
           while IFS= read -r -d '' f; do
-            if ! npx --yes @geolonia/yuuhitsu@0.1.11 glossary check \
+            if ! npx --yes @geolonia/yuuhitsu@0.1.12 glossary check \
                 --input "$f" \
                 --glossary glossary.yaml \
                 --lang ja \
@@ -144,7 +144,7 @@ jobs:
         if: steps.detect.outputs.has_changes == 'true'
         run: |
           while IFS= read -r -d '' f; do
-            npx --yes @geolonia/yuuhitsu@0.1.11 glossary fix \
+            npx --yes @geolonia/yuuhitsu@0.1.12 glossary fix \
               --input "$f" \
               --glossary glossary.yaml \
               --lang ja
@@ -162,7 +162,7 @@ jobs:
         run: |
           WARN_COUNT=0
           while IFS= read -r -d '' f; do
-            if ! npx --yes @geolonia/yuuhitsu@0.1.11 glossary check \
+            if ! npx --yes @geolonia/yuuhitsu@0.1.12 glossary check \
                 --input "$f" \
                 --glossary glossary.yaml \
                 --lang ja \
@@ -181,7 +181,7 @@ jobs:
           mkdir -p /tmp/glossary-sarif
           while IFS= read -r -d '' f; do
             safename=$(echo "$f" | sed 's|/|_|g')
-            npx --yes @geolonia/yuuhitsu@0.1.11 glossary check \
+            npx --yes @geolonia/yuuhitsu@0.1.12 glossary check \
               --input "$f" \
               --glossary glossary.yaml \
               --lang ja \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- chore(deps): bump @geolonia/yuuhitsu to 0.1.12 — code-block boundary protection; package.json and sync-and-translate.yml (4 locations) updated. (Closes #95)
+
 ### Added
 - feat(translate-pipeline): HF3 code fence validation — `validateCodeBlocks` in `translate-pipeline-validators.ts` detects chunk-boundary fence breaks (original ≠ translated ``` count) and triggers retry. Prevents HTML build errors caused by broken code blocks. (Closes #93)
 - feat(workflow): SF2 artifact upload on build failure — `sync-and-translate.yml` uploads `docs/ja/` as `translated-docs-build-failure` artifact (7-day retention) when build verification fails, enabling post-mortem analysis. (Closes #93)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.11",
+    "@geolonia/yuuhitsu": "^0.1.12",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.5",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.11
-        version: 0.1.11(ws@8.19.0)
+        specifier: ^0.1.12
+        version: 0.1.12(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -448,8 +448,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.11':
-    resolution: {integrity: sha512-7woP2DnP2jUFo/nfM91Q9iEgKg68anLP32erfkYejega7m3LT4LMUcJxoHs2XKcxFvRkqV+6+62Wr4mSog36aA==}
+  '@geolonia/yuuhitsu@0.1.12':
+    resolution: {integrity: sha512-3kANdpPwtqxYGUkt0brzrbNsDT+1b3p+VJBIqFCN7IwOrtxmjIEOaY/Wdp8NTxxR+VMjsdb6CeBPKb4Rj836+w==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1854,7 +1854,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.11(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.12(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary

- `package.json`: `@geolonia/yuuhitsu ^0.1.11` → `^0.1.12`
- `pnpm-lock.yaml`: lockfile updated automatically via `pnpm install`
- `.github/workflows/sync-and-translate.yml`: 4箇所の `npx --yes @geolonia/yuuhitsu@0.1.11` → `@0.1.12` に更新

yuuhitsu 0.1.12 はコードブロック境界保護機能を追加したバージョンでございます。

## Test plan

- [x] `pnpm install` 成功
- [x] `pnpm docs:build` 成功
- [x] `pnpm test` 全 114 テスト PASS（SKIP=0）
- [x] `/code-review-expert --auto` P0/P1 なし

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 用語処理・翻訳関連のツール依存関係をアップデートしました。複数のワークフロー処理ステップに適用されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->