### PR TITLE
deps: yuuhitsu 0.1.12 → 0.1.13 (SF1 prompt 強化)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- chore(deps): bump @geolonia/yuuhitsu 0.1.12 → 0.1.13 (SF1 prompt 強化: code fence lang 必須化 + glossary warn 強化) (Closes #110)
 - feat(docs): SaaS 中心 docs 再編 Phase 1 — docs/{en,ja}/getting-started/installation.md 削除、VitePress config GitHub 関連削除（socialLinks / nav GitHub / sidebar Installation）、index.md hero CTA → Sign Up(brand)/Quick Start/API Reference、changelog GitHub compare/tag URL 削除、本文 git clone / GitHub URL 削除（orion-to-geonicdb.md は Phase 2 範囲ゆえ除外）(Closes #108)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.12",
+    "@geolonia/yuuhitsu": "^0.1.13",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.3.5",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.12
-        version: 0.1.12(ws@8.19.0)
+        specifier: ^0.1.13
+        version: 0.1.13(ws@8.19.0)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -448,8 +448,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.12':
-    resolution: {integrity: sha512-3kANdpPwtqxYGUkt0brzrbNsDT+1b3p+VJBIqFCN7IwOrtxmjIEOaY/Wdp8NTxxR+VMjsdb6CeBPKb4Rj836+w==}
+  '@geolonia/yuuhitsu@0.1.13':
+    resolution: {integrity: sha512-nAGRvtS+ZAjo0TvPQNorO2so31b/CLKVlXMnQtpGETNoWsxPbn4FmzFSz1FBp65b2xqbnVaxL4dasVC1iXKzIA==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1854,7 +1854,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.12(ws@8.19.0)':
+  '@geolonia/yuuhitsu@0.1.13(ws@8.19.0)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
Closes https://github.com/geolonia/geonicdb-docs/issues/110

## 変更内容
- @geolonia/yuuhitsu 0.1.12 → 0.1.13
  - code fence lang 必須ルール追加（bare ``` 生成を構造的に防止）
  - buildGlossaryPrompt do_not_use 全 tier 禁止強化
  - severity=warn 文言を near-mandatory に強化
  - bash counter-example 追加

## 効果検証予定
マージ後 2026-05-09 に bare ``` 残存件数を自動計測（目標: 85 件 → 10 件未満）

## テスト結果
- vitest run: 126 tests PASS, SKIP=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存ライブラリ `@geolonia/yuuhitsu` をバージョン 0.1.13 にアップグレードしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->