### PR TITLE
docs: README に sync 関係追記 + docs.geonicdb.org 誤記修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Documentation
+- docs: README に sync 関係（上流リポジトリ・管理区分・pnpm sync-docs 動作・MAPPING_TABLE 編集手順）を追記（B-1〜B-4）(Closes #111)
+- fix: README docs.geonicdb.org → docs.geonicdb.com 誤記修正
+
 ### Changed
 - feat(docs): SaaS 中心 docs 再編 Phase 1 — docs/{en,ja}/getting-started/installation.md 削除、VitePress config GitHub 関連削除（socialLinks / nav GitHub / sidebar Installation）、index.md hero CTA → Sign Up(brand)/Quick Start/API Reference、changelog GitHub compare/tag URL 削除、本文 git clone / GitHub URL 削除（orion-to-geonicdb.md は Phase 2 範囲ゆえ除外）(Closes #108)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@
 - **デュアル API サポート**: 単一インスタンスで NGSIv2 と NGSI-LD の両方をサポート
 - **日本標準対応**: CADDE 互換、来歴追跡機能を搭載
 
-🌐 **公開ドキュメント**: https://docs.geonicdb.org/
+🌐 **公開ドキュメント**: https://docs.geonicdb.com/
 
 ## 技術スタック
 
@@ -107,6 +107,49 @@ pnpm translate:ja -- docs/en/path/to/file.md
 # 日本語ファイルを英語に翻訳
 pnpm translate:en -- docs/ja/path/to/file.md
 ```
+
+## ドキュメント同期
+
+### B-1: 上流リポジトリとの関係
+
+ドキュメントコンテンツの源泉は、上流リポジトリ **[geolonia/geonicdb](https://github.com/geolonia/geonicdb)**（製品本体リポジトリ）です。この `geonicdb-docs` リポジトリは、そのドキュメントをレンダリング・公開する VitePress サイトです。
+
+同期スクリプト（`scripts/sync-geonicdb-docs.ts`）が `geolonia/geonicdb/docs/` の Markdown ファイルをこのリポジトリの `docs/en/` にコピーし、VitePress フロントマターの付与と内部リンクの書き換えを行います。
+
+### B-2: 同期対象ページ vs 独自ページ
+
+`scripts/sync-geonicdb-docs.ts` の `MAPPING_TABLE` に記載されているファイルのみが上流リポジトリから同期されます。`MAPPING_TABLE` に記載のないファイルはスキップされます（ログに `SKIP (no mapping)` と出力）。
+
+`docs/en/` 配下で上流ファイルに対応しないページは、このリポジトリで直接管理している **独自ページ** です。
+
+### B-3: `pnpm sync-docs` の動作フロー
+
+```bash
+GEONICDB_REPO_PATH=/path/to/geonicdb pnpm sync-docs
+```
+
+1. `MAPPING_TABLE` に記載された各 `.md` ファイルを `GEONICDB_REPO_PATH/docs/` から読み込む
+2. VitePress フロントマター（`title`・`description`・`outline: deep`）を付与する
+3. 内部リンクを `MAPPING_TABLE` の定義に基づいて相対パスへ書き換える
+4. `MAPPING_TABLE` で指定した `docs/en/<dest>` へ書き出す
+5. CI では同期後に `yuuhitsu` が `docs/en/` → `docs/ja/` を自動翻訳する
+
+### B-4: 新規ページを同期対象に追加する手順
+
+新しい上流 Markdown ファイルをサイトに追加するには、`scripts/sync-geonicdb-docs.ts` の `MAPPING_TABLE` にエントリを追加します：
+
+```ts
+// scripts/sync-geonicdb-docs.ts
+'NEW_FILE.md': [
+  {
+    dest: 'section/page-name.md',   // docs/en/ 以下の出力パス
+    title: 'ページタイトル',
+    description: '検索用の短い説明',
+  },
+],
+```
+
+エントリ追加後、`pnpm sync-docs` をローカルで実行して出力を確認し、コミット・プッシュしてください。翻訳は CI ワークフローが自動処理します。
 
 ## プロジェクト構造
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -128,7 +128,7 @@ pnpm translate:en -- docs/ja/path/to/file.md
 GEONICDB_REPO_PATH=/path/to/geonicdb pnpm sync-docs
 ```
 
-1. `MAPPING_TABLE` に記載された各 `.md` ファイルを `GEONICDB_REPO_PATH/docs/` から読み込む
+1. `MAPPING_TABLE` に記載された各 `.md` ファイルを `GEONICDB_REPO_PATH/docs/` から読み込む（例外: `CHANGELOG.md` はリポジトリルートから読み込む）
 2. VitePress フロントマター（`title`・`description`・`outline: deep`）を付与する
 3. 内部リンクを `MAPPING_TABLE` の定義に基づいて相対パスへ書き換える
 4. `MAPPING_TABLE` で指定した `docs/en/<dest>` へ書き出す

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Pages under `docs/en/` that do not correspond to any upstream source file are **
 GEONICDB_REPO_PATH=/path/to/geonicdb pnpm sync-docs
 ```
 
-1. Reads each `.md` file listed in `MAPPING_TABLE` from `GEONICDB_REPO_PATH/docs/`
+1. Reads each `.md` file listed in `MAPPING_TABLE` from `GEONICDB_REPO_PATH/docs/` (exception: `CHANGELOG.md` is read from the repository root, not `docs/`)
 2. Adds VitePress frontmatter (`title`, `description`, `outline: deep`)
 3. Rewrites internal links (`./FILENAME.md` → relative path based on `MAPPING_TABLE`)
 4. Writes the result to `docs/en/<dest>` as defined in `MAPPING_TABLE`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository hosts the official documentation for **GeonicDB**, a serverless 
 - **Dual API Support**: Both NGSIv2 and NGSI-LD on a single instance
 - **Japan Standards Ready**: CADDE compatible with provenance tracking
 
-🌐 **Live Documentation**: https://docs.geonicdb.org/
+🌐 **Live Documentation**: https://docs.geonicdb.com/
 
 ## Tech Stack
 
@@ -107,6 +107,49 @@ pnpm translate:ja -- docs/en/path/to/file.md
 # Translate a specific Japanese file to English
 pnpm translate:en -- docs/ja/path/to/file.md
 ```
+
+## Documentation Sync
+
+### B-1: Upstream Repository Relationship
+
+The documentation content originates from the upstream repository **[geolonia/geonicdb](https://github.com/geolonia/geonicdb)** (the main product repository). This `geonicdb-docs` repository is a separate VitePress site that renders and publishes those docs.
+
+The sync script (`scripts/sync-geonicdb-docs.ts`) copies Markdown files from `geolonia/geonicdb/docs/` into `docs/en/` of this repository, adding VitePress frontmatter and rewriting internal links.
+
+### B-2: Synced Pages vs. Custom Pages
+
+Only files listed in the `MAPPING_TABLE` in `scripts/sync-geonicdb-docs.ts` are synced from the upstream repository. Files that are **not** in `MAPPING_TABLE` are skipped (logged as `SKIP (no mapping)`).
+
+Pages under `docs/en/` that do not correspond to any upstream source file are **custom pages** maintained directly in this repository.
+
+### B-3: How `pnpm sync-docs` Works
+
+```bash
+GEONICDB_REPO_PATH=/path/to/geonicdb pnpm sync-docs
+```
+
+1. Reads each `.md` file listed in `MAPPING_TABLE` from `GEONICDB_REPO_PATH/docs/`
+2. Adds VitePress frontmatter (`title`, `description`, `outline: deep`)
+3. Rewrites internal links (`./FILENAME.md` → relative path based on `MAPPING_TABLE`)
+4. Writes the result to `docs/en/<dest>` as defined in `MAPPING_TABLE`
+5. In CI, after sync, `yuuhitsu` translates `docs/en/` → `docs/ja/` automatically
+
+### B-4: Adding a New Page to Sync
+
+To include a new upstream Markdown file in the site, add an entry to `MAPPING_TABLE` in `scripts/sync-geonicdb-docs.ts`:
+
+```ts
+// scripts/sync-geonicdb-docs.ts
+'NEW_FILE.md': [
+  {
+    dest: 'section/page-name.md',   // output path under docs/en/
+    title: 'Page Title',
+    description: 'Short description for SEO',
+  },
+],
+```
+
+After adding the entry, run `pnpm sync-docs` locally to verify the output, then commit and push. The CI workflow handles translation automatically.
 
 ## Project Structure
 


### PR DESCRIPTION
Closes https://github.com/geolonia/geonicdb-docs/issues/111

## 変更内容

### A. ドメイン誤記修正
- README.md / README.ja.md: `docs.geonicdb.org` → `docs.geonicdb.com`（L16 各1箇所）

### B. README 補強（Documentation Sync セクション追加）
- **B-1**: 上流リポジトリ `geolonia/geonicdb` との関係（geonicdb-docs は VitePress レンダリング用の別リポジトリ）
- **B-2**: `MAPPING_TABLE` による同期対象 vs 独自ページの判定方法
- **B-3**: `pnpm sync-docs` の動作フロー（読み込み → frontmatter 付与 → リンク書き換え → 書き出し → yuuhitsu 翻訳）
- **B-4**: `MAPPING_TABLE` に新規ページを追加する手順

各セクションは英語（README.md）・日本語（README.ja.md）両方に追加。
加筆後の行数は各 232 行（300 行未満）のため別ページ分離なし。

### C. CHANGELOG.md 更新
- `## [Unreleased]` に `### Documentation` セクション追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ドキュメントの公開URLを更新しました（docs.geonicdb.org → docs.geonicdb.com）。
  * 「ドキュメント同期」セクションを追加し、上流との関係、同期の対象選定、同期の実行と出力、CIでの翻訳処理の概要を説明しました。
  * 新規ページを同期対象に追加する手順と注意点を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->