### PR TITLE
feat(ci): Glossary Check warn-only with --severity-filter block (cmd_334 HF2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,10 +78,11 @@ jobs:
           while IFS= read -r -d '' f; do
             TOTAL=$((TOTAL + 1))
             echo "Checking: $f"
-            if ! npx --yes @geolonia/yuuhitsu glossary check \
+            if ! npx --yes @geolonia/yuuhitsu@0.1.12 glossary check \
                 --input "$f" \
                 --glossary glossary.yaml \
-                --lang ja; then
+                --lang ja \
+                --severity-filter block; then
               echo "::warning file=$f::Glossary violation detected"
               FAILED=$((FAILED + 1))
             fi


### PR DESCRIPTION
## Summary

- Pin yuuhitsu to `@0.1.12` in test.yml Glossary Check step
- Add `--severity-filter block` so only block-severity violations fail CI
- warn-severity violations become GitHub Annotations (no CI failure), matching the behavior of `sync-and-translate.yml` (cmd_315)

## Motivation

PR#97 (auto-translation) contains warn-level glossary violations. Currently these fail CI. This change makes CI consistent with the sync workflow and allows warn-level violations to be addressed incrementally without blocking automated translation PRs.

## Test plan

- [x] Local: `pnpm test:unit` — 114 tests passed, SKIP=0
- [ ] CI: Glossary Check should PASS even when warn violations exist in docs/ja/

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * 開発ワークフローの依存ツールをより安定したバージョンに固定し、チェック処理の信頼性を向上させました。

---

*このリリースに含まれる変更はユーザー向けの機能に直接的な影響はありません。*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->