### PR TITLE
fix: docs/en/changelog.md 日本語混入修正（PR#103 CR Thread 6）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - feat(docs): SaaS 中心 docs 再編 Phase 1 — docs/{en,ja}/getting-started/installation.md 削除、VitePress config GitHub 関連削除（socialLinks / nav GitHub / sidebar Installation）、index.md hero CTA → Sign Up(brand)/Quick Start/API Reference、changelog GitHub compare/tag URL 削除、本文 git clone / GitHub URL 削除（orion-to-geonicdb.md は Phase 2 範囲ゆえ除外）(Closes #108)
 
 ### Fixed
+- fix: docs/en/changelog.md 日本語混入修正（PR#103 残存 CR Thread 6 対応）(Closes #115)
 - fix(translate-pipeline): SF2 embedded fence cascade violations — `fixEmbeddedFences` in `fix-doc-quality.ts` detects and splits `prose```lang` merged lines (`.```[a-z]` pattern); applied as pre-fix in `fixBareCodeBlocks` and as post-process in `translate-protected.ts` after restore steps. `ensureFenceSpacing` pre-processes input to insert blank lines before code fence starts at chunk boundaries, preventing LLM merging. Eliminates bare block cascade violations seen in PR#97. (Closes #104)
 
 ### Changed

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -3,1164 +3,672 @@ title: "Changelog"
 description: "GeonicDB changelog"
 outline: deep
 ---
-# 変更履歴
+# Changelog
 
-このプロジェクトのすべての重要な変更は、このファイルに記録されます。
+All notable changes to this project will be documented in this file.
 
-このフォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に基づいており、
-このプロジェクトは [Semantic Versioning](https://semver.org/lang/ja/) に準拠しています。
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### 2026-05-02
-- **修正**: SDK 公開パッケージの d.ts root が strict tsconfig で named import を解決できない問題 (issue #1127)
-  - 背景: PR #1124 (#1118 の修正) で `geonicdb.d.ts` を `export * from './index'` の wildcard re-export に変更したが、`src/sdk/package.json` の `files: ["geonicdb.*"]` は **意図的な single-file 配信** (#877) のため `./index.d.ts` 等の per-file d.ts は npm パッケージに含まれない。strict tsconfig (`verbatimModuleSyntax`, `strict` 等) の consumer から見ると wildcard が空に解決され、`AuthorizationError` を含む全 named export が消えていた (locus サンプル開発で `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` がモジュール解決エラーになり発覚)
-  - 修正: `scripts/build-sdk.ts` の d.ts 生成を hardcoded export 列挙形式に戻した。ただし TypeScript AST (`typescript` の `createSourceFile`) で `src/sdk/index.ts` を走査して export 一覧を **build 時に自動収集** するため、新規 export 追加時に build-sdk.ts を後追い修正する必要なし (drift 自動防止)
-  - **検証強化** (回帰防止): 既存の `dist/sdk/` 直読みではなく、`npm pack` の tarball を抽出した上で
-    - 公開ファイルから `geonicdb.d.ts` / `geonicdb.{cjs,mjs,iife.js}` が含まれていることを検証
-    - **strict tsconfig 環境を再現** した consumer プロジェクトを `tmpdir` に組み立て、`tsc --project` で実コンパイルし、各エラークラス / public type の named import (`import { ... }` および `import type { ... }`) が **TS2614 にならないこと** を assertion
-    - 公開 d.ts に `export * from` 形式が混入しないことを正規表現で禁止
-    - `src/sdk/index.ts` ソースの export 名と公開 d.ts の export 名が一致することを drift guard で検証
-  - ドキュメント: `docs/SDK.md` / `src/sdk/README.md` に「TypeScript」節を追加し、strict tsconfig でも named import が解決できる旨を明記
+- **Fix**: SDK published package `d.ts` root failed to resolve named imports under strict tsconfig (issue #1127)
+  - Background: PR #1124 (#1118 fix) changed `geonicdb.d.ts` to wildcard re-export `export * from './index'`, but `src/sdk/package.json` `files: ["geonicdb.*"]` intentionally delivers only single-file bundle (#877), so `./index.d.ts` and other per-file d.ts files are not included in the npm package. Under strict tsconfig (`verbatimModuleSyntax`, `strict`, etc.), consumers saw the wildcard resolve to empty and all named exports including `AuthorizationError` disappeared (discovered during locus sample development: `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` caused module resolution error)
+  - Fix: Reverted `scripts/build-sdk.ts` d.ts generation to hardcoded export enumeration format. However, TypeScript AST (`createSourceFile` from `typescript`) now traverses `src/sdk/index.ts` at build time to auto-collect the export list, so no need to manually update `build-sdk.ts` when adding new exports (drift auto-prevention)
+  - **Verification strengthening** (regression prevention): Instead of reading `dist/sdk/` directly, extract npm pack tarball and:
+    - Verify published files include `geonicdb.d.ts` / `geonicdb.{cjs,mjs,iife.js}`
+    - **Reproduce strict tsconfig environment**: assemble a consumer project in `tmpdir`, compile with `tsc --project`, and assert named imports (`import { ... }` and `import type { ... }`) of each error class / public type **do not cause TS2614**
+    - Prohibit `export * from` form in published d.ts via regex
+    - Drift guard: verify export names in `src/sdk/index.ts` source match export names in published d.ts
+  - Docs: Added "TypeScript" section to `docs/SDK.md` / `src/sdk/README.md` clarifying named imports work under strict tsconfig
 
 ## [0.7.0] — 2026-05-02
 
 ### 2026-05-02
-- **改善**: ReactiveCore Rules の SLO 超過に対する協調キャンセルを実装 (issue #1122) (#1123)
-  - 背景: PR #1121 で導入した `RuleProcessorFunction` の `Promise.race` ベースの soft timeout は、wait を打ち切るだけで `ruleEngine.processEntityChange()` の裏での実行は継続していた。Lambda hard timeout (30s) で最終的に止まるが、SLO (`MAX_RULE_EXECUTION_TIME_MS = 5s`) を超えた処理が走り続け、unintended な entity 作成 / webhook 発火を起こし得た (CodeRabbit 指摘)
-  - 対応: `RuleEngineService.processEntityChange(event, signal?)` に optional `AbortSignal` を追加。ルール評価ループ・アクション実行ループの境界で `signal.throwIfAborted()` をチェックし、新しいルール / アクションの開始を阻止する。`executeWebhookAction` は `AbortSignal.any([外部 signal, 内部 timeout signal])` で外部 signal と既存の内部 timeout を合成し、HTTP fetch も中断するようにした
-  - `handlers/rules/processor.ts` で `AbortController` を作成し、SLO 超過で `controller.abort()` を呼ぶ。span 上は abort されたかを区別して ERROR を記録 (`aborted` フラグを log に出す)
-  - 既存の `entity.service` / `temporal.service` の各メソッドへの signal threading は影響範囲が広いため別 issue に切り出し、本対応では「ループ境界で次の処理を始めない」までを保証する。in-flight の DB 操作は完走させる
-  - 関連: `src/core/rules/rule-engine.service.ts`、`src/handlers/rules/processor.ts`、`tests/unit/core/rules/rule-engine.service.test.ts` (signal 経由の協調キャンセル 4 ケース追加)、`tests/unit/handlers/rules/processor.test.ts` (signal 経由の abort/log/span 検証 2 ケース追加)
-- **修正**: SDK 公開 d.ts (`@geolonia/geonicdb-sdk` の `geonicdb.d.ts`) からエラークラスが silently 落ちていた問題 (issue #1118) (#1124)
-  - 原因: `scripts/build-sdk.ts` が `geonicdb.d.ts` を hardcoded な export 列挙で書き出しており、`src/sdk/index.ts` で `errors.ts` から再エクスポートしている `GeonicDBError` / `AuthenticationError` / `AuthorizationError` / `NotFoundError` / `ConflictError` / `ValidationError` / `RateLimitError` / `NetworkError` が含まれていなかった。runtime バンドル (cjs / mjs) では正しく export されていたが、TypeScript からは `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` でモジュール解決エラーになっていた
-  - 修正: `scripts/build-sdk.ts` の d.ts 生成を `export * from './index'; export { default } from './index';` に変更し、`src/sdk/index.ts` の named export を全て自動転送する。今後 index に export を追加してもこのスクリプトの修正は不要
-  - 回帰防止: `tests/unit/sdk/build-artifacts.test.ts` を新設。`geonicdb.d.ts` が wildcard 形式であること、`index.d.ts` でエラークラスが `errors.ts` から re-export 形で公開されていること、runtime CJS / ESM 両バンドルでエラークラスが constructor として呼び出せ Error サブクラスかつ `GeonicDBError` を共通基底とすることを検証 (ESM は子プロセス経由で評価)
-- **追加**: ReactiveCore Rules のアクションテンプレートで `${now()}` / `${uuid()}` 等の関数を呼べるようにした (issue #1120) (#1125)
-  - 背景: 既存の `${path}` 解決は `entity.id` / `attribute.<name>.value` / `trigger.*` のみを参照する path 限定で、サーバー時刻や一意 ID を生成する手段がなかった。`urn:ngsi-ld:ActivityLog:${entity.id}` のような決定的な entityId しか作れず、同一エンティティの複数回 update から派生 entity を生成すると id 衝突で 2 回目以降が失敗していた
-  - 修正: `rule-engine.service.ts` の `substituteTemplate` を拡張し、`${name(args)}` 形式を関数呼び出しとして解釈する。実装した関数は副作用なし・外部 I/O なしの whitelist のみ:
-    - `${now()}` / `${now('iso')}` → ISO 8601 タイムスタンプ
-    - `${now('unix')}` → UNIX 秒
-    - `${now('unix-ms')}` → UNIX ミリ秒
+- **Improve**: Implemented cooperative cancellation for ReactiveCore Rules on SLO overrun (issue #1122) (#1123)
+  - Background: The `Promise.race`-based soft timeout for `RuleProcessorFunction` introduced in PR #1121 only stopped waiting but continued execution of `ruleEngine.processEntityChange()` in the background. Lambda hard timeout (30s) would eventually stop it, but processing exceeding SLO (`MAX_RULE_EXECUTION_TIME_MS = 5s`) could cause unintended entity creation / webhook firing (CodeRabbit comment)
+  - Fix: Added optional `AbortSignal` to `RuleEngineService.processEntityChange(event, signal?)`. Checks `signal.throwIfAborted()` at rule evaluation loop and action execution loop boundaries to prevent starting new rules / actions. `executeWebhookAction` uses `AbortSignal.any([external signal, internal timeout signal])` to compose external signal with existing internal timeout and also abort HTTP fetch
+  - `handlers/rules/processor.ts` creates `AbortController` and calls `controller.abort()` on SLO overrun. Records ERROR on span distinguishing whether aborted (`aborted` flag in log)
+  - Signal threading to each method of existing `entity.service` / `temporal.service` has wide blast radius, cut to separate issue; this fix guarantees "don't start next processing at loop boundary". In-flight DB operations are allowed to complete
+  - Related: `src/core/rules/rule-engine.service.ts`, `src/handlers/rules/processor.ts`, `tests/unit/core/rules/rule-engine.service.test.ts` (4 cooperative cancellation via signal cases added), `tests/unit/handlers/rules/processor.test.ts` (2 abort/log/span verification via signal cases added)
+- **Fix**: Error classes silently dropped from SDK published d.ts (`geonicdb.d.ts` of `@geolonia/geonicdb-sdk`) (issue #1118) (#1124)
+  - Cause: `scripts/build-sdk.ts` wrote `geonicdb.d.ts` with hardcoded export enumeration, and `GeonicDBError` / `AuthenticationError` / `AuthorizationError` / `NotFoundError` / `ConflictError` / `ValidationError` / `RateLimitError` / `NetworkError` re-exported from `errors.ts` in `src/sdk/index.ts` were not included. Runtime bundles (cjs / mjs) exported correctly, but TypeScript showed module resolution error for `import { AuthorizationError } from '@geolonia/geonicdb-sdk'`
+  - Fix: Changed `scripts/build-sdk.ts` d.ts generation to `export * from './index'; export { default } from './index';` to auto-forward all named exports from `src/sdk/index.ts`. No need to modify this script when adding exports to index in the future
+  - Regression prevention: Added `tests/unit/sdk/build-artifacts.test.ts`. Verifies `geonicdb.d.ts` is in wildcard form, error classes are publicly available via re-export form from `errors.ts` in `index.d.ts`, and error classes can be called as constructors in both runtime CJS / ESM bundles, are Error subclasses, and have `GeonicDBError` as common base (ESM evaluated via child process)
+- **Add**: ReactiveCore Rules action templates now support calling functions like `${now()}` / `${uuid()}` (issue #1120) (#1125)
+  - Background: Existing `${path}` resolution was limited to paths referencing `entity.id` / `attribute.<name>.value` / `trigger.*`, with no way to generate server time or unique IDs. Only deterministic entityIds like `urn:ngsi-ld:ActivityLog:${entity.id}` were possible; generating derived entities from multiple updates of the same entity would fail with id collision from the 2nd time onwards
+  - Fix: Extended `substituteTemplate` in `rule-engine.service.ts` to interpret `${name(args)}` form as function calls. Implemented functions are whitelist-only with no side effects or external I/O:
+    - `${now()}` / `${now('iso')}` → ISO 8601 timestamp
+    - `${now('unix')}` → UNIX seconds
+    - `${now('unix-ms')}` → UNIX milliseconds
     - `${uuid()}` → RFC 4122 v4 UUID
-  - 安全性: 引数パーサは単純なクォート付き文字列リテラルのみ受け付ける。未対応の関数名・フォーマットは literal として残し warn ログを出す (発火を止めない)
-  - ドキュメント: `docs/REACTIVCORE_RULES.md` の Template Variables セクションに「Template Functions」サブセクションを追加。append-only ActivityLog の実用例も掲載
-  - テスト: `rule-engine.service.test.ts` の `template substitution` describe に 10 シナリオを追加 (各関数の戻り値形式、複数関数の同時展開、path 参照との混在、未知関数 / 不正フォーマットの literal 保持、`createEntity` での `${uuid()}` 一意性)
+  - Safety: Argument parser accepts only simple quoted string literals. Unsupported function names / formats are left as literals with a warn log (does not stop firing)
+  - Docs: Added "Template Functions" subsection to Template Variables section of `docs/REACTIVCORE_RULES.md`. Includes append-only ActivityLog practical example
+  - Tests: Added 10 scenarios to `template substitution` describe in `rule-engine.service.test.ts` (return value formats for each function, simultaneous multi-function expansion, mixing with path references, unknown function / invalid format literal preservation, `createEntity` `${uuid()}` uniqueness)
 
 ### 2026-05-01
-- **修正**: 本番 (Lambda) で ReactiveCore Rules が一切発火しない問題 (issue #1119) (#1121)
-  - 原因: `entity.service` から EventBridge へ publish される `EntityCreated/Updated/Deleted` イベントを listen する Rule consumer Lambda が `infrastructure/template.yaml` に存在せず、Rules 発火経路が `ChangeStreamProcessorFunction` の `Schedule: rate(1 minute)` 起動 → MongoDB Change Stream tail だけに依存していた。本番 Lambda 環境ではこの経路が静かに失敗しており Rules が一切実行されなかった (locus サンプル開発時に発覚)
-  - 修正: 新規 Lambda `RuleProcessorFunction` (`src/handlers/rules/processor.ts`) を SubscriptionMatcher と同じ EventBridgeRule で `EntityCreated/Updated/Deleted` を listen させ、`RuleEngineService.processEntityChange` を駆動する。`ChangeStreamProcessorFunction` 側からは rule engine 呼び出しを撤去 (二重発火防止)
-  - **E2E でこのバグを検出できなかった反省を反映**: 既存の `tests/e2e/support/rule-execution-helper.ts` (`triggerRuleExecution`) が `ruleEngine.processEntityChange` を直接呼んでおり EventBridge 経路を完全にスキップしていたため、template.yaml の配線喪失を E2E で気付けなかった。以下の検出策を追加:
-    - `tests/e2e/support/hooks.ts` に `@rules-auto-fire` タグ専用ブリッジを追加。`getLocalEventBus().on('entityChange', ...)` で本番 handler `handlers/rules/processor.handler` を直接呼び、entity 作成 API → EventBridge 相当 → RuleProcessor Lambda → ruleEngine の経路を丸ごと貫通させる
-    - `tests/e2e/features/auth/rules-auto-fire.feature` で「entity 作成 API のみで Rule action が自動実行される」シナリオを 2 つ追加 (`triggerRuleExecution` を介さない再現テスト)
-    - `tests/unit/infrastructure/sam-template.test.ts` で `infrastructure/template.yaml` の最小構造を検証 (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction が EventBridgeRule で 3 種の detail-type を listen していることを機械的に確認)
-    - `tests/unit/handlers/rules/processor.test.ts` で新規 handler 単体の挙動 (3 種イベント委譲・secondary region スキップ・エラー握り潰し・タイムアウト) を検証
-  - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
+- **Fix**: ReactiveCore Rules not firing at all in production (Lambda) (issue #1119) (#1121)
+  - Cause: Rule consumer Lambda listening to `EntityCreated/Updated/Deleted` events published from `entity.service` to EventBridge was not present in `infrastructure/template.yaml`, making Rules firing path depend solely on `ChangeStreamProcessorFunction` `Schedule: rate(1 minute)` startup → MongoDB Change Stream tail. This path was silently failing in production Lambda environment so Rules never executed (discovered during locus sample development)
+  - Fix: Added new Lambda `RuleProcessorFunction` (`src/handlers/rules/processor.ts`) to listen to `EntityCreated/Updated/Deleted` with same EventBridgeRule as SubscriptionMatcher, driving `RuleEngineService.processEntityChange`. Removed rule engine call from `ChangeStreamProcessorFunction` side (double-firing prevention)
+  - **Reflecting on failure to detect this bug with E2E**: Existing `tests/e2e/support/rule-execution-helper.ts` (`triggerRuleExecution`) called `ruleEngine.processEntityChange` directly, completely skipping EventBridge path, so loss of wiring in `template.yaml` went unnoticed. Added following detection measures:
+    - Added `@rules-auto-fire` tag dedicated bridge to `tests/e2e/support/hooks.ts`. Calls production handler `handlers/rules/processor.handler` directly via `getLocalEventBus().on('entityChange', ...)`, threading through entity creation API → EventBridge equivalent → RuleProcessor Lambda → ruleEngine path
+    - Added 2 scenarios to `tests/e2e/features/auth/rules-auto-fire.feature` for "Rule action auto-executes from entity creation API alone" (reproduction test without `triggerRuleExecution`)
+    - Added `tests/unit/infrastructure/sam-template.test.ts` to mechanically verify minimum structure of `infrastructure/template.yaml` (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction listen to 3 detail-types via EventBridgeRule)
+    - Added `tests/unit/handlers/rules/processor.test.ts` verifying new handler unit behavior (3 event delegation, secondary region skip, error suppression, timeout)
+  - Related: `src/handlers/rules/processor.ts` (new), `src/handlers/streams/change-stream.ts` (rule engine call removed), `infrastructure/template.yaml` (`RuleProcessorFunction` added), `tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
 
 ## [0.6.0] — 2026-05-01
 
 ### 2026-05-01
-- **認可**: WebSocket 配信時の XACML AuthzRequest に `entityOwner` / `entityId` を inject (issue #1107) (#1116)
-  - `src/handlers/websocket/broadcaster.ts` の `filterByAuthz` と `src/core/streaming/local-ws-server.ts` の `broadcastEventAsync` を改修。各コネクションに対する `authorizeWs()` 呼び出しに、配信対象 entity の `entityOwner` (createdBy) / `entityId` / `entityType` を渡す。これまで `entityType` のみだったため、「**自分が所有する entity の更新だけ受信する**」per-user 通知フィルタが XACML カスタムポリシーで書けなかった
-  - これに伴い `EntityChangeEvent.entity` に optional な `owner?: string` を追加。`entity.service.ts` の publish 経路 (CREATE/UPDATE/DELETE 各種) で entity の `createdBy` を transparent に伝播する。`InternalEntity.createdBy` も追加 (内部用; NGSI トランスフォーマでは出力されない)
-  - `WsEntityContext` インターフェースを `policy.pip.ts` に追加。`buildWsAuthzRequest` / `authorizeWs` の 5 番目の引数を `entityType?: string` から `entityContext?: WsEntityContext` (`{ entityType?, entityId?, entityOwner? }`) に変更。`WS ⊂ GET` 評価時に entityOwner も両方の AuthzRequest に inject される
-  - 認可キャッシュキーを `role:policyId` → `role:policyId:userId` に拡張。`subject.userId == entityOwner` 形式のポリシーは role/policyId が同じでも userId 単位で decision が分岐するため。同一ユーザーがマルチデバイス接続している場合のみキャッシュ再利用される
-  - 新しいユースケース: 「自分宛のイベントだけ受信」(チャット, 通知)、「自分が所有する entity の subscribe」(マイページフィード)、locus サンプルの「自分が編集した GeoJSON の activity だけ流れる」フィード等が XACML カスタムポリシーで実現可能
-  - 関連: `src/infrastructure/eventbridge/client.ts` (`EntityChangeEvent.entity.owner`)、`src/core/entities/entity.types.ts` (`InternalEntity.createdBy`)、`src/core/entities/entity.repository.ts` (`toInternalEntity` 経由で createdBy 伝搬)、`src/core/entities/entity.service.ts` (CREATE/UPDATE/DELETE 各 publish で `entity.owner` を inject)、`src/core/auth/policy/policy.pip.ts` (`WsEntityContext`, `buildWsAuthzRequest`, `authorizeWs`)、`src/handlers/websocket/broadcaster.ts` / `src/core/streaming/local-ws-server.ts` (キャッシュキー + entityOwner 引き渡し)、`docs/AUTH.md` / `docs/EVENT_STREAMING.md` 追記、`tests/unit/core/auth/policy/policy.pip.test.ts` / `tests/unit/handlers/websocket/broadcaster.test.ts` / `tests/unit/core/entities/entity.service.test.ts` (happy / unhappy 計 12 ケース追加)、`tests/e2e/features/common/websocket.feature` (owner-based WS フィルタの 1 シナリオ追加)
-- **ReactiveCore Rules**: `eventType` 条件を追加 (issue #1103) (#1115)
-  - Rule の `conditions` に `{type: "eventType", eventTypes: ["create" | "update" | "delete"]}` を指定できるようにした。EntityCreated / EntityUpdated / EntityDeleted の発火元を Rule 側でフィルタできる。サンプルアプリ `geonicdb-locus` (GeoJSON コラボ編集) の「作成時のみ ActivityLog を生成」「削除時のみクリーンアップ」というよくあるパターンが直接書けるようになる
-  - これまで `change` 条件 (`changedAttributes` 参照) では CREATE と DELETE を区別できず (両者とも `changedAttributes` が undefined)、自然な書き方ができなかった
-  - 既存の `entityType` / `value` / `change` / `and` / `or` / `not` などと自由に組み合わせ可能。`{type: "not", condition: {type: "eventType", eventTypes: ["delete"]}}` で「削除以外」も書ける
-  - 関連: `src/core/rules/rule.types.ts` (`EventTypeCondition` / `RuleEventType` 追加)、`src/core/rules/rule-engine.service.ts` (`evaluateEventTypeCondition` 追加 — `EntityCreated`→`create` 等のマッピング)、`src/api/shared/schemas/rule.schemas.ts` (`EventTypeConditionSchema` を discriminatedUnion に追加)、`docs/REACTIVCORE_RULES.md` 追記、`tests/unit/core/rules/rule-engine.service.test.ts` / `tests/unit/api/shared/schemas/rule.schemas.test.ts` (happy / unhappy シナリオ追加)、`tests/e2e/features/auth/rules.feature` (発火・非発火・複数指定・バリデーションのシナリオ追加)
-- **ReactiveCore Rules**: CEL 評価コンテキストに `previous.attribute.<name>` を露出 (issue #1106) (#1114)
-  - `src/core/rules/rule-engine.service.ts` の `evaluateCelExpressionCondition` で、`RuleEvaluationContext.previousEntity` の属性を `previous.attribute.<name>.value` / `previous.attribute.<name>.type` として CEL 環境にバインド。これまで `previousEntity` は内部的に保持されていたが CEL からは参照できなかった
-  - 振る舞い: `EntityCreated` 時 `previous.attribute` は空オブジェクト (`{}`)、`EntityUpdated` 時は更新前の属性スナップショット、`EntityDeleted` 時は最終状態。空オブジェクトに対する直接プロパティ参照 (`previous.attribute.x.value`) は CEL が `No such key` を throw するため、`has()` ガードを推奨 (例: `has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30`)
-  - これにより「閾値クロス検出」「`draft` → `published` 等の状態遷移検出」「設定変更の監査ログ」「idempotent 更新の誤発火回避」など、現在値だけでは表現できないルールが直接記述可能になる。`change` 条件タイプの「何から何に変化したか不明」「同値再 update で誤発火」という限界を補完する
-  - `docs/REACTIVCORE_RULES.md` の CEL Context Variables 表に `previous.attribute.<name>.value` / `.type` の行と `has()` ガードの注意書き、及び 4 種の使用例 (閾値クロス・状態遷移・新規属性追加検出・型変化検出) を追加
-  - テスト: `tests/unit/core/rules/rule-engine.service.test.ts` に 12 ケース追加 (Boolean 状態遷移 / 閾値クロス成功 + 既に超過時の発火抑制 / 値変化 / `draft→published` ワークフロー / EntityCreated 時 `has(previous.*)` が false / has ガードによる安全なスキップ / 直接アクセスでの catch / EntityDeleted 時の previous 露出 / 新規追加属性検出 / type フィールドアクセス)。E2E は `tests/e2e/features/auth/rules.feature` に閾値クロス・状態遷移の 2 シナリオを追加
-- **SDK**: anonymous モードを追加 (issue #1105) (#1113)
-  - `new GeonicDB({ anonymous: true, tenant, baseUrl })` で token 取得・`Authorization` ヘッダ送信を完全にスキップしてリクエストできるようにした。サーバー側 (`optionalAuth`) で `role: 'anonymous'` として通り、`anonymous` ロールに対する XACML カスタムポリシーが認可判定する。GeoJSON 公開ビューア / BI ダッシュボード / 公的データ可視化のような「未登録閲覧者にも公開リソースを返したい」公開アプリで、ログインフォームを挟まずに SDK が使えるようになる
-  - `apiKey` と同時指定はコンストラクタで throw (token 取得経路と相互排他)。`login()` / `setCredentials()` で認証付きへ昇格でき、`logout()` で再び anonymous へ戻る (`db.isAnonymous()` で現在状態を確認可能)
-  - anonymous リクエストの 401 / 403 はトークン再取得ループに入らず透過。XACML Deny がそのまま呼び出し側に届く
-  - WebSocket は `connect()` 時点で明示的に throw (サーバー `local-ws-server.ts` が token 必須)。WS の anonymous 対応は別 issue へ送る
-  - 関連: `src/sdk/auth.ts` (`AuthManager._anonymous` / `isAnonymous()` / `request()` 分岐), `src/sdk/index.ts` (オプション透過 / `db.isAnonymous()`), `src/sdk/types.ts` (`GeonicDBOptions.anonymous`), `src/sdk/websocket.ts` (anonymous 時の `connect()` ガード), `tests/unit/sdk/auth.test.ts` / `tests/unit/sdk/index.test.ts` (happy 4 / unhappy 5 シナリオ追加)、`docs/SDK.md`、`src/sdk/README.md`
-- **認可**: NGSI-LD Subscription 作成時に購読対象属性を XACML AuthzRequest へ inject (issue #1104) (#1112)
-  - `POST /ngsi-ld/v1/subscriptions` の認可判定で、これまで `body.type === "Subscription"` がそのまま `resource.entityType` に乗っていた問題を修正。代わりに `entities[]` 各要素から購読対象の `entityType` / `entityId` / `entityIdPattern` を抽出し、`notification.endpoint.uri` を `resource.notificationEndpoint` として inject する (#1112)
-  - `entities[]` が複数要素を持つ場合は **all-Permit セマンティクス**で評価。1 件でも非許可 (Deny / NotApplicable / Indeterminate) があれば全体を Deny する。最初の要素だけ許可しておけば後続を抜けられる、という抜け穴を防ぐ (#1112)
-  - 新しい resource 属性で「`anonymous` は `entityType=ActivityLog` の購読のみ許可」「`notificationEndpoint` が `https://*.example.com/**` の subscription のみ許可 (SSRF / データ持ち出し対策)」のような型ベース・URI ベース制御が XACML カスタムポリシーで書けるようになる (#1112)
-  - 関連: `src/core/auth/policy/policy.types.ts` (AuthzRequest.resource 拡張)、`src/core/auth/policy/policy.pip.ts` (`extractSubscriptionAuthzAttributes` / `buildSubscriptionAuthzRequests` 追加)、`src/core/auth/policy/policy.pdp.ts` (`entityIdPattern` / `notificationEndpoint` 属性対応)、`src/api/shared/middleware/authz.middleware.ts` (subscription 用 all-Permit 評価パス)、`docs/AUTH.md` 追記 (#1112)
-  - locus サンプルアプリ (#1103) で「ActivityLog 以外の subscription を弾く」厳密ポリシーが書けるようになる (#1112)
-- **セキュリティ**: PoW 難易度を 4 → 16 ビットに引き上げ (issue #1093) (#1110)
-  - `src/config/defaults.ts` の `PROOF_OF_WORK.DIFFICULTY` を `4` → `16` に変更。平均 SHA256 計算回数 16 → 65,536 で GPU バースト bot の単発成功コストを引き上げ
-  - 1 次防御は IP / OAuth client_id ベースのレート制限 (#1075)。PoW は副次防御だが、4 ビットでは最新 GPU で数 μs で解けるため抑止力として弱く、16 ビットへ引き上げ
-  - SDK (`src/sdk/pow.ts`) は `difficulty` パラメータ可変対応済 (`MAX_ITERATIONS=1M`、Web Crypto バッチ処理) のためクライアント互換性影響なし。サーバ側 `MAX_PROOF_VALUE: 1_000_000` 内で 99.99999% の確率で proof が見つかる
-  - テスト: `tests/unit/core/auth/pow/pow.service.test.ts` の `default difficulty` 期待値と探索条件 (先頭 16 ビット 0) を更新
-- **セキュリティ**: `MONGODB_ENFORCE_SECRETS=true` で `MONGODB_URI` 環境変数経路を fail-closed に禁止 (issue #1086) (#1111)
-  - `src/infrastructure/mongodb/client.ts` の `getMongoUriAsync()` を改修。`HA.SECRETS_MANAGER.MONGODB_ENFORCE_SECRETS` (env 由来、`@config/defaults`) が真のとき:
-    - `MONGODB_URI_ARN` 未設定なら起動時に throw (ARN 必須)
-    - ARN 設定済だが Secrets Manager 取得失敗時も throw (env フォールバックなし)
-  - SAM template (`infrastructure/template.yaml`) の `ApiHandlerFunction` Environment で `MONGODB_ENFORCE_SECRETS: 'true'` を設定し、Lambda 本番デプロイをデフォルト hardened 化。Docker Smoke E2E / ローカル `npm start` / dev/test では未設定のまま env URI で起動可能。Docker / EC2 で本番運用する場合は運用者が明示的に `MONGODB_ENFORCE_SECRETS=true` を設定する
-  - 当初 `NODE_ENV=production` で判定 → Docker Smoke E2E が壊れる → `AWS_LAMBDA_FUNCTION_NAME` 判定に変更 → CodeRabbit 指摘で「ランタイム種別ではなく中央設定 flag に」と最終的に再変更
-  - メモリダンプ / CloudWatch ログ汚染で平文認証情報が露出する経路を塞ぐ fail-closed 設計。`docs/SECURITY.md` に挙動マトリクスを追記
-  - テスト: `tests/unit/infrastructure/mongodb.test.ts` に `getMongoUriAsync` の 5 ケース (enforce + ARN 未設定・enforce + fetch 失敗・enforce + secret 取得・unset env フォールバック × 2) を追加
+- **Authz**: Inject `entityOwner` / `entityId` into XACML AuthzRequest on WebSocket delivery (issue #1107) (#1116)
+  - Refactored `filterByAuthz` in `src/handlers/websocket/broadcaster.ts` and `broadcastEventAsync` in `src/core/streaming/local-ws-server.ts`. Pass `entityOwner` (createdBy) / `entityId` / `entityType` of the entity being delivered to each connection's `authorizeWs()` call. Previously only `entityType` was passed, so XACML custom policies for "receive only updates to entities you own" per-user notification filter could not be written
+  - Added optional `owner?: string` to `EntityChangeEvent.entity`. Propagate entity `createdBy` transparently in `entity.service.ts` publish paths (CREATE/UPDATE/DELETE). Also added `InternalEntity.createdBy` (internal use; not output by NGSI transformer)
+  - Added `WsEntityContext` interface to `policy.pip.ts`. Changed 5th argument of `buildWsAuthzRequest` / `authorizeWs` from `entityType?: string` to `entityContext?: WsEntityContext` (`{ entityType?, entityId?, entityOwner? }`). entityOwner injected into both AuthzRequests in `WS ⊂ GET` evaluation
+  - Extended authz cache key from `role:policyId` to `role:policyId:userId`. Policies of form `subject.userId == entityOwner` have different decisions per userId even with same role/policyId. Cache is only reused when same user connects from multiple devices
+  - New use cases: "receive only events addressed to me" (chat, notifications), "subscribe to entities you own" (my page feed), "only feed for GeoJSON I edited" in locus sample, etc. are now possible with XACML custom policies
+  - Related: `src/infrastructure/eventbridge/client.ts`, `src/core/entities/entity.types.ts`, `src/core/entities/entity.repository.ts`, `src/core/entities/entity.service.ts`, `src/core/auth/policy/policy.pip.ts`, `src/handlers/websocket/broadcaster.ts` / `src/core/streaming/local-ws-server.ts`, `docs/AUTH.md` / `docs/EVENT_STREAMING.md`, tests (12 happy/unhappy cases added), `tests/e2e/features/common/websocket.feature` (1 owner-based WS filter scenario)
+- **ReactiveCore Rules**: Added `eventType` condition (issue #1103) (#1115)
+  - Rules `conditions` now support `{type: "eventType", eventTypes: ["create" | "update" | "delete"]}`. Can filter EntityCreated / EntityUpdated / EntityDeleted trigger events on the Rule side. Common patterns in `geonicdb-locus` sample app (GeoJSON collaborative editing) like "generate ActivityLog only on create" and "cleanup only on delete" can now be written directly
+  - Previously `change` condition (`changedAttributes` reference) couldn't distinguish CREATE and DELETE (both have `changedAttributes` undefined), making natural expressions impossible
+  - Can be freely combined with existing `entityType` / `value` / `change` / `and` / `or` / `not` etc. Use `{type: "not", condition: {type: "eventType", eventTypes: ["delete"]}}` to express "anything except delete"
+  - Related: `src/core/rules/rule.types.ts`, `src/core/rules/rule-engine.service.ts`, `src/api/shared/schemas/rule.schemas.ts`, `docs/REACTIVCORE_RULES.md`, tests added
+- **ReactiveCore Rules**: Exposed `previous.attribute.<name>` in CEL evaluation context (issue #1106) (#1114)
+  - In `evaluateCelExpressionCondition` of `src/core/rules/rule-engine.service.ts`, bound `RuleEvaluationContext.previousEntity` attributes as `previous.attribute.<name>.value` / `previous.attribute.<name>.type` in CEL environment. Previously `previousEntity` was held internally but could not be referenced from CEL
+  - Behavior: `previous.attribute` is empty object (`{}`) on `EntityCreated`, pre-update attribute snapshot on `EntityUpdated`, final state on `EntityDeleted`. Direct property reference on empty object (`previous.attribute.x.value`) throws `No such key` in CEL, so `has()` guard is recommended
+  - Enables rules like "threshold crossing detection", "`draft` → `published` state transition detection", "configuration change audit log", "idempotent update misfiring avoidance" that cannot be expressed with current values alone
+  - Docs: Added `previous.attribute.<name>.value` / `.type` rows and `has()` guard notes to CEL Context Variables table in `docs/REACTIVCORE_RULES.md`, plus 4 usage examples
+  - Tests: Added 12 cases to `rule-engine.service.test.ts`. E2E: 2 scenarios for threshold crossing and state transition added to `rules.feature`
+- **SDK**: Added anonymous mode (issue #1105) (#1113)
+  - `new GeonicDB({ anonymous: true, tenant, baseUrl })` completely skips token acquisition and `Authorization` header sending. Server-side (`optionalAuth`) passes as `role: 'anonymous'`, with XACML custom policy deciding authorization for `anonymous` role. Public apps like GeoJSON viewers / BI dashboards / public data visualization that want to return public resources to unregistered viewers can now use the SDK without login forms
+  - Simultaneous specification with `apiKey` throws in constructor (mutually exclusive with token acquisition path). Can upgrade to authenticated with `login()` / `setCredentials()`, and return to anonymous with `logout()` (check current state with `db.isAnonymous()`)
+  - 401 / 403 from anonymous requests don't enter token re-acquisition loop and are passed through transparently. XACML Deny reaches caller as-is
+  - WebSocket explicitly throws at `connect()` (server `local-ws-server.ts` requires token). WS anonymous support deferred to separate issue
+  - Related: `src/sdk/auth.ts`, `src/sdk/index.ts`, `src/sdk/types.ts`, `src/sdk/websocket.ts`, tests, `docs/SDK.md`, `src/sdk/README.md`
+- **Authz**: Inject subscription target attributes into XACML AuthzRequest on NGSI-LD Subscription creation (issue #1104) (#1112)
+  - Fixed issue where `body.type === "Subscription"` was going directly to `resource.entityType` in authorization for `POST /ngsi-ld/v1/subscriptions`. Now extracts `entityType` / `entityId` / `entityIdPattern` from each element of `entities[]` and injects `notification.endpoint.uri` as `resource.notificationEndpoint`
+  - For `entities[]` with multiple elements, evaluates with **all-Permit semantics**. If even one is not permitted (Deny / NotApplicable / Indeterminate), deny overall. Prevents the loophole of permitting only the first element to skip the rest
+  - New resource attributes enable type-based / URI-based control in XACML custom policies like "allow `anonymous` only for `entityType=ActivityLog` subscriptions" or "allow only subscriptions where `notificationEndpoint` matches `https://*.example.com/**`" (SSRF / data exfiltration countermeasure)
+- **Security**: Raised PoW difficulty from 4 to 16 bits (issue #1093) (#1110)
+  - Changed `PROOF_OF_WORK.DIFFICULTY` in `src/config/defaults.ts` from `4` to `16`. Average SHA256 computations 16 → 65,536, raising the cost for GPU burst bots to succeed
+  - Primary defense is IP / OAuth `client_id`-based rate limiting (#1075). PoW is secondary defense, but 4 bits is solvable in a few microseconds on modern GPUs making it ineffective as a deterrent
+  - SDK (`src/sdk/pow.ts`) already supports variable `difficulty` parameter (`MAX_ITERATIONS=1M`, Web Crypto batch processing), so no client compatibility impact
+- **Security**: `MONGODB_ENFORCE_SECRETS=true` makes `MONGODB_URI` env variable path fail-closed (issue #1086) (#1111)
+  - Refactored `getMongoUriAsync()` in `src/infrastructure/mongodb/client.ts`. When `HA.SECRETS_MANAGER.MONGODB_ENFORCE_SECRETS` (env-derived, `@config/defaults`) is true: throws at startup if `MONGODB_URI_ARN` not set; also throws if ARN is set but Secrets Manager fetch fails (no env fallback)
+  - Set `MONGODB_ENFORCE_SECRETS: 'true'` in Lambda prod deployment by default. Docker Smoke E2E / local `npm start` / dev/test can start with env URI without this setting. For production on Docker / EC2, operators explicitly set `MONGODB_ENFORCE_SECRETS=true`
+  - Fail-closed design blocking plaintext credentials exposed via memory dumps / CloudWatch log contamination. Added behavior matrix to `docs/SECURITY.md`
 
 ### 2026-04-30
-- **セキュリティ**: Lambda IAM の `kms:CreateKey` に Condition を追加し用途・タグを強制 (issue #1071) (#1108)
-  - `infrastructure/template.yaml` の `ApiHandlerFunction.Policies` 内 `kms:CreateKey` Statement に `Condition` を追加: `kms:KeyUsage = ENCRYPT_DECRYPT` / `kms:KeySpec = SYMMETRIC_DEFAULT` / `aws:RequestTag/geonicdb:purpose = envelope-encryption` を強制し、未知タグキーは `ForAllValues:StringEquals` の `aws:TagKeys` で `geonicdb:tenantId` / `geonicdb:purpose` のみに制限。`Null: aws:RequestTag/geonicdb:tenantId = false` で tenant 所有情報のないキー作成を禁止
-  - `Resource` は AWS 仕様上 `kms:CreateKey` (new-resource action) では `'*'` 必須のため変更しない。代わりに `kms:TagResource` を別 Statement として `arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*` で許可し、`CreateKeyCommand` の `Tags` パラメータ適用に必要な権限を Region/Account 制限付きで付与
-  - 実コード (`src/infrastructure/kms/key-manager.ts createTenantKey()`) は既に上記タグ・KeyUsage・KeySpec で発行しているため非破壊。compromised Lambda が署名鍵・非対称鍵・無タグキー・tenantId 不明のキーを量産する経路を抑止
-- **セキュリティ**: API Gateway `GatewayResponses` の `Access-Control-Allow-Origin` を Parameter 化 (issue #1088) (#1108)
-  - 新 Parameter `GatewayResponseAllowOrigin` を追加 (デフォルト `*` で互換維持)。`infrastructure/template.yaml` の `DEFAULT_4XX` / `DEFAULT_5XX` で `!Sub "'${GatewayResponseAllowOrigin}'"` を参照
-  - 本番デプロイ時は `--parameter-overrides GatewayResponseAllowOrigin='https://app.example.com'` で許可 origin に限定可能。Lambda 経由の通常応答は `src/api/shared/middleware/cors.middleware.ts` の origin echo back + `tenant.allowedOrigins` で制御 (#1069 で導入済)
-  - これにより Lambda が呼ばれない API Gateway 直返しエラー応答経由でのエラーボディ漏洩経路 (任意 origin からの fetch) を本番で塞げるようにする
-- **セキュリティ**: XACML ポリシー登録時に WS ⊂ GET 不変条件違反を WARN ログで検出 (issue #1085) (#1109)
-  - `PolicyService.validateWsGetSymmetry()` を追加。`createPolicy` / `updatePolicy` / `updatePolicySystem` / `updatePolicyForUser` の各経路で、`rule.target.actions` に `attributeId === 'method'` かつ `matchValue === 'WS'` (`string-equal`) のエントリがあり、同じ rule に `'GET'` が含まれていない場合に WARN ログを出力
-  - `authorizeWs()` (`src/core/auth/policy/policy.pip.ts`) は WS と GET を両方評価し両方 Permit でないと許可しない設計のため、WS-only ルールは管理者意図と実挙動が乖離しやすい (例: 「WS だけ Deny」を意図しても GET 経由でデータが取得可能)。reject ではなく WARN に留めることで既存ポリシーとの後方互換を維持
-  - `docs/AUTH.md` に「WebSocket Authorization (WS ⊂ GET)」セクションを追加し、不変条件・推奨記法・WARN ログの読み方を明示
-  - テスト: `tests/unit/core/auth/policy/policy.service.test.ts` に 7 ケース (WS-only / WS+GET / GET-only / glob matchFunction / 非 method attributeId / actions なし / updatePolicy・updatePolicySystem 経由) を追加
-
-- **セキュリティ**: 公開エンドポイントレート制限の部分失敗時のロールバック実装 (issue #1075 follow-up) (#1102)
-  - 旧挙動: `consumeBucket()` で 3 つの時間窓（minute/hour/day）を `Promise.all` で並列更新していたため、一部の窓で例外（DDB / Mongo の一時障害等）が発生した場合、成功した窓だけトークンが消費されたまま残り、後続リクエストがその窓を不当に削られる「過大カウント」が発生していた。また制限超過拒否時にも、拒否された窓以外で消費が成立しているケースがあり同様の不整合が起きていた
-  - 対応:
-    - `Promise.allSettled` で 3 窓を並列更新し、(a) 一部 throw 時は **値が非負で fulfilled** な窓だけを負 weight で `updateBucket` し直してトークンを返却（ロールバック）した上で元の例外を再 throw、(b) 制限超過拒否時にも拒否された窓以外で消費が成立した窓を同様にロールバック
-    - **negative-value guard**: `updateBucket` は条件失敗時に負値を fulfilled として返すが、その場合 DDB の SET / Mongo の $inc は実行されず消費は成立していない。これを誤ってロールバックすると過大トークンが加算されるため、ロールバック対象は `r.value >= 0` の fulfilled 結果のみに限定（CodeRabbit 指摘 #1102 の追加修正）
-    - DDB の `ConditionExpression: remainingTokens - :consumed >= 0` は負 `:consumed` を常に満たすため `SET remainingTokens = remainingTokens - (-weight)` で加算復元される。Mongo の `$inc: { remainingTokens: -tokensToConsume }` も負 `tokensToConsume` で `+weight` の `$inc` として正しく動作することを確認済み
-    - ロールバック自体が失敗した場合は黙って許容（過大カウント方向の安全な失敗モード）。Promise.all reject 時は呼び出し側 (`enforcePublicRateLimit`) で fail-open 扱いとなり公開エンドポイントを落とさない
-  - テスト: 既存 11 ケースに加え、ロールバック挙動を検証する 6 ケースを追加（一部 throw 時の正しいロールバック対象選択、negative-value 混在時のロールバック対象除外回帰テスト、全窓 throw 時のロールバック発火なし、ロールバック失敗時の握り潰し、制限超過拒否時の整合性確保、全成功時のロールバック非発火）
-  - PR #1101 への CodeRabbit レビュー指摘 (`src/core/quotas/rate-limit/public-rate-limit.service.ts` lines 97-101) への follow-up
-
-- **セキュリティ**: 公開（未認証）エンドポイントに IP ベースのレート制限を導入 (issue #1075) (#1101)
-  - 旧挙動: `/.well-known/ai-plugin.json` `/.well-known/agent-card.json` `/.well-known/ngsi-ld` `/openapi.json` `/api.json` `/tools.json` `/llms.txt` および `/oauth/token` `/auth/refresh` `/auth/nonce` には一切のレート制限が掛かっておらず、テナント単位の `checkRateLimit()` も認証後にしか発火しないため事実上無制限だった。OAuth `client_id+secret` のオフラインなしブルートフォース、重い JSON 生成 (`/openapi.json` 等) の連打による Lambda 同時実行枠枯渇 (DoS) が成立していた (#1101)
-  - 対応 (#1101):
-    - `src/core/quotas/rate-limit/public-rate-limit.service.ts` を新設し、既存の `providers.rateLimit` (DynamoDB / MongoDB トークンバケット) を再利用しつつ IP / OAuth `client_id` 別バケットでレート制限を行う `checkPublicRateLimit()` / `checkOAuthClientRateLimit()` を追加
-    - `src/handlers/api/index.ts` に `enforcePublicRateLimit()` ヘルパーと `isPublicMetadataPath()` / `extractOAuthClientId()` を追加し、メタデータ系・OAuth・auth refresh / nonce のディスパッチ前に呼び出す。`/auth/login` は既存の `LoginProtectionService` で保護されているため除外、`/health` `/version` は監視ポーリング用途のため除外
-    - **早期発火**: 公開パスのレート制限チェックを `Promise.all([resolveJwtSecret(), getMongoClient()])` および `resolveHostnameContext()` よりも前に実行し、レート制限超過時に JWT 秘密の解決・Mongo 接続・ホスト名 DDB 参照を全てスキップ。これによりレート超過リクエストの Lambda CPU 消費とコールドスタート待機を最小化
-    - `src/config/defaults.ts` に `PUBLIC_RATE_LIMIT` を新設しカテゴリ別 (metadata / oauth / auth) のデフォルト値を集約。OAuth は IP 別バケットに加えて `client_id` 別バケットも併用してパスワードスプレー対策。`DISCOVERY` 定数に `OPENAPI_JSON_PATH` / `API_JSON_PATH` / `NGSI_LD_WELL_KNOWN_PATH` を追加してパス文字列を集約
-    - バケットストア障害時は安全側に倒さず通過させる (公開エンドポイントを落とさない)。`TooManyRequestsError` 経由で 429 + `Retry-After` ヘッダを返す
-  - テスト: `tests/unit/core/quotas/rate-limit/public-rate-limit.service.test.ts` に 11 ケース、`tests/unit/handlers/api/index.test.ts` に「公開エンドポイントのレート制限 (#1075)」13 ケースを追加 (Basic Auth / form-urlencoded / JSON ボディからの `client_id` 抽出、429 + Retry-After、`/auth/refresh` と `/auth/nonce` 両方の確認、`/health` `/auth/login` の除外、ストア障害フォールバック) (#1101)
-
-- **セキュリティ**: PBKDF2 反復回数を `NODE_ENV` 依存から固定定数に変更 (issue #1073) (#1100)
-  - 旧挙動: `process.env.NODE_ENV === 'test'` の三項演算で iter=1000 / 100000 を切り替えていたため、CI/CD や Lambda 環境変数の誤設定で `NODE_ENV=test` が混入すると本番ハッシュ計算が 100 倍弱体化する経路があった
-  - 修正: `src/config/defaults.ts` に `PASSWORD_HASH` ブロックを新設し、`PBKDF2_ITERATIONS: 100000` (本番固定値) / `KEY_LENGTH` / `SALT_LENGTH` / `DIGEST` を集約。`password.service.ts` は `NODE_ENV` を一切参照しない
-  - テスト用オーバーライドは独立した環境変数 `PASSWORD_HASH_ITERATIONS_TEST` を明示設定した時のみ有効化 (正の整数チェック)。Jest / Cucumber 両セットアップでこの変数を `'1000'` に設定
-  - 起動時 (初回 hash 呼び出し時) に反復回数を INFO ログに出力し、誤設定の回帰を CloudWatch から検知可能化
-  - テスト: `password.service.test.ts` に新規 6 ケース (override 適用 / 不正値拒否 / NODE_ENV 非依存性) を追加
-
-- **[Breaking] WebSocket 認証**: URL クエリパラメータ `?token=` 経路を完全廃止 (issue #1072) (#1099)
-  - 旧挙動: `extractWebSocketToken()` (`src/handlers/websocket/connect.ts`) と `extractLocalWebSocketToken()` (`src/core/streaming/local-ws-server.ts`) が `Authorization` ヘッダ / `Sec-WebSocket-Protocol` に加え、フォールバックとして `?token=<jwt>` URL クエリも受領していた (deprecation warning ログのみで実利用許可) (#1099)
-  - 攻撃面: URL に乗ったトークンはリバースプロキシ / WAF / LB のアクセスログに記録され、ブラウザ履歴やキャッシュにも残存。`Referer` ヘッダ経由で外部に漏洩する経路もあり (Referrer-Policy 未設定と相乗) (#1099)
-  - 対応: query token 抽出ロジックを auth flow の最先頭に移動して **fail-closed** 化。クエリに `token` が含まれていれば、たとえ有効な `Authorization` ヘッダや `Sec-WebSocket-Protocol` が併送されていても warn ログを残した上で `null` を返し、1008 / 401 で接続を拒否する。URL は既に上流プロキシのログに記録された後なので、トークンは漏洩済みとして扱う (#1099)
-  - クライアント影響: 既存クライアントはトークンを以下のいずれかに移行する必要がある (#1099)
-    - **Node.js / 自前 WebSocket クライアント**: `Authorization: Bearer <token>` ヘッダ
-    - **ブラウザ**: 標準の `WebSocket` API は任意ヘッダ設定不可のため、`new WebSocket(url, ['access_token', token])` 形式の `Sec-WebSocket-Protocol` サブプロトコル
-  - 関連プロジェクト確認: `@geolonia/geonicdb-sdk` (`src/sdk/websocket.ts`) は既に `Sec-WebSocket-Protocol` 採用済 → SDK ユーザ (geonicdb-pulse / geonicdb-voice) はノーオペで移行可能。geonicdb-cli / geonicdb-app-template は WebSocket 未使用、geonicdb-demo-app の `use-geonicdb-stream.ts` も query token 未使用 (#1099)
-  - ドキュメント更新: `docs/EVENT_STREAMING.md`、`docs/INSTRUCTION.md` (7.2 接続方法 / 7.6 実装例)、`src/api/shared/controllers/meta.controller.ts` (`/llms.txt` の Event Streaming セクション・`/api.json` の `eventStreaming.auth`) から `&token=...` の記述を除去し、ヘッダ 2 経路に書き換え。`?token=` 経由の接続は拒否される旨を明示 (#1099)
-  - テスト: `tests/unit/handlers/websocket/connect.test.ts` / `tests/unit/core/streaming/local-ws-server.test.ts` に「クエリ `?token=` だけの接続は 401 / 1008 で拒否される」「ヘッダと query token を併送しても query があれば fail-closed」回帰テストを追加。warn ログ送出も spy で固定。既存テストは Bearer ヘッダ送信に書き換え。E2E `tests/e2e/step-definitions/common/websocket.steps.ts` の `connectWebSocket` ヘルパーも `Authorization` ヘッダ送信に変更し、url/options 構築は `buildLocalWsConnection` ヘルパーに共通化 (#1099)
+- **Security**: Added Condition to Lambda IAM `kms:CreateKey` to enforce key usage and tags (issue #1071) (#1108)
+  - Added `Condition` to `kms:CreateKey` Statement in `ApiHandlerFunction.Policies` in `infrastructure/template.yaml`: enforces `kms:KeyUsage = ENCRYPT_DECRYPT` / `kms:KeySpec = SYMMETRIC_DEFAULT` / `aws:RequestTag/geonicdb:purpose = envelope-encryption`, limits unknown tag keys with `ForAllValues:StringEquals` `aws:TagKeys` to `geonicdb:tenantId` / `geonicdb:purpose` only, prohibits key creation without tenant ownership info with `Null: aws:RequestTag/geonicdb:tenantId = false`
+  - Added separate Statement for `kms:TagResource` allowed under `arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*` with Region/Account limits, providing permission needed for `Tags` parameter in `CreateKeyCommand`
+  - Actual code (`src/infrastructure/kms/key-manager.ts createTenantKey()`) already issues with above tags/KeyUsage/KeySpec, so non-breaking. Suppresses path for compromised Lambda to mass-produce signing keys / asymmetric keys / untagged keys / keys with unknown tenantId
+- **Security**: Parameterized `Access-Control-Allow-Origin` in API Gateway `GatewayResponses` (issue #1088) (#1108)
+  - Added new `GatewayResponseAllowOrigin` Parameter (default `*` for backward compatibility). Referenced via `!Sub "'${GatewayResponseAllowOrigin}'"` in `DEFAULT_4XX` / `DEFAULT_5XX` of `infrastructure/template.yaml`
+  - In production deployment, restrict to allowed origin with `--parameter-overrides GatewayResponseAllowOrigin='https://app.example.com'`
+- **Security**: Log WS ⊂ GET invariant violations when registering XACML policies (issue #1085) (#1109)
+  - Added `PolicyService.validateWsGetSymmetry()`. In each path of `createPolicy` / `updatePolicy` / `updatePolicySystem` / `updatePolicyForUser`, outputs WARN log when `rule.target.actions` has entry with `attributeId === 'method'` and `matchValue === 'WS'` (`string-equal`) but the same rule doesn't include `'GET'`
+  - `authorizeWs()` evaluates both WS and GET and permits only when both Permit, so WS-only rules are prone to divergence between admin intent and actual behavior. Left as WARN rather than reject to maintain backward compatibility with existing policies
+  - Added "WebSocket Authorization (WS ⊂ GET)" section to `docs/AUTH.md` clarifying invariant, recommended notation, and how to read WARN logs
+- **Security**: Implemented rollback on partial failure for public endpoint rate limiting (issue #1075 follow-up) (#1102)
+  - Old behavior: `consumeBucket()` updated 3 time windows (minute/hour/day) in parallel with `Promise.all`, so if an exception occurred in some windows (DDB / Mongo transient failure, etc.), only successful windows had tokens consumed, causing "over-counting" where subsequent requests were unfairly depleted. Also when rejecting limit exceedance, consumption could be committed in windows other than the rejecting window
+  - Fix: Updated 3 windows in parallel with `Promise.allSettled`; on (a) partial throws, rolled back by `updateBucket` with negative weight only for windows that are fulfilled with non-negative values, then re-throws original exception; (b) on limit exceedance rejection, similarly rolled back windows where consumption was committed other than the rejecting window
+  - **Negative-value guard**: `updateBucket` returns negative values as fulfilled when condition fails, but DDB SET / Mongo $inc is not executed in that case and consumption was not committed. Rollback target limited to `r.value >= 0` fulfilled results only (CodeRabbit comment #1102 additional fix)
+- **Security**: Introduced IP-based rate limiting for public (unauthenticated) endpoints (issue #1075) (#1101)
+  - Old behavior: `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json`, `/.well-known/ngsi-ld`, `/openapi.json`, `/api.json`, `/tools.json`, `/llms.txt`, `/oauth/token`, `/auth/refresh`, `/auth/nonce` had no rate limiting at all; tenant-level `checkRateLimit()` only fires after authentication, effectively unlimited. Enabled offline brute-force of OAuth `client_id+secret` and Lambda concurrency exhaustion (DoS) by hammering heavy JSON generation endpoints
+  - Fix: Added new `src/core/quotas/rate-limit/public-rate-limit.service.ts` reusing existing `providers.rateLimit` (DynamoDB / MongoDB token bucket) with `checkPublicRateLimit()` / `checkOAuthClientRateLimit()` per IP / OAuth `client_id` bucket. Added `enforcePublicRateLimit()` helper and related helpers to `src/handlers/api/index.ts`, calling before dispatch for metadata / OAuth / auth refresh / nonce. `/auth/login` excluded (protected by existing `LoginProtectionService`), `/health` `/version` excluded (monitoring polling use)
+  - **Early firing**: Public path rate limit check runs before `Promise.all([resolveJwtSecret(), getMongoClient()])` and `resolveHostnameContext()`, skipping JWT secret resolution / Mongo connection / hostname DDB reference on limit exceedance. Minimizes Lambda CPU consumption and cold start wait for rate-exceeded requests
+  - Returns 429 + `Retry-After` header via `TooManyRequestsError`. Fail-open on bucket store failure (don't drop public endpoints)
+- **Security**: Changed PBKDF2 iteration count from `NODE_ENV`-dependent to fixed constant (issue #1073) (#1100)
+  - Old behavior: Ternary `process.env.NODE_ENV === 'test'` switched iter=1000 / 100000, creating a path where production hash computation could be weakened 100x if `NODE_ENV=test` leaked into CI/CD or Lambda env vars
+  - Fix: Added `PASSWORD_HASH` block to `src/config/defaults.ts` with `PBKDF2_ITERATIONS: 100000` (production fixed value). `password.service.ts` no longer references `NODE_ENV`
+  - Test override only activated when explicitly setting separate env var `PASSWORD_HASH_ITERATIONS_TEST` (with positive integer check). Set this variable to `'1000'` in both Jest / Cucumber setups
+- **[Breaking] WebSocket Authentication**: Completely removed `?token=` URL query parameter path (issue #1072) (#1099)
+  - Old behavior: `extractWebSocketToken()` and `extractLocalWebSocketToken()` accepted `?token=<jwt>` URL query as fallback in addition to `Authorization` header / `Sec-WebSocket-Protocol` (only deprecation warning log, actual use permitted)
+  - Attack surface: Token in URL is recorded in reverse proxy / WAF / LB access logs, and also remains in browser history and cache. Leakage path via `Referer` header also exists (compounded with unset Referrer-Policy)
+  - Fix: Moved query token extraction logic to the very front of auth flow with **fail-closed** behavior. If query contains `token`, even if valid `Authorization` header or `Sec-WebSocket-Protocol` is co-sent, leaves warn log and returns `null`, rejecting connection with 1008 / 401. URL already recorded in upstream proxy logs so token is treated as leaked
+  - Client migration: Existing clients need to migrate token to one of: **Node.js / own WebSocket client**: `Authorization: Bearer <token>` header; **Browser**: Standard `WebSocket` API can't set arbitrary headers, so use `new WebSocket(url, ['access_token', token])` form `Sec-WebSocket-Protocol`
+  - `@geolonia/geonicdb-sdk` (`src/sdk/websocket.ts`) already uses `Sec-WebSocket-Protocol` → SDK users (geonicdb-pulse / geonicdb-voice) can migrate with no operation. geonicdb-cli / geonicdb-app-template don't use WebSocket, geonicdb-demo-app `use-geonicdb-stream.ts` doesn't use query token
 
 ### 2026-04-29
-- **CORS / セキュリティ**: Origin echo back + テナント単位 `allowedOrigins` でトークン漏洩・CSRF 経路を遮断 (issue #1069) (#1097)
-  - 旧挙動: `Access-Control-Allow-Origin: '*'` を返しつつ `Authorization` / `X-Api-Key` / `DPoP` を `Access-Control-Allow-Headers` に含めていたため、攻撃者制御のサイトからブラウザに乗ったユーザの Bearer トークン / API Key 付きリクエストを送らせる経路が成立していた (CSRF + トークン漏洩懸念) (#1097)
-  - 環境変数による単一ホワイトリストは GeonicDB がマルチテナント・データ連携基盤 (Context Broker) であるため不適切。許可 origin はテナント運用者がランタイムに DB 越しで設定できる設計に変更 (#1097)
-  - **データモデル拡張**: `TenantSettings.allowedOrigins?: string[]` を追加 (`src/core/auth/tenant/tenant.types.ts`)。`undefined` = 後方互換で全許可、`[]` = 全 deny、`['*']` = 全許可、`[origin1, ...]` = 完全一致。最大 50 個 (`TENANT.MAX_ALLOWED_ORIGINS`) (#1097)
-  - **CORS middleware の echo back 化** (`src/api/shared/middleware/cors.middleware.ts`): `Access-Control-Allow-Origin` をリクエストの `Origin` ヘッダ echo back に変更し、`Vary: Origin` を必ず付与。CDN / ブラウザキャッシュで origin 別レスポンスが混ざらないようにする (#1097)
-  - **認証層での fail-close** (`src/core/auth/origin/origin-check.ts` 新設、`src/api/shared/middleware/auth.middleware.ts` に統合): preflight (OPTIONS) は origin 検証なしで通過させ、実 request の認証フェーズで `validateOriginForTenant()` が違反を 403 で fail-close する。data API は `optionalAuth(event, tenantService)` で、admin API / `/auth/logout` は `requireAuth(event)` で `user.tenantId` から tenant を引いて検証 (#1097)
-  - **エラー時も CORS ヘッダ echo back**: 403 を返すケースでも `Access-Control-Allow-Origin` / `Vary: Origin` を付ける。echo back しないとブラウザはレスポンスを完全ブロックして「Network error」になり、運用者にも原因が見えないため (#1097)
-  - **共通 OriginSchema 切り出し**: API Key の `OriginSchema` を `src/api/admin/schemas/origin.schemas.ts` に共通化し、API Key と Tenant の両方で再利用 (#1097)
-  - **Admin API**: `PATCH /admin/tenants/{tenantId}` の `settings.allowedOrigins` で CRUD 可能 (zod `OriginSchema.array().max(50)` バリデーション) (#1097)
-  - **super_admin はテナントに紐付かない (tenantId=null) ため origin 検証 skip**。認証無効モード (`AUTH_ENABLED=false`) も従来通り origin 検証 skip — IP 制限と同じ扱い (#1097)
-  - テスト: `validateOriginForTenant` unit test (13 ケース)、`cors.middleware.test` を echo back / Vary / extractRequestOrigin で更新 (28 ケース)、`auth.middleware.test` に origin 検証 13 ケース追加。`cors-comprehensive.feature` に `@issue-1069` シナリオ 10 件追加 (origin echo back / preflight 通過 / tenant allow/deny / wildcard / 空配列 / Origin 不在 / 後方互換) (#1097)
-  - 関連プロジェクト影響: geonicdb-cli は `Origin` ヘッダを送らないため API Key / Bearer 認証で動作するが、絞り込み済みテナントには CLI 利用者が `Origin` ヘッダ付与か `*` 許可が必要。geonicdb-pulse / voice / demo-app は SDK 経由で `Origin` 自動付与のため、本番テナントの `allowedOrigins` に `https://*.geolonia.com` 等の登録運用が必要 (#1097)
-
-- **セキュリティ監査バッチ**: 総合監査 (#1068) の互換性影響なし issue 5 件を一括対応 (#1098)
-  - `TestPasswordHasher` を `tests/` 配下に移動。本番モジュールから SHA-256 / salt なしのテスト用ハッシャー export を削除し、誤注入経路を排除 (#1077)
-  - ログイン失敗経路 (user not found / env super admin password mismatch) にダミー PBKDF2 検証を追加。timing-based user enumeration を防ぐため、応答時間を均等化 (#1095)
-  - `loadBoundPolicy()` のテナント不一致 / global→tenant 違反バインドを `error` レベル + `errorCode` / `securityEvent` 構造化フィールドに昇格。CloudWatch メトリクスフィルタで検知可能化 (#1081)
-  - `validateAllowedPath()` にパストラバーサル拒否 (`..`, `//`, `/./`) を追加。string-prefix チェックでの誤評価を防御層として完全排除。テスト 6 ケース追加 (#1083)
-  - `docs/AUTH.md` に「Path-Level vs Entity-Level Authorization」節を追加。`requireAuthz` (fail-closed) と `requireEntityAuthz` (fail-open) の設計判断と運用上の含意 (owner-only ポリシーは明示的 Deny ルールが必要) を明文化 (#1076)
+- **CORS / Security**: Block token leakage / CSRF paths with Origin echo-back + tenant-level `allowedOrigins` (issue #1069) (#1097)
+  - Old behavior: Returning `Access-Control-Allow-Origin: '*'` while including `Authorization` / `X-Api-Key` / `DPoP` in `Access-Control-Allow-Headers` created a path for attackers to send requests with browser-held user Bearer tokens / API Keys from attacker-controlled sites (CSRF + token leakage concern)
+  - Single environment variable whitelist is inappropriate since GeonicDB is a multi-tenant data integration platform (Context Broker). Changed to design where allowed origins are set by tenant operators at runtime via DB
+  - **Data model extension**: Added `TenantSettings.allowedOrigins?: string[]`. `undefined` = backward-compatible allow all, `[]` = deny all, `['*']` = allow all, `[origin1, ...]` = exact match. Max 50 (`TENANT.MAX_ALLOWED_ORIGINS`)
+  - **CORS middleware echo-back**: Changed `Access-Control-Allow-Origin` to echo-back request `Origin` header, always including `Vary: Origin`. Prevents CDN / browser cache mixing responses by origin
+  - **Fail-close in authentication layer**: New `src/core/auth/origin/origin-check.ts` integrated into `src/api/shared/middleware/auth.middleware.ts`. Preflight (OPTIONS) passes without origin validation; actual request authentication phase validates origin with `validateOriginForTenant()`, failing 403 on violation
+  - **CORS headers on error**: Even when returning 403, include `Access-Control-Allow-Origin` / `Vary: Origin`. Without echo-back, browsers completely block response as "Network error", hiding cause from operators
+- **Security audit batch**: Batch fix for 5 compatibility-safe issues from comprehensive audit (#1068) (#1098)
+  - Moved `TestPasswordHasher` under `tests/`. Removed test-only SHA-256/salt-less hasher export from production modules, eliminating accidental injection paths (#1077)
+  - Added dummy PBKDF2 verification to login failure paths (user not found / env super admin password mismatch). Equalizes response time to prevent timing-based user enumeration (#1095)
+  - Elevated tenant mismatch / global→tenant violation bind in `loadBoundPolicy()` to `error` level + `errorCode` / `securityEvent` structured fields. Enabled detection via CloudWatch metrics filter (#1081)
+  - Added path traversal rejection (`..`, `//`, `/./`) to `validateAllowedPath()`. Completely eliminated potential for string-prefix check miseval as defense layer. 6 test cases added (#1083)
+  - Added "Path-Level vs Entity-Level Authorization" section to `docs/AUTH.md`. Documented design rationale and operational implications of `requireAuthz` (fail-closed) vs `requireEntityAuthz` (fail-open) (#1076)
 
 ### 2026-04-28
-- **CORS 修正**: `Access-Control-Allow-Headers` に `If-None-Match` / `If-Modified-Since` を追加 (#1065)
-  - 旧設定では cross-origin リクエストにこれら 2 ヘッダーが allow されていなかったため、ブラウザの HTTP cache auto-revalidation と SDK の `_cachedRequest` が CORS preflight (OPTIONS) で reject され、INM 付き GET を送ることができなかった (#1065)
-  - 結果として PR #1060 (SDK invalidation 削除) / #1062 (CORS expose ETag) / #1063 (Cache-Control: no-cache strip) という 3 段の修正が揃っていても、INM そのものがブラウザから出ないため 304 経路全体が機能していなかった (incident 2026-04-28: pulse で SDK cache が効かない現象の最終真因) (#1065)
-  - 修正: `src/config/defaults.ts` に `CORS_ALLOW_HEADERS` 定数を新設し `If-None-Match` / `If-Modified-Since` を含めた完全な allow-list を集約。`cors.middleware.ts` と `infrastructure/template.yaml` (Cors.AllowHeaders / GatewayResponses) は同定数に同期 (#1065)
-  - 検証方法: `curl -X OPTIONS -H 'Access-Control-Request-Headers: if-none-match' <endpoint>/ngsi-ld/v1/entities` で `If-None-Match` が allow-headers に含まれることを確認 (#1065)
-  - テスト: cors.middleware.test に `If-None-Match` / `If-Modified-Since` の allow ケースを追加。cors-comprehensive.feature に `@issue-1065` シナリオ 2 件追加 (#1065)
-
-- **デプロイ可視化**: `/version` エンドポイントの `git_hash` フィールドにコミット SHA を埋め込み (#1064)
-  - `infrastructure/template.yaml` に `GitHash` パラメータを追加し、Lambda 環境変数 `GIT_HASH` として注入 (#1064)
-  - `deploy-env.yml` で `GitHash=${{ github.sha }}` を SAM パラメータに渡す (staging / prod 両経路対応) (#1064)
-  - 用途: staging / prod でデプロイ済みのコミットを `curl /version` で即時確認できるようにする。デプロイ問題の切り分けが従来 CloudFormation event log まで遡らないと判明しなかったが、これで一発で分かる (#1064)
-
-- **条件付きリクエスト修正**: `Cache-Control: no-cache` リクエストヘッダーを INM 評価から除外 (#1063)
-  - 旧挙動: `fresh` パッケージが RFC 2616 §14.9.4 に従いリクエストの `Cache-Control: no-cache` を "force reload" として扱い、`If-None-Match` 一致でも 304 を返さず常に 200 + body を返却していた (#1063)
-  - ブラウザは特定の context (ハードリロード後の継続フェッチ等) で `Cache-Control: no-cache` を fetch に自動付与するため、SDK が明示的に `If-None-Match` を送っていてもサーバが 304 を返さなくなり、SDK の帯域節約が常に死ぬ問題が発生 (incident 2026-04-28: pulse で SDK キャッシュが効いているように見えて毎回 200 が返る現象の真因) (#1063)
-  - 修正: `evaluateConditionalRequest` の `normalizeRequestHeaders` でリクエストヘッダーから `cache-control` を除外。SDK の明示的な `If-None-Match` 送信 = 「同じなら 304 で OK」という意思表示なので、ブラウザ自動付与の `Cache-Control: no-cache` で 304 を抑制しないのが正しい (#1063)
-  - `Cache-Control: no-store` (CDN bypass 意図) は引き続き `honorClientNoStore` で適切に扱う (本修正は INM 評価のみ影響) (#1063)
-  - テスト: `evaluateConditionalRequest` unit test に Cache-Control: no-cache + INM / + IMS の 2 ケース追加。`http-cache-control.feature` に NGSIv2 単一 entity / NGSI-LD list の 2 シナリオ追加 (#1063)
-
-- **CORS 修正**: `Access-Control-Expose-Headers` に複数のレスポンスヘッダーを追加 (#1062)
-  - **ETag / Vary**: 旧設定では `ETag` が CORS で隠され、ブラウザ JS から `res.headers.get('etag')` が `null` を返していたため、SDK がキャッシュエントリを作れず `If-None-Match` も送れず、304 帯域節約パスが完全に機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが一切効かなかった真因) (#1062)
-  - **Content-Crs**: NGSI-LD / NGSIv2 の geo response で CRS を通知するヘッダー。ブラウザクライアントが座標系を判別するために必要 (#1062)
-  - **Fiware-Next-Token**: NGSIv2 ページネーション継続トークン。クライアントが次ページをリクエストするために必要 (#1062)
-  - **NGSILD-Warning**: NGSI-LD federation warning。クライアントに警告を通知するために必要 (#1062)
-  - **Retry-After**: 429 rate limit / 503 retry-after 案内。クライアントが retry 戦略を決めるために必要 (#1062)
-  - `Cache-Control` / `Last-Modified` / `Content-Type` 等は CORS-safelisted なので expose 不要 (#1062)
-  - 漏れ検出: 全エンドポイント response header を grep して CORS expose リストと突合し、missing 4 件 (Content-Crs / Fiware-Next-Token / NGSILD-Warning / Retry-After) を発見・追加 (#1062)
-  - 設定値は `src/config/defaults.ts` の `CORS_EXPOSE_HEADERS` (`as const` 配列) に集約 (#1062)
-
-- **セキュリティ**: Dependabot アラート 13 件を一括解消 (#1061)
-  - 直接依存 (overrides 経由): `hono` ^4.12.14, `@hono/node-server` ^1.19.13 — JSX SSR HTML injection / cookie name 検証 / IPv4-mapped IPv6 / serveStatic / toSSG path traversal を解消 (#1061)
-  - 間接依存 (overrides 追加): `protobufjs@<8` ^7.5.5 (任意コード実行), `basic-ftp` ^5.3.1 (CRLF injection / DoS), `follow-redirects` ^1.16.0 (Authorization ヘッダーリーク), `uuid` ^14.0.0 (バッファ境界) (#1061)
-  - `npm audit` で 0 vulnerabilities を確認 (#1061)
-
-- **SDK パフォーマンス修正**: WebSocket entity events での自動キャッシュ無効化を削除 (#1060)
-  - 旧実装: `entityCreated` / `entityUpdated` / `entityDeleted` 受信時に SDK が `_invalidateCacheForEntityEvent()` で全 entities cache エントリを `deleteWhere` で削除していた (#1060)
-  - 削除すると ETag も失われ、次回読み取りで `If-None-Match` が送られず、サーバは毎回 full `200` body を返却 → 304 帯域節約パスが完全に死んでいた (#1060)
-  - data エンドポイントは `Cache-Control: private, no-cache` で毎回 revalidation されるため、cache を残しても安全 (server 側 ETag マッチで 304 / 200 が自動的に振り分けられる) (#1060)
-  - 結果: pulse 等のリアルタイム監視アプリで WebSocket 受信中にキャッシュが効くようになり、unchanged data の再取得が 304 で済むようになる (#1060)
-  - 明示的に全クリアしたい場合は `clearCache()` を呼ぶ (公開 API なので未変更)。`clearCache()` で `cacheInvalidated` イベントが発火するように修正 — WebSocket 経路を削除した結果、このイベントが発火しなくなる退行を回避 (#1060)
-
-- **セキュリティ強化**: Security Audit Group 3 — 公開 vs 認証境界の網羅検証 (#1057)
-  - **#1053: 公開メタエンドポイントに STATIC ポリシーを適用** — `/llms.txt`, `/api.json`, `/openapi.json`, `/tools.json`, `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json` の 6 エンドポイントが `Cache-Control` を返していなかった (CDN がキャッシュ判断できず、コスト・レイテンシが悪化)。`applyCachePolicy('static')` を適用して `Cache-Control: public, max-age=3600` を返すよう修正。ただし `/openapi.json` は tenant 依存の `CustomDataModel_*` を埋め込むケースがあるため、注入された場合のみ `meta` ポリシーへフォールバック (#1057)
-  - **#1053: STATIC ポリシーの Vary を最小化** — STATIC は cross-tenant で共有可能なため、`Vary` を `Accept` のみに制限。`Fiware-Service` / `Authorization` / `X-Api-Key` を含めると CDN がテナント / ユーザ毎にキャッシュ分離してしまい、STATIC の意義 (CDN 広域共有) が損なわれる (#1057)
-  - **#1053: lint test 追加** — `meta.controller.test.ts` に「Cache-Control policy assignment lint」を新設。各公開エンドポイントが `public, max-age=3600` を返し、`private` / `no-cache` を含まないこと、`Vary` がテナント / 認証次元を含まないこと、`/openapi.json` の tenant スキーマありケースで `meta` フォールバックが効くことを 12 ケースで検証 (#1057)
-  - **#1048: Vary 網羅性 audit + 文書化** — 現状の `Vary` (`Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`) が網羅的であることを確認。`DPoP` (per-request)、`Accept-Language` (NGSI で使われない)、`Origin`、`X-Forwarded-For` (auth 段階で評価) を意図的に除外することを `docs/SECURITY.md` に明記 (#1057)
-  - **#1052: DPoP / DPoP-Nonce × cache 検証 + 文書化** — `DPoP-Nonce` が 304 passthrough whitelist に既に含まれていることを unit test で固定。DPoP 認証失敗が `evaluateConditionalRequest` より前に評価される invariant を `docs/AUTH.md` / `docs/SECURITY.md` に明記 (#1057)
-  - **ドキュメント**: `docs/SECURITY.md` に「Vary Header Coverage Audit」「DPoP / DPoP-Nonce & Cache Integrity」「Public vs Authenticated Endpoint Cache Policy Matrix」3 セクション追加。`docs/AUTH.md` に「DPoP & HTTP Cache Interaction」サブセクション追加 (#1057)
+- **CORS Fix**: Added `If-None-Match` / `If-Modified-Since` to `Access-Control-Allow-Headers` (#1065)
+  - Old config: These 2 headers were not allowed in cross-origin requests, causing CORS preflight (OPTIONS) to reject them, preventing browser HTTP cache auto-revalidation and SDK `_cachedRequest` from sending INM-bearing GET requests
+  - This meant that even with 3-step fix of PR #1060 (SDK invalidation removal) / #1062 (CORS expose ETag) / #1063 (Cache-Control: no-cache strip), INM itself wasn't sent from browser so entire 304 path was non-functional (incident 2026-04-28: final root cause of SDK cache not working in pulse)
+  - Fix: Added new `CORS_ALLOW_HEADERS` constant to `src/config/defaults.ts` with complete allow-list including `If-None-Match` / `If-Modified-Since`. Synced `cors.middleware.ts` and `infrastructure/template.yaml` to this constant
+- **Deploy visibility**: Embedded commit SHA in `git_hash` field of `/version` endpoint (#1064)
+  - Added `GitHash` parameter to `infrastructure/template.yaml`, injected as Lambda env var `GIT_HASH`
+  - `deploy-env.yml` passes `GitHash=${{ github.sha }}` as SAM parameter (both staging / prod paths)
+- **Conditional Request Fix**: Excluded `Cache-Control: no-cache` request header from INM evaluation (#1063)
+  - Old behavior: `fresh` package treated request `Cache-Control: no-cache` as "force reload" per RFC 2616 §14.9.4, returning 200 + body even on `If-None-Match` match
+  - Fix: Excluded `cache-control` from request headers in `normalizeRequestHeaders` of `evaluateConditionalRequest`. SDK explicitly sending `If-None-Match` = "304 is OK if same" intent, so browser auto-appended `Cache-Control: no-cache` should not suppress 304
+- **CORS Fix**: Added multiple response headers to `Access-Control-Expose-Headers` (#1062)
+  - **ETag / Vary**: Old config hid ETag via CORS, so browser JS `res.headers.get('etag')` returned `null`, SDK couldn't create cache entries or send `If-None-Match`, 304 bandwidth saving path completely non-functional (incident 2026-04-28: root cause of SDK cache never working in pulse)
+  - **Content-Crs**: Header for CRS notification in NGSI-LD / NGSIv2 geo responses. Needed for browser clients to determine coordinate system
+  - **Fiware-Next-Token**: NGSIv2 pagination continuation token
+  - **NGSILD-Warning**: NGSI-LD federation warning
+  - **Retry-After**: 429 rate limit / 503 retry-after guidance
+- **Security**: Batch resolution of 13 Dependabot alerts (#1061)
+  - Direct dependencies (via overrides): `hono` ^4.12.14, `@hono/node-server` ^1.19.13 — resolved JSX SSR HTML injection / cookie name validation / IPv4-mapped IPv6 / serveStatic / toSSG path traversal
+  - Indirect dependencies (overrides added): `protobufjs@<8` ^7.5.5 (arbitrary code execution), `basic-ftp` ^5.3.1 (CRLF injection / DoS), `follow-redirects` ^1.16.0 (Authorization header leak), `uuid` ^14.0.0 (buffer boundary)
+  - Confirmed `npm audit` 0 vulnerabilities
+- **SDK Performance Fix**: Removed automatic cache invalidation on WebSocket entity events (#1060)
+  - Old implementation: `_invalidateCacheForEntityEvent()` deleted all `entities` cache entries via `deleteWhere` on receiving `entityCreated` / `entityUpdated` / `entityDeleted`
+  - Deletion also loses ETag, so next read doesn't send `If-None-Match`, server returns full `200` body every time → 304 bandwidth saving path completely dead
+  - Data endpoints are `Cache-Control: private, no-cache` so revalidated every time regardless, safe to keep cache (server-side ETag match automatically routes 304 / 200)
+  - Result: Cache becomes effective in real-time monitoring apps like pulse during WebSocket reception, unchanged data re-fetches resolve with 304
+- **Security Enhancement**: Security Audit Group 3 — Comprehensive validation of public vs authenticated boundary (#1057)
+  - **#1053: Applied STATIC policy to public meta endpoints** — 6 endpoints weren't returning `Cache-Control`. Applied `applyCachePolicy('static')` to return `Cache-Control: public, max-age=3600`. `/openapi.json` falls back to `meta` policy only when tenant-specific `CustomDataModel_*` is injected
+  - **#1053: Minimized Vary for STATIC policy** — Since STATIC is shareable cross-tenant, limited `Vary` to `Accept` only
+  - **#1048: Vary coverage audit + documentation** — Confirmed existing `Vary` is comprehensive. Documented intentional exclusions in `docs/SECURITY.md`
+  - **#1052: DPoP / DPoP-Nonce × cache verification + documentation** — Fixed `DPoP-Nonce` in 304 passthrough whitelist in unit test. Documented DPoP authentication failure evaluating before `evaluateConditionalRequest` in `docs/AUTH.md` / `docs/SECURITY.md`
+  - **Docs**: Added 3 sections to `docs/SECURITY.md`: "Vary Header Coverage Audit", "DPoP / DPoP-Nonce & Cache Integrity", "Public vs Authenticated Endpoint Cache Policy Matrix". Added "DPoP & HTTP Cache Interaction" subsection to `docs/AUTH.md`
 
 ### 2026-04-28
-- **セキュリティ強化**: Security Audit Group 2 — 認可整合性 (#1056)
-  - **#1049: HMAC ベース ETag** — ETag 生成を `createHash` から `createHmac(algo, secret)` に変更。鍵は `ETAG_HMAC_SECRET` 環境変数から取得し、本番 (`ENVIRONMENT='prod'`) では未設定なら fail-fast で起動失敗。dev/test では documented なフォールバックを使う。これまで決定的だった ETag が攻撃者に再現不能化され、`If-None-Match` 試行による `modifiedAt` / 件数ブラインド情報リークを根本的に排除。同テナント内の正規ユーザは同じ鍵で計算されるため 304 帯域節約は維持 (#1056)
-  - **#1050: XACML ポリシー Revoke 後のキャッシュ整合性** — handler の評価順 (`requireAuthz` → controller → `evaluateConditionalRequest`) を unit test で固定 (jest `invocationCallOrder` で controller 含めた順序を検証)。`requireAuthz` が throw した場合、catch 経路が 4xx を返し controller / `evaluateConditionalRequest` を経由しないため、認可剥奪後に旧 ETag の `If-None-Match` が 304 で旧 view を resurface することはない。E2E では実 ETag を取得後に認証/テナントを変更して投げ直し、4xx が返ることを検証 (#1056)
-  - **テスト**: cache-control middleware unit test に HMAC 関連 6 ケース追加 (異なる secret / 同 secret stable / 環境変数 fallback / prod fail-fast / prod with secret OK)。handler unit test に `#1050` regression test 2 ケース追加 (controller 未呼び出し検証 + invocationCallOrder で順序固定)。`policy-enforcement.feature` に `@issue-1050` シナリオ 2 件追加 (実 ETag を取得 → 認証クリア / 別テナントへの切替後 INM が 304 にならず 4xx) (#1056)
-  - **ドキュメント**: `docs/AUTH.md` に「Policy Propagation Delay & HTTP Cache Integrity」セクション新設 (PolicyService cache TTL: 60s 仕様化)。`docs/SECURITY.md` に「HMAC-Based ETag」「Policy Revocation & Cache Integrity」サブセクション追加。`docs/ENV.md` / `infrastructure/template.yaml` に `ETAG_HMAC_SECRET` 追加 (#1056)
+- **Security Enhancement**: Security Audit Group 2 — Authorization consistency (#1056)
+  - **#1049: HMAC-based ETag** — Changed ETag generation from `createHash` to `createHmac(algo, secret)`. Key obtained from `ETAG_HMAC_SECRET` env var; in prod (`ENVIRONMENT='prod'`), fails fast if unset. Dev/test uses documented fallback. Previously deterministic ETag is now unreproducible for attackers, fundamentally eliminating `modifiedAt` / count blind information leak via `If-None-Match` attempts. Same-tenant legitimate users share the same key so 304 bandwidth saving is maintained
+  - **#1050: XACML policy Revoke and cache consistency** — Fixed handler evaluation order (`requireAuthz` → controller → `evaluateConditionalRequest`) in unit test. When `requireAuthz` throws, catch path returns 4xx without going through controller / `evaluateConditionalRequest`, preventing old ETag `If-None-Match` from 304ing stale view after authorization revocation. E2E verifies 4xx is returned after changing auth/tenant after obtaining real ETag
+  - **Docs**: Added 2 sections to `docs/SECURITY.md`: "HMAC-Based ETag", "Policy Revocation & Cache Integrity". Added "Policy Propagation Delay & HTTP Cache Integrity" section to `docs/AUTH.md` (PolicyService cache TTL: 60s). Added `ETAG_HMAC_SECRET` to `docs/ENV.md` / `infrastructure/template.yaml`
 
 ### 2026-04-28
-- **セキュリティ強化**: Security Audit Group 1 — Cache-Control / ETag の即値強化 (#1055)
-  - **#1047: 共有キャッシュ汚染防止** — data エンドポイントの `Cache-Control` を `no-cache` から `private, no-cache` に変更。RFC 7234 §5.2.2.6 の `private` で CloudFront / 中間プロキシ / ISP プロキシでの保存を禁止し、ブラウザ等の private cache のみを許容。`Authorization` 付きレスポンスがブラウザ disk cache に乗らない問題 (Chrome/Safari の挙動) も同時に解消 (#1055)
-  - **#1051: テナント間 ETag 衝突防止** — `deriveEtagScope(event)` の seed に `Fiware-Service` + `Fiware-ServicePath` を追加。Vary が壊れた中間キャッシュ越しでも ETag 値そのものがテナント / サブテナント間で必ず異なることを保証。`Authorization` / `X-Api-Key` は seed に含めない (同テナント内の別ユーザは 304 で帯域節約できるべきで、テナント seed が認可境界として十分) (#1055)
-  - **テスト** (#1055): cache-control middleware unit test に scope 検証 4 ケース追加 (cross-tenant / cross-servicePath / case-insensitive header lookup)。`http-cache-control.feature` に `@issue-1047` シナリオ 3 件、`@issue-1051` シナリオ 3 件追加
-  - **ドキュメント** (#1055): `docs/API.md`, `docs/API_NGSIV2.md`, `docs/API_NGSILD.md`, `docs/INSTRUCTION.md`, `docs/SECURITY.md` に `private, no-cache` ポリシーと tenant-scoped ETag を反映
+- **Security Enhancement**: Security Audit Group 1 — Immediate Cache-Control / ETag hardening (#1055)
+  - **#1047: Prevent shared cache contamination** — Changed data endpoint `Cache-Control` from `no-cache` to `private, no-cache`. RFC 7234 §5.2.2.6 `private` prohibits storage in CloudFront / intermediate proxies / ISP proxies, allowing only browser private cache
+  - **#1051: Prevent cross-tenant ETag collision** — Added `Fiware-Service` + `Fiware-ServicePath` to `deriveEtagScope(event)` seed. Guarantees ETag values differ between tenants / sub-tenants even through broken intermediate caches. `Authorization` / `X-Api-Key` not included in seed (tenant seed is sufficient as authorization boundary)
+  - **Tests**: Added 4 scope verification cases to cache-control middleware unit test. Added `@issue-1047` 3 scenarios and `@issue-1051` 3 scenarios to `http-cache-control.feature`
+  - **Docs**: Reflected `private, no-cache` policy and tenant-scoped ETag in `docs/API.md`, `docs/API_NGSIV2.md`, `docs/API_NGSILD.md`, `docs/INSTRUCTION.md`, `docs/SECURITY.md`
 
 ### 2026-04-27
-- **セキュリティ / バグ修正**: HTTP キャッシュコントロール監査で検出した 4 件のバグを修正 (#1054)
-  - **B-1: Accept ヘッダー違いで body が異なるのに ETag 同一** — `Accept: application/json` (257B) と `application/ld+json` (476B、`@context` 含む) で body は明確に異なるが ETag が完全一致する weak validator 違反 (RFC 7232 §2.3.3)。shared cache が cross-Accept で 304 を返し、クライアントが間違った形式の body を replay する誤動作を確認 (#1054)
-  - **B-2: 別エンドポイント間で空リスト ETag が衝突** — `/v2/subscriptions` と `/ngsi-ld/v1/csourceRegistrations` 等が共に空 (count=0) のとき同一 ETag。subscription の ETag を csourceRegistrations の `If-None-Match` に投げると 304 が返り、URL を cache key に使わない中間層で誤配信されうる (#1054)
-  - **B-3: HEAD メソッドが 405** — RFC 7231 §4.3.2 違反。HEAD は GET 対応リソースで MUST サポートだが、ルーティング層で全 GET エンドポイントが 405 を返していた (#1054)
-  - **B-4: temporal endpoint が cache control middleware の管轄外** — `/ngsi-ld/v1/temporal/entities` 系が `Cache-Control` も `Vary` も付けずに返していた (#1054)
-  - **対策実装** (#1054):
-    - `cache-control.middleware.ts` — `deriveEtagScope(event)` を新設し、ETag 計算 seed に `path + Accept` を混ぜることで B-1 / B-2 を一括解消。`createListEtagBuilder(scope)` / `generateEntityEtag(scope, modifiedAt)` シグネチャ変更
-    - 全 controller (NGSIv2/NGSI-LD の entities / subscriptions / registrations / csource-subscriptions) が `deriveEtagScope(event)` を渡すよう更新
-    - `handlers/api/index.ts` — HEAD リクエストを内部で GET にフォールバックし、`addCorsHeaders` ラッパーで最終 body を抑止 (成功・エラー両経路)
-    - `temporal.controller.ts` の GET 4 経路に `applyCachePolicy('data')` を適用
-    - `local-server.ts` — Express の自動 ETag 生成を `app.set('etag', false)` で無効化。ローカル開発でも本番 (API Gateway + Lambda) と同じ挙動を再現
-    - **追加カバレッジ**: NGSIv2 / NGSI-LD の attribute-level GET エンドポイント (`/v2/entities/{id}/attrs`, `/v2/entities/{id}/attrs/{name}`, `/v2/entities/{id}/attrs/{name}/value`, `/ngsi-ld/v1/entities/{id}/attrs/{name}`) も `applyCacheHeaders` 経由で ETag/Last-Modified/Cache-Control/Vary を返すよう追加。Express auto-ETag 無効化に伴うキャッシュ無し状態を回避
-  - **テスト** (#1054): cache-control middleware unit test に scope 検証 11 ケース追加。`http-cache-control.feature` に B-1 / B-2 / B-3 / B-4 シナリオ 7 件追加。`head-requests.feature` を 200 期待形に書き換え (HEAD が GET 等価で動作することを検証)
-  - **ドキュメント** (#1054): `docs/API.md` に Temporal クラス追加、ETag scope (path + Accept) の説明追加、HEAD サポート明記、attribute-level エンドポイント追加
+- **Security / Bug Fix**: Fixed 4 bugs detected in HTTP cache control audit (#1054)
+  - **B-1: Different body for different Accept but same ETag** — Weak validator violation (RFC 7232 §2.3.2): body clearly differs for `Accept: application/json` (257B) vs `application/ld+json` (476B with `@context`) but ETag was identical. Confirmed cross-Accept 304 from shared cache causing clients to replay wrong format body
+  - **B-2: Empty list ETag collision between different endpoints** — `/v2/subscriptions` and `/ngsi-ld/v1/csourceRegistrations` etc. had same ETag when both empty (count=0). Sending subscription ETag to csourceRegistrations `If-None-Match` returned 304
+  - **B-3: HEAD method returning 405** — RFC 7231 §4.3.2 violation. HEAD MUST be supported for GET-supporting resources
+  - **B-4: temporal endpoint outside cache control middleware scope** — `/ngsi-ld/v1/temporal/entities` series was returning without `Cache-Control` or `Vary`
+  - **Fix implementation**: Added `deriveEtagScope(event)` to `cache-control.middleware.ts`, mixed `path + Accept` into ETag computation seed to batch resolve B-1 / B-2. Changed `createListEtagBuilder(scope)` / `generateEntityEtag(scope, modifiedAt)` signatures. HEAD requests fall back internally to GET, suppressing final body with `addCorsHeaders` wrapper. Applied `applyCachePolicy('data')` to 4 GET paths in `temporal.controller.ts`
+  - **Tests**: Added 11 scope verification cases to cache-control middleware unit test. Added 7 scenarios for B-1 / B-2 / B-3 / B-4 to `http-cache-control.feature`. Rewrote `head-requests.feature` to expect 200 (verify HEAD operates equivalent to GET)
+  - **Docs**: Added Temporal class, ETag scope (path + Accept) explanation, HEAD support note to `docs/API.md`
 
 ## [0.4.0] — 2026-04-27
 
 ### 2026-04-27
-- **Feature**: SDK クライアントキャッシュ Phase A — `@geolonia/geonicdb-sdk` に in-memory cache + ETag/304 自動ハンドリング + リクエスト重複排除 + ETag ベースの `poll()` API を追加 (#1043)
-  - `src/sdk/cache.ts` — `SdkCache` (LRU、`maxEntries` 制限、URL+method キーで `etag` / `lastModified` / `data` / `headers` を保持) (#1043)
-  - `src/sdk/auth.ts` `request()` — GET / HEAD では cache 経由で `If-None-Match` / `If-Modified-Since` を自動付与し、304 受信時は cached body を 200 として透過的に返却。304 で更新された validator を cache に再反映 (#1043)
-  - 同一 path への in-flight 重複リクエストを 1 つにまとめる dedup を追加 (#1043)
-  - `src/sdk/index.ts` — `db.poll(params, { interval, onData, onNoChange, onError })` を新設。ETag を比較して未変更時は転送ゼロ。`handle.stop()` で停止。`interval` の入力検証あり (#1043)
-  - WebSocket の `entityCreated` / `entityUpdated` / `entityDeleted` 受信時にキャッシュを自動無効化 (#1043)
-  - 認証コンテキスト (`login()` / `setCredentials()` / `logout()`) の切替時に cache + in-flight dedup を自動破棄 — クロスユーザー漏洩対策 (#1043)
-  - `GeonicDBOptions` に `cache` / `cacheMaxEntries`、`GeonicDBEventMap` に `cacheHit` / `cacheMiss` / `cacheInvalidated` を追加 (#1043)
-  - SDK 設定値 (`SDK_CACHE_MAX_ENTRIES_DEFAULT` / `SDK_POLL_INTERVAL_MS_DEFAULT`) を `src/config/defaults.ts` に集約 (#1043)
-  - `docs/SDK.md` / `src/sdk/README.md` 更新 (#1043)
-  - Phase B (Service Worker + オフラインファースト) は #1044 で対応予定 (#1043)
-- **Chore**: 依存関係の一括アップデート — 12個の Dependabot PR をまとめて適用
-  - npm: `@cucumber/cucumber` 12.8.1→12.8.2, `eslint` 10.2.0→10.2.1, `mongodb` 7.1.1→7.2.0, `@opentelemetry/auto-instrumentations-node` 0.72.0→0.73.0, `@opentelemetry/exporter-trace-otlp-http` 0.214.0→0.215.0, `typescript-eslint` 8.58.2→8.59.0, `@aws-sdk/*` 3.1032.0→3.1037.0 (9パッケージ)
+- **Feature**: SDK client cache Phase A — Added in-memory cache + ETag/304 auto-handling + request deduplication + ETag-based `poll()` API to `@geolonia/geonicdb-sdk` (#1043)
+  - `src/sdk/cache.ts` — `SdkCache` (LRU, `maxEntries` limit, keys by URL+method, holds `etag` / `lastModified` / `data` / `headers`)
+  - `src/sdk/auth.ts` `request()` — For GET / HEAD, auto-adds `If-None-Match` / `If-Modified-Since` via cache; on 304 transparently returns cached body as 200. Re-reflects updated validators from 304 to cache
+  - Added dedup to bundle multiple in-flight requests to same path into one
+  - `src/sdk/index.ts` — Added new `db.poll(params, { interval, onData, onNoChange, onError })`. Zero transfer when ETag unchanged. Stop with `handle.stop()`. Input validation for `interval`
+  - Auto-invalidates cache on WebSocket `entityCreated` / `entityUpdated` / `entityDeleted` receive
+  - Auto-discards cache + in-flight dedup on auth context (`login()` / `setCredentials()` / `logout()`) switch — cross-user leakage protection
+  - Added `cache` / `cacheMaxEntries` to `GeonicDBOptions`, added `cacheHit` / `cacheMiss` / `cacheInvalidated` to `GeonicDBEventMap`
+- **Chore**: Batch update of 12 Dependabot PRs
+  - npm: `@cucumber/cucumber`, `eslint`, `mongodb`, `@opentelemetry/*`, `typescript-eslint`, `@aws-sdk/*` (9 packages)
   - GitHub Actions: `docker/setup-qemu-action` v3→v4, `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/metadata-action` v5→v6, `docker/build-push-action` v6→v7
-  - `typescript-eslint` 8.59.0 で新しく検出された `no-unnecessary-type-assertion` を `eslint --fix` で一括修正、`no-base-to-string` 違反を `isSimpleValue` の型ガード化で解消、未使用 import 3件を削除
-- **Fix**: `GET /v2/entities/{entityId}` および `GET /ngsi-ld/v1/entities/{entityId}` に entity-level XACML 認可チェック (`checkEntityOwnership`) が抜けていた既存問題を修正 (#1028)
-  - XACML 統合 (#748) リファクタリング後の漏れ。他の操作 (PATCH/PUT/DELETE/属性取得) では呼ばれていたが、GET 単一取得だけ不在だった (#1028)
-  - 影響: entity-level policy (`resource.entityId` / `resource.entityOwner` ベース) が GET で無視され、Phase 2 の cache control と組み合わさると認可剥奪後も 304 で古いキャッシュが返るリスクがあった (#1028)
-  - 修正: NGSIv2 / NGSI-LD の `getEntity` で `await this.checkEntityOwnership(...)` を呼ぶよう追加。E2E に「entity-level Deny → 403」「Permit → ETag → policy 更新で Deny → If-None-Match で 403 (304 ではない)」の 2 シナリオ追加 (#1028)
-  - 同時に entity-ownership.feature と instruction.feature の `deny-non-owner-write` ポリシーで `target.actions` が指定されておらず GET にも誤って Deny が効いてしまっていた既存の policy 設計の不備を修正。`PATCH/PUT/DELETE` のみに限定 (#1028)
-- **Feature**: HTTP キャッシュコントロール Phase 2 — レスポンスに `Cache-Control` / `Vary` ヘッダーを付与し、エンドポイント別ポリシーとクライアント主導 `no-store` 上書きをサポート (#989)
-  - data API (entities / subscriptions / registrations / csourceSubscriptions): `Cache-Control: no-cache` (#989)
-  - meta API (types / attributes): `Cache-Control: max-age=60, stale-while-revalidate=120` (#989)
-  - 全レスポンスに `Vary: Fiware-Service, Fiware-ServicePath, Authorization, Accept` を付与し、CloudFront 等のエッジキャッシュでテナント分離を保証 (#989)
-  - クライアントが `Cache-Control: no-store` リクエストヘッダーを送信した場合、レスポンスの `Cache-Control` を `no-store` で上書き (#989)
-  - `applyCachePolicy()` ヘルパー追加。ETag を持たない API (types / attributes) にも Cache-Control + Vary を一貫して適用 (#989)
-- **Feature**: HTTP キャッシュコントロール Phase 1 — GET エンドポイントに `ETag` / `Last-Modified` を導入し、`If-None-Match` / `If-Modified-Since` による条件付きリクエスト (304 Not Modified) をサポート (#1026)
-  - 対象: `/v2/entities`, `/v2/subscriptions`, `/v2/registrations`, `/ngsi-ld/v1/entities`, `/ngsi-ld/v1/subscriptions`, `/ngsi-ld/v1/csourceRegistrations`, `/ngsi-ld/v1/csourceSubscriptions` の一覧 / 単一取得 (#1026)
-  - リスト用 ETag は各要素の `id + modifiedAt` のストリーミングハッシュ + 総件数のダイジェスト (RFC 7232 §2.3.2 weak validator として正確)、単一用 ETag は `modifiedAt` のハッシュ (#1026)
-  - `fresh` モジュールで RFC 7232 準拠の評価（弱い ETag、ワイルドカード、HTTP-date）(#1026)
-  - 304 レスポンスは ETag / Last-Modified / Cache-Control / Vary / CORS / 相関 ID / トレースを保持 (#1026)
-- **Feature**: A2A (Agent-to-Agent) プロトコル Phase 1 対応 (#1025)
-  - `GET /.well-known/agent-card.json` — Agent Card 配信（5スキル: entities, batch, temporal, config, admin） (#1025)
-  - `POST /a2a` — JSON-RPC 2.0 エンドポイント。`message/send`, `tasks/get`, `tasks/list`, `tasks/cancel` メソッドに対応 (#1025)
-  - MongoDB `a2aTasks` コレクションによる Task 状態管理（ライフサイクル: submitted → working → completed/failed/canceled、TTL 30日） (#1025)
-  - 既存 MCP ツール 5つを A2A スキルにマッピング。サービス層を直接呼び出し (#1025)
-  - `@a2a-js/sdk` v0.3.13 を活用（`JsonRpcTransportHandler` + `DefaultRequestHandler`） (#1025)
+- **Fix**: Entity-level XACML authorization check (`checkEntityOwnership`) was missing from `GET /v2/entities/{entityId}` and `GET /ngsi-ld/v1/entities/{entityId}` (#1028)
+  - Bug from XACML integration (#748) refactoring. Was being called for other operations (PATCH/PUT/DELETE/attribute retrieval) but absent for GET single entity
+  - Impact: Entity-level policy (`resource.entityId` / `resource.entityOwner` based) was ignored for GET, risking 304 returning stale cache after authorization revocation when combined with Phase 2 cache control
+  - Fix: Added `await this.checkEntityOwnership(...)` call in NGSIv2 / NGSI-LD `getEntity`. Added 2 E2E scenarios
+- **Feature**: HTTP Cache Control Phase 2 — Added `Cache-Control` / `Vary` headers to responses, supporting endpoint-specific policies and client-driven `no-store` override (#989)
+  - data API (entities / subscriptions / registrations / csourceSubscriptions): `Cache-Control: no-cache`
+  - meta API (types / attributes): `Cache-Control: max-age=60, stale-while-revalidate=120`
+  - All responses include `Vary: Fiware-Service, Fiware-ServicePath, Authorization, Accept` to ensure tenant isolation in edge caches like CloudFront
+  - If client sends `Cache-Control: no-store` request header, overrides response `Cache-Control` with `no-store`
+- **Feature**: HTTP Cache Control Phase 1 — Introduced `ETag` / `Last-Modified` to GET endpoints, supporting conditional requests (304 Not Modified) via `If-None-Match` / `If-Modified-Since` (#1026)
+  - Targets: list / single retrieval of `/v2/entities`, `/v2/subscriptions`, `/v2/registrations`, `/ngsi-ld/v1/entities`, `/ngsi-ld/v1/subscriptions`, `/ngsi-ld/v1/csourceRegistrations`, `/ngsi-ld/v1/csourceSubscriptions`
+  - List ETag: streaming hash of each element `id + modifiedAt` + total count digest (accurate weak validator per RFC 7232 §2.3.2)
+  - Single ETag: hash of `modifiedAt`
+  - RFC 7232 compliant evaluation via `fresh` module (weak ETag, wildcard, HTTP-date)
+  - 304 response retains ETag / Last-Modified / Cache-Control / Vary / CORS / correlation ID / trace
+- **Feature**: A2A (Agent-to-Agent) protocol Phase 1 support (#1025)
+  - `GET /.well-known/agent-card.json` — Agent Card delivery (5 skills: entities, batch, temporal, config, admin)
+  - `POST /a2a` — JSON-RPC 2.0 endpoint. Supports `message/send`, `tasks/get`, `tasks/list`, `tasks/cancel` methods
+  - Task state management via MongoDB `a2aTasks` collection (lifecycle: submitted → working → completed/failed/canceled, TTL 30 days)
+  - Mapped 5 existing MCP tools to A2A skills. Calls service layer directly
+  - Leveraged `@a2a-js/sdk` v0.3.13 (`JsonRpcTransportHandler` + `DefaultRequestHandler`)
 
 ## [0.3.0] — 2026-04-24
 
 ### 2026-04-24
-- **Feature**: カスタムデータモデルに `additionalProperties` フィールドを追加。`false` 指定でモデル未定義の属性を拒否する厳格モードを有効化。デフォルトは `true`（NGSI-LD の自然な挙動を維持） (#1007)
-- **Feature**: SDK に型付きエラークラスを導入。`GeonicDBError` 基底クラスと `AuthenticationError`, `AuthorizationError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `NetworkError` を追加。`instanceof` でエラー種別を判定可能に (#1008)
-- **Feature**: SDK WebSocket イベント（`entityCreated`/`entityUpdated`/`entityDeleted`）に `entity` フィールドを追加。`id` + `type` + `data` から構築した完全な NGSI-LD エンティティオブジェクトを直接取得可能に (#1009)
-- **Feature**: SDK に `debug` オプションを追加。有効時に HTTP リクエスト/レスポンス、WebSocket 接続・イベント、トークンリフレッシュをコンソールにログ出力 (#1010)
+- **Feature**: Added `additionalProperties` field to custom data models. Setting to `false` enables strict mode rejecting attributes not defined in the model. Default is `true` (maintains natural NGSI-LD behavior) (#1007)
+- **Feature**: Introduced typed error classes to SDK. Added `GeonicDBError` base class and `AuthenticationError`, `AuthorizationError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `NetworkError`. Can determine error type with `instanceof` (#1008)
+- **Feature**: Added `entity` field to SDK WebSocket events (`entityCreated`/`entityUpdated`/`entityDeleted`). Directly retrieve complete NGSI-LD entity object built from `id` + `type` + `data` (#1009)
+- **Feature**: Added `debug` option to SDK. When enabled, logs HTTP requests/responses, WebSocket connections/events, and token refreshes to console (#1010)
 
 ### 2026-04-23
-- **Feature**: ReactiveCore Rules のクロスプロトコル エンティティ生成 (#1004)
-  - `createEntity` / `updateAttribute` / `deleteAttribute` アクションに `protocol` フィールドを追加（NGSIv2 ↔ NGSI-LD の壁を越えた操作が可能に）
-  - `createEntity` に `servicePath` / `scope` フィールドを追加（ターゲットの階層パスを制御）
-  - servicePath ↔ scope の自動マッピング（NGSIv2 `/sensors` → NGSI-LD `["/sensors"]`）
-  - `${trigger.protocol}`, `${trigger.servicePath}`, `${trigger.scope}`, `${trigger.service}` テンプレート変数を追加
-  - Change Stream ハンドラが EntityDocument の `protocol` / `scope` をルールエンジンに伝播するよう修正
-- **Improve**: WAF カスタムルール（RateLimitPerIP, SizeRestrictionBody10MB）にカスタムレスポンスを追加。アプリケーション互換の JSON エラーボディと適切な HTTP ステータスコード（429/413）を返すように改善 (#986)
-- **Feature**: WAF ロギング設定を追加。BLOCK/COUNT アクションのみ記録し、マネージドルールのブロック原因をトレース可能に (#986)
+- **Feature**: Cross-protocol entity creation for ReactiveCore Rules (#1004)
+  - Added `protocol` field to `createEntity` / `updateAttribute` / `deleteAttribute` actions (enables operations crossing NGSIv2 ↔ NGSI-LD boundary)
+  - Added `servicePath` / `scope` fields to `createEntity` (control target hierarchy path)
+  - Auto-mapping between servicePath ↔ scope (NGSIv2 `/sensors` → NGSI-LD `["/sensors"]`)
+  - Added template variables `${trigger.protocol}`, `${trigger.servicePath}`, `${trigger.scope}`, `${trigger.service}`
+- **Improve**: Added custom responses to WAF custom rules (RateLimitPerIP, SizeRestrictionBody10MB). Returns application-compatible JSON error body and appropriate HTTP status codes (429/413) (#986)
+- **Feature**: Added WAF logging configuration. Records only BLOCK/COUNT actions, enabling tracing of block causes from managed rules (#986)
 
 ### 2026-04-21
-- **Fix**: WAF `SizeRestrictionBody10MB` ルールの `OversizeHandling: MATCH` により 8KB 超のリクエストが全て 403 Forbidden になる問題を修正 (#983)
+- **Fix**: Fixed issue where `SizeRestrictionBody10MB` WAF rule's `OversizeHandling: MATCH` caused all requests over 8KB to return 403 Forbidden (#983)
 
 ### 2026-04-18
-- **Breaking**: NGSIv2 と NGSI-LD のエンティティ分離・仕様準拠 (#966)
-  - **プロトコルベースのエンティティ分離**: NGSIv2 で作成したエンティティは NGSIv2 からのみ、NGSI-LD で作成したエンティティは NGSI-LD からのみアクセス可能に
-  - NGSI-LD API で `Fiware-ServicePath` ヘッダーを無視するよう修正（ETSI GS CIM 009 仕様準拠）
-  - servicePath と scope を独立した概念として維持
-  - NGSIv2 `servicePath` built-in attribute を追加（`?attrs=servicePath` で取得可能）
-  - 既存エンティティ（`protocol` フィールドなし）は NGSI-LD 扱い
+- **Breaking**: NGSIv2 and NGSI-LD entity separation and spec compliance (#966)
+  - **Protocol-based entity separation**: Entities created in NGSIv2 accessible only from NGSIv2, entities created in NGSI-LD accessible only from NGSI-LD
+  - Fixed to ignore `Fiware-ServicePath` header in NGSI-LD API (ETSI GS CIM 009 spec compliance)
+  - Maintained servicePath and scope as independent concepts
+  - Added NGSIv2 `servicePath` built-in attribute (retrievable with `?attrs=servicePath`)
+  - Existing entities (without `protocol` field) treated as NGSI-LD
 
 ### 2026-04-14
-- **Release**: SDK v0.2.0 — `count()` と `requestRaw()` メソッドを追加 (#928)
-- **Change**: SDK ライセンスを AGPL-3.0 から MIT に変更（本体は AGPL-3.0 のまま） (#942)
-- **Remove**: 内蔵 SDK 配信エンドポイント（`/sdk/v1/geonicdb.js`, `/sdk/v1/geonicdb.d.ts`）を削除。npm / unpkg CDN から取得する方式に統一 (#942)
+- **Release**: SDK v0.2.0 — Added `count()` and `requestRaw()` methods (#928)
+- **Change**: Changed SDK license from AGPL-3.0 to MIT (main product remains AGPL-3.0) (#942)
+- **Remove**: Removed built-in SDK delivery endpoints (`/sdk/v1/geonicdb.js`, `/sdk/v1/geonicdb.d.ts`). Unified to obtain from npm / unpkg CDN (#942)
 
 ### 2026-04-10
-- **Fix**: ユニークインデックスをテナントスコープ化 — policies, policySets, apiKeys, oauthClients, rules の ID がテナント内で一意に変更。異なるテナント間で同一 ID を使用可能に (#896)
-- **Feature**: MCP ツールの NGSI-LD クエリパラメータを大幅拡張 (#898)
-  - `entities` ツール: `idList`, `idPattern`, `orderBy`, `orderDirection`, `sysAttrs`, `pick`, `omit`, `scopeQ`, `lang`, `geoproperty`, `spatialId`, `spatialIdDepth` を追加
-  - `batch` ツールの `query` アクション: `orderBy`, `orderDirection`, `sysAttrs` を追加
-  - `entityToKeyValues` に `sysAttrs`（`createdAt`/`modifiedAt` 出力）と `distance` 出力を追加
-  - `orderBy` の `!` プレフィックスによる降順指定をサポート
-  - CSV パラメータの空要素フィルタリングを追加
-  - MCP ツールを NGSI-LD に統一（NGSIv2 固有パラメータ `mq`, `typePattern` を削除）
-  - `/tools.json` AI ディスカバリーエンドポイントを同期
+- **Fix**: Scoped unique indexes to tenant — policies, policySets, apiKeys, oauthClients, rules IDs now unique within tenant. Same ID can be used across different tenants (#896)
+- **Feature**: Significantly expanded NGSI-LD query parameters in MCP tools (#898)
+  - `entities` tool: Added `idList`, `idPattern`, `orderBy`, `orderDirection`, `sysAttrs`, `pick`, `omit`, `scopeQ`, `lang`, `geoproperty`, `spatialId`, `spatialIdDepth`
+  - `batch` tool `query` action: Added `orderBy`, `orderDirection`, `sysAttrs`
+  - Added `sysAttrs` (`createdAt`/`modifiedAt` output) and `distance` output to `entityToKeyValues`
+  - Support descending sort with `!` prefix in `orderBy`
+  - Added CSV parameter empty element filtering
+  - Unified MCP tools to NGSI-LD (removed NGSIv2-specific parameters `mq`, `typePattern`)
 
 ### 2026-04-09
-- SDK を TypeScript で書き直し、npm パッケージ `@geolonia/geonicdb-sdk` として公開可能に
-- Types/Attributes Discovery, Temporal API, Batch Operations の convenience methods を追加 (#832)
-- `setCredentials()` の `expiresIn: 0` が無視されるバグを修正 (#876)
+- Rewrote SDK in TypeScript, publishable as npm package `@geolonia/geonicdb-sdk`
+- Added convenience methods for Types/Attributes Discovery, Temporal API, Batch Operations (#832)
+- Fixed bug where `expiresIn: 0` in `setCredentials()` was ignored (#876)
 
 ### 2026-04-08
-- **Feature**: カスタムデータモデルの JSON-LD `@context` URI 改善 (#858)
-  - `propertyDetails` に `@context` フィールドを追加（既存語彙 URL の指定が可能に）
-  - 自動生成 URI を URN → URL に移行（`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`）
-  - 属性 URI をエンティティタイプから独立させ、テナント内で再利用可能に
-  - MCP ツール / llms.txt / openapi.json に schema.org 語彙サジェスト指示を追加
+- **Feature**: Improved custom data model JSON-LD `@context` URI (#858)
+  - Added `@context` field to `propertyDetails` (enables specifying existing vocabulary URLs)
+  - Migrated auto-generated URI from URN → URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
+  - Made attribute URI independent from entity type, reusable within tenant
+  - Added schema.org vocabulary suggestion instructions to MCP tools / llms.txt / openapi.json
 
 ### 2026-04-07
-- **Fix**: 不正な GeoJSON データが存在する場合のインデックス初期化失敗を自動回復 — 問題のあるエンティティを隔離して `2dsphere` インデックスを再構築 (#857)
-- **Fix**: WAF `EC2MetaDataSSRF_BODY` ルールが `allowedOrigins` 内の `localhost` URL を SSRF として誤検知しブロックする問題を修正 (#848)
-- **Fix**: WAF `CrossSiteScripting_BODY` ルールが `allowedOrigins` 内の URL を XSS と誤検知し API キー作成が 403 になる問題を修正 (#846)
+- **Fix**: Auto-recovery from index initialization failure when invalid GeoJSON data exists — isolates problematic entities and rebuilds `2dsphere` index (#857)
+- **Fix**: Fixed issue where WAF `EC2MetaDataSSRF_BODY` rule falsely detected `localhost` URLs in `allowedOrigins` as SSRF and blocked them (#848)
+- **Fix**: Fixed issue where WAF `CrossSiteScripting_BODY` rule falsely detected URLs in `allowedOrigins` as XSS causing 403 on API key creation (#846)
 
 ### 2026-04-05
-- **Breaking**: `onTokenRefresh(callback)` を廃止し `on('tokenRefresh', cb)` イベントに統一 (#831)
-- **Change**: `request()` がエラーチェック + JSON パース済みの値を返すように変更（生 Response → `Promise<Object|string|null>`） (#831)
-- **Feature**: `GET /sdk/v1/geonicdb.d.ts` エンドポイントを追加 — TypeScript 型定義を配信 (#831)
-- **Docs**: `setCredentials()` で Bearer + refreshToken を指定すると DPoP/PoW を完全にバイパスする旨を明記 (#831)
+- **Breaking**: Deprecated `onTokenRefresh(callback)` and unified to `on('tokenRefresh', cb)` event (#831)
+- **Change**: Changed `request()` to return error-checked + JSON-parsed value (raw Response → `Promise<Object|string|null>`) (#831)
+- **Feature**: Added `GET /sdk/v1/geonicdb.d.ts` endpoint — delivers TypeScript type definitions (#831)
+- **Docs**: Documented that specifying Bearer + refreshToken in `setCredentials()` completely bypasses DPoP/PoW (#831)
 
 ### 2026-04-04
-- **Feature**: JavaScript SDK に公開 API メソッドを追加 — 内部メソッドへの依存を排除 (#830)
-  - `setCredentials()`: 外部認証トークンの注入（Bearer JWT セッション等） (#830)
-  - `onTokenRefresh(callback)`: トークンリフレッシュ時のコールバック登録 (#830)
-  - `request(method, path, body)`: 認証付き汎用 API リクエスト (#830)
-  - `reconnect()`: WebSocket 強制再接続 (#830)
-  - `isConnected()`: WebSocket 接続状態の確認 (#830)
-  - WebSocket ライフサイクルイベント追加: `connected`, `disconnected`, `reconnecting` (#830)
-  - SDK ファイル冒頭に JSDoc 型定義を埋め込み — AI コーディングアシスタントが自動的に全 API を把握可能 (#830)
+- **Feature**: Added public API methods to JavaScript SDK — eliminating dependency on internal methods (#830)
+  - `setCredentials()`: Inject external authentication token (Bearer JWT session etc.)
+  - `onTokenRefresh(callback)`: Register callback on token refresh
+  - `request(method, path, body)`: Authenticated generic API request
+  - `reconnect()`: Force WebSocket reconnection
+  - `isConnected()`: Check WebSocket connection state
+  - Added WebSocket lifecycle events: `connected`, `disconnected`, `reconnecting`
+  - Embedded JSDoc type definitions at SDK file header — AI coding assistants can automatically understand all APIs
 
 ### 2026-04-01
-- **Fix**: WAF `SizeRestrictions_BODY` ルールがリクエストボディ 8KB 以上で 403 Forbidden を返す問題を修正 (#813)
-  - `AWSManagedRulesCommonRuleSet` から `SizeRestrictions_BODY` を除外
-  - 代替としてカスタム 10MB ボディサイズ制限ルールを追加（API Gateway REST API 上限と一致）
+- **Fix**: Fixed issue where WAF `SizeRestrictions_BODY` rule returned 403 Forbidden for request bodies over 8KB (#813)
+  - Excluded `SizeRestrictions_BODY` from `AWSManagedRulesCommonRuleSet`
+  - Added custom 10MB body size limit rule as alternative (matches API Gateway REST API limit)
 
 ### 2026-03-25
-- **Feature**: `POST /me/api-keys/{keyId}/refresh` & `POST /admin/api-keys/{keyId}/refresh` で API キーのローテーション機能を追加 (#798)
-- **Breaking**: `keyPrefix` フィールドを `ApiKeyPublic` レスポンスから削除 (#798)
-- **Breaking**: 新規 API キーの `keyId` を `gdb_` + UUID 形式から素の UUID 形式に変更（既存キーは後方互換で維持） (#798)
-- **Change**: API キー一覧・詳細レスポンスに `key: "******"` マスク表示を追加 (#798)
-- **Perf**: コールドスタート時の初期化を並列化 — 最大 1000ms 短縮 (#775)
-  - `handlers/api/index.ts` で `resolveJwtSecret()` と `getMongoClient()` を `Promise.all` で並列実行
-  - Secrets Manager 解決（〜100-500ms）と MongoDB 接続確立（〜500-1000ms）を直列から並列に変更
-- **Security**: `updatePolicy` の TOCTOU 競合状態を Optimistic Locking で修正 (#784) (#793)
-  - `Policy`/`PolicyDocument`/`PolicyPublic` に `version: number` フィールドを追加
-  - `PolicyRepository.updatePolicy()` にバージョンフィルタ（`findOneAndUpdate` で `version` 一致確認）を追加
-  - バージョン不一致時に `ConflictError` (409) を返す
-  - 既存ドキュメント（`version` フィールドなし）は `version: 0` として移行互換対応
-- **Security**: `permit-overrides` 結合アルゴリズムを `super_admin` 以外に禁止（defense in depth） (#785) (#793)
-  - `validateCombiningAlgorithm()` に `actorRole` パラメータを追加
-  - `tenant_admin`/`user` が `permit-overrides` を指定した場合 `ForbiddenError` (403) を返す
-  - 更新時に `ruleCombiningAlgorithm` を指定しない場合も既存値（有効アルゴリズム）を検証
+- **Feature**: Added API key rotation with `POST /me/api-keys/{keyId}/refresh` & `POST /admin/api-keys/{keyId}/refresh` (#798)
+- **Breaking**: Removed `keyPrefix` field from `ApiKeyPublic` response (#798)
+- **Breaking**: Changed `keyId` format for new API keys from `gdb_` + UUID to plain UUID (existing keys maintained with backward compatibility) (#798)
+- **Change**: Added `key: "******"` masked display to API key list/detail responses (#798)
+- **Perf**: Parallelized cold start initialization — up to 1000ms reduction (#775)
+  - Parallel execution of `resolveJwtSecret()` and `getMongoClient()` with `Promise.all` in `handlers/api/index.ts`
+  - Changed Secrets Manager resolution (~100-500ms) and MongoDB connection establishment (~500-1000ms) from sequential to parallel
+- **Security**: Fixed TOCTOU race condition in `updatePolicy` with Optimistic Locking (#784) (#793)
+  - Added `version: number` field to `Policy`/`PolicyDocument`/`PolicyPublic`
+  - Added version filter to `PolicyRepository.updatePolicy()` (`version` match check via `findOneAndUpdate`)
+  - Returns `ConflictError` (409) on version mismatch
+- **Security**: Prohibited `permit-overrides` combining algorithm for non-`super_admin` roles (defense in depth) (#785) (#793)
+  - Added `actorRole` parameter to `validateCombiningAlgorithm()`
+  - `tenant_admin`/`user` specifying `permit-overrides` returns `ForbiddenError` (403)
 
 ### 2026-03-24
-- **Perf**: テナントデータ二重取得の排除 (#776)
-  - `handlers/api/index.ts` のリクエストボディサイズチェックで `tenantData` を直接更新するよう修正
-  - レート制限無効かつリクエストボディあり時に、ボディチェックとレスポンスサイズチェックで計2回発生していた `TenantRepository.getByName()` を1回に削減
-- **Perf**: policyId バインドポリシーのキャッシュ追加 (#777)
-  - `PolicyCache` に `getPolicy/setPolicy` メソッドを追加（TTL: 60秒）
-  - `PolicyService.loadBoundPolicy()` でキャッシュを参照し、カスタムポリシーを持つテナントの認証フローで MongoDB ラウンドトリップを削減
-- **Perf**: API Gateway gzip 圧縮を有効化（MinimumCompressionSize: 1024）(#791)
-  - 1KB 以上のレスポンスを自動 gzip 圧縮 — Entity リスト等で 60〜75% の転送量削減
-- **Perf**: Lambda アーキテクチャを ARM64 (Graviton2) へ移行 (#791)
-  - 全 Lambda 関数を arm64 に統一 — 約 20% の CPU 処理速度向上
-- **Perf**: Lambda メモリサイズを 256MB → 512MB に引き上げ (#791)
-  - CPU 割り当て倍増により JSON シリアライズ・MongoDB クエリ・XACML 評価を高速化
-- **Perf**: esbuild Minify を有効化してバンドルサイズを削減 (#791)
-  - 全 Lambda ハンドラのコードバンドルを minify — 推定 30〜50% サイズ削減、コールドスタート短縮
-- **Security Fix**: path 属性に対する `string-regexp` matchFunction を禁止 (#788)
-  - `validateNonEscalatingPolicy` 内でポリシーレベル・ルールレベル両方の path 属性に `matchFunction: 'string-regexp'` が指定された場合に `ForbiddenError` を返すよう修正
-  - 正規表現によるパスプレフィックス制約バイパスを防止（代替: `glob` を使用）
-- **Security Fix**: API Key 更新時の `policyId` バリデーションに `minPriority` チェックを追加 (#788)
-  - `ApiKeyService.updateKey()` で `validatePolicyId()` に `ROLE_MIN_PRIORITY[actor.role]` を渡すよう修正
-  - `tenant_admin` が priority < 10 のポリシーを API Key にバインドできる権限昇格を防止
-- **Fix**: `DELETE /me/policies/{policyId}` で tenant_admin が自分のポリシーを削除できない問題を修正 (#790)
-  - tenant_admin の場合、`createdBy` 一致 または テナントスコープ一致（`tenantId` 一致）でアクセス許可
-  - 旧データ（`createdBy: null`）も tenant_admin は削除・更新・取得可能に
-  - GET・PATCH も同一ロジックで統一（`checkOwnershipOrTenantScope` 導入）
-- **Fix**: DPoP Nonce リトライ時の 400 エラーをブラウザコンソールから排除 (#758)
-  - `POST /auth/nonce` レスポンスに `dpop_nonce` フィールドを追加（RFC 9449 §8 準拠）
-  - SDK が事前取得した `dpop_nonce` を使って最初から nonce 付き DPoP proof を送信
-  - ページロード後初回のトークン取得で発生していた `400 use_dpop_nonce` ハンドシェイクを回避
+- **Perf**: Eliminated duplicate tenant data fetch (#776)
+  - Fixed `handlers/api/index.ts` request body size check to update `tenantData` directly
+  - Reduced 2 `TenantRepository.getByName()` calls (body check + response size check) to 1 when rate limiting disabled and request body present
+- **Perf**: Added cache for `policyId`-bound policies (#777)
+  - Added `getPolicy/setPolicy` methods to `PolicyCache` (TTL: 60 seconds)
+  - Reduced MongoDB round-trips in auth flow for tenants with custom policies
+- **Perf**: Enabled API Gateway gzip compression (MinimumCompressionSize: 1024) (#791)
+  - Auto gzip compression for responses over 1KB — 60-75% transfer reduction for entity lists etc.
+- **Perf**: Migrated Lambda architecture to ARM64 (Graviton2) (#791)
+  - Unified all Lambda functions to arm64 — approximately 20% CPU processing speed improvement
+- **Perf**: Increased Lambda memory size from 256MB to 512MB (#791)
+  - Doubled CPU allocation, accelerating JSON serialization / MongoDB queries / XACML evaluation
+- **Perf**: Enabled esbuild Minify to reduce bundle size (#791)
+  - Minified code bundles for all Lambda handlers — estimated 30-50% size reduction, cold start reduction
+- **Security Fix**: Prohibited `string-regexp` matchFunction for `path` attribute (#788)
+  - Fixed to return `ForbiddenError` when `matchFunction: 'string-regexp'` is specified for path attributes in both policy-level and rule-level within `validateNonEscalatingPolicy`
+  - Prevents path prefix constraint bypass via regex (use `glob` instead)
+- **Security Fix**: Added `minPriority` check to `policyId` validation when updating API Key (#788)
+  - Fixed `ApiKeyService.updateKey()` to pass `ROLE_MIN_PRIORITY[actor.role]` to `validatePolicyId()`
+  - Prevents `tenant_admin` privilege escalation by binding policies with priority < 10 to API Keys
+- **Fix**: Fixed issue where `tenant_admin` could not delete their own policies via `DELETE /me/policies/{policyId}` (#790)
+  - For `tenant_admin`, allow access when `createdBy` matches OR tenant scope matches (`tenantId` matches)
+  - `tenant_admin` can also delete/update/retrieve old data (`createdBy: null`)
+- **Fix**: Eliminated 400 errors from DPoP Nonce retry from browser console (#758)
+  - Added `dpop_nonce` field to `POST /auth/nonce` response (RFC 9449 §8 compliant)
+  - SDK uses pre-fetched `dpop_nonce` to send nonce-attached DPoP proof from the start
+  - Avoids `400 use_dpop_nonce` handshake that occurred on first token acquisition after page load
 
 ### 2026-03-23
-- **Feature**: PATCH /me/api-keys/{keyId} と PATCH /me/oauth-clients/{clientId} を実装 (#791)
-  - 自分が作成した API キー・OAuth クライアントの属性を部分更新可能に
-  - 更新可能フィールド（API キー）: `name`, `allowedOrigins`, `policyId`, `rateLimit`, `dpopRequired`, `isActive`
-  - 更新可能フィールド（OAuth クライアント）: `name`, `description`, `policyId`, `isActive`
-  - `policyId` バインドは `createdBy === actor.id` チェック済み — 自分が作成したポリシーのみ許可
-  - API キー作成時（POST /me/api-keys）にも `policyId` 指定が可能に
+- **Feature**: Implemented `PATCH /me/api-keys/{keyId}` and `PATCH /me/oauth-clients/{clientId}` (#791)
+  - Enables partial update of attributes for own API keys and OAuth clients
+  - Updatable fields (API key): `name`, `allowedOrigins`, `policyId`, `rateLimit`, `dpopRequired`, `isActive`
+  - Updatable fields (OAuth client): `name`, `description`, `policyId`, `isActive`
+  - `policyId` binding checked `createdBy === actor.id` — only own policies allowed
 
 ### 2026-03-21
-- **Breaking**: API キー・OAuth クライアントのフィールド変更 (#759)
-  - API キー: `allowedScopes`, `allowedEntityTypes`, `permissions` フィールドを削除、`policyId`（オプション）を追加
-  - OAuth クライアント: `clientName` を `name` にリネーム、`allowedScopes` を削除、`policyId`（オプション）を追加
-  - 自動生成ポリシー（`__apikey_*` プレフィックス、`buildAutoPolicy`、`syncAutoPolicy`）を廃止
-  - `policyId` で既存の XACML ポリシーをクレデンシャルに紐付け可能（紐付けポリシーの Target はバイパス）
-  - `policyId` 未指定時はテナントポリシー + ロールデフォルトにフォールバック
-- **Fix**: XACML Target の同一 `attributeId` 複数値が OR 評価されるように修正 (#756)
-  - 同一 `attributeId` 内の複数 `matchValue` を OR（いずれかマッチ）で評価
-  - 異なる `attributeId` 間は AND（全てマッチ必須）を維持
-  - これにより `actions` に `POST` と `PATCH` を並記して複数メソッドを許可可能に
+- **Breaking**: Changed API key and OAuth client fields (#759)
+  - API key: Removed `allowedScopes`, `allowedEntityTypes`, `permissions` fields, added optional `policyId`
+  - OAuth client: Renamed `clientName` to `name`, removed `allowedScopes`, added optional `policyId`
+  - Deprecated auto-generated policies (`__apikey_*` prefix, `buildAutoPolicy`, `syncAutoPolicy`)
+  - Can bind existing XACML policies to credentials via `policyId` (policy Target is bypassed for bound policy)
+  - Falls back to tenant policy + role default when `policyId` not specified
+- **Fix**: Fixed XACML Target multiple values for same `attributeId` to be evaluated as OR (#756)
+  - Multiple `matchValue` within same `attributeId` evaluated as OR (any match)
+  - AND (all must match) maintained between different `attributeId`s
+  - Enables listing `POST` and `PATCH` in `actions` to allow multiple methods
 
 ### 2026-03-20
-- **Feature**: API キー作成時に XACML ポリシーを自動生成する (#749)
-  - `permissions` フィールド（`read`/`write`/`create`/`update`/`delete`）を指定するだけで XACML ポリシーが自動生成
-  - `write` は `create` + `update` + `delete` のエイリアス
-  - `allowedEntityTypes` との連動でエンティティタイプ制限付きポリシーも自動生成
-  - API キー削除時にポリシーも連動削除
-  - `permissions` 未指定時は既存動作と同一（デフォルト Deny）
-- **Feature**: XACML resource 属性に `servicePath` を追加 (#750)
-  - `Fiware-ServicePath` ヘッダーの値をポリシー評価に使用可能に
-  - glob パターン（例: `/opendata/**`）でサービスパス階層のアクセス制御が可能
-  - 正規表現マッチ（`string-regexp`）にも対応
-- **Feature**: XACML 認可一元化 — 5層の認可ロジックを統合 (#748)
-  - ロールごとのデフォルトフォールバックポリシーを追加: user (readonly), api_key (全Deny), anonymous (全Deny)
-  - entity-type ミドルウェアを廃止（`allowedEntityTypes` フィールドは ApiKey モデルに残存）
-  - テナントフィーチャーフラグを全廃（`apiKeysEnabled`, `oauthClientsEnabled`, `anonymousAccessEnabled`）
-  - scope/resource-scope ミドルウェアを廃止（XACML ポリシーに統合）
-  - **破壊的変更**: user ロール（ポリシーなし）は GET のみ Permit、api_key ロール（ポリシーなし）は全 Deny
-  - **破壊的変更**: 未認証リクエストは 401 ではなく 403 を返す（anonymous として XACML 評価）
+- **Feature**: Auto-generate XACML policy on API key creation (#749)
+  - Just specifying `permissions` field (`read`/`write`/`create`/`update`/`delete`) auto-generates XACML policy
+  - `write` is alias for `create` + `update` + `delete`
+  - Auto-generates entity-type restricted policy in combination with `allowedEntityTypes`
+  - Policy also deleted when API key is deleted
+  - Unspecified `permissions` behaves same as before (default Deny)
+- **Feature**: Added `servicePath` to XACML resource attributes (#750)
+  - Enables using `Fiware-ServicePath` header value in policy evaluation
+  - Enables access control for service path hierarchy with glob patterns (e.g., `/opendata/**`)
+  - Also supports regex match (`string-regexp`)
+- **Feature**: XACML authorization unification — integrated 5-layer authorization logic (#748)
+  - Added default fallback policies per role: user (readonly), api_key (all Deny), anonymous (all Deny)
+  - Deprecated entity-type middleware (`allowedEntityTypes` field remains in ApiKey model)
+  - Completely removed tenant feature flags (`apiKeysEnabled`, `oauthClientsEnabled`, `anonymousAccessEnabled`)
+  - Deprecated scope/resource-scope middleware (integrated into XACML policies)
+  - **Breaking**: user role (no policy) Permit for GET only, api_key role (no policy) all Deny
+  - **Breaking**: Unauthenticated requests return 403 instead of 401 (evaluated as anonymous via XACML)
 
 ### 2026-03-19
-- **Fix**: `api_key` ロールでポリシー未マッチ時に 403 エラーが返される問題を修正 (#744)
-  - テナントに anonymous 用ポリシーのみ存在する場合、`api_key` ロールのリクエストが `NotApplicable` → `Deny` に変換されていた
-  - `api_key` ロールはスコープベースのアクセス制御（`allowedScopes` / `allowedEntityTypes`）で制限済みのため、XACML ポリシー未マッチ時は `Permit` にフォールバックするように変更
-  - 明示的な `Deny` ポリシーは引き続き有効
+- **Fix**: Fixed 403 error returned for `api_key` role when policy not matched (#744)
+  - When tenant only has policies for anonymous, `api_key` role requests were converting `NotApplicable` → `Deny`
+  - Since `api_key` role is already restricted by scope-based access control (`allowedScopes` / `allowedEntityTypes`), changed to fall back to `Permit` when XACML policy not matched
+  - Explicit `Deny` policies remain effective
 
 ### 2026-03-18
-- **Feature**: テナント単位の匿名アクセスポリシーをサポート (#730)
-  - `anonymous` ロールを追加し、未認証リクエストにポリシー評価を適用
-  - テナントフィーチャーフラグ `anonymousAccessEnabled`（デフォルト: false）でオプトイン制御
-  - `optionalAuth()` ミドルウェア追加: 認証トークンがあれば検証、なければ匿名アクターとして通過
-  - 匿名アクセスはポリシーで明示的に Permit されない限り Deny（fail-closed）
-  - テナント管理者が XACML ポリシーで `role=anonymous` 向けのアクセス制御を定義可能
-- **Fix**: SDK のエンティティ API パスを NGSIv2 (`/v2/entities`) から NGSI-LD (`/ngsi-ld/v1/entities`) に修正 (#728)
-  - 全 CRUD メソッド (createEntity, getEntities, getEntity, updateEntity, deleteEntity) のパスを修正
-  - Content-Type / Accept ヘッダーを `application/ld+json` に変更
-  - エラーレスポンスの `detail` フィールド（NGSI-LD 形式）に対応
-- **Fix**: API Gateway レベルの CORS 設定に DPoP ヘッダーを追加 (#726)
-  - `template.yaml` の `Cors.AllowHeaders` / `GatewayResponses` (4XX/5XX) に `DPoP` を追加
-  - Lambda に到達しないプリフライト/エラーレスポンスでもブラウザから DPoP 送信可能に
-- **Fix**: CORS ヘッダーに DPoP 関連ヘッダーを追加 (RFC 9449) (#725)
-  - `Access-Control-Allow-Headers` に `DPoP` を追加（ブラウザからの DPoP proof 送信を許可）
-  - `Access-Control-Expose-Headers` に `DPoP-Nonce` を追加（クライアント JS での nonce 読み取りを許可）
+- **Feature**: Support tenant-level anonymous access policy (#730)
+  - Added `anonymous` role, applying policy evaluation to unauthenticated requests
+  - Opt-in control via tenant feature flag `anonymousAccessEnabled` (default: false)
+  - Added `optionalAuth()` middleware: validates auth token if present, passes as anonymous actor if absent
+  - Anonymous access is Deny unless explicitly Permitted by policy (fail-closed)
+  - Tenant admins can define access control for `role=anonymous` via XACML policies
+- **Fix**: Fixed SDK entity API path from NGSIv2 (`/v2/entities`) to NGSI-LD (`/ngsi-ld/v1/entities`) (#728)
+  - Fixed paths for all CRUD methods (createEntity, getEntities, getEntity, updateEntity, deleteEntity)
+  - Changed Content-Type / Accept headers to `application/ld+json`
+  - Handle `detail` field in error responses (NGSI-LD format)
+- **Fix**: Added DPoP headers to API Gateway-level CORS configuration (#726)
+  - Added `DPoP` to `Cors.AllowHeaders` / `GatewayResponses` (4XX/5XX) in `template.yaml`
+  - Enables DPoP transmission from browser even for preflight/error responses not reaching Lambda
+- **Fix**: Added DPoP-related headers to CORS headers (RFC 9449) (#725)
+  - Added `DPoP` to `Access-Control-Allow-Headers` (allows DPoP proof transmission from browser)
+  - Added `DPoP-Nonce` to `Access-Control-Expose-Headers` (allows nonce reading in client JS)
 
 ### 2026-03-17
-- **Breaking**: `write:X` スコープが `read:X` を暗黙的に含まなくなった (#723)
-  - 問い合わせフォームなどの write-only ユースケースで、読み取りアクセスを防止
-  - `admin:X` → `read:X` / `write:X` の包含は維持
-  - 読み書き両方必要な場合は `read:X write:X` を明示的に付与すること
-- **Fix**: ユーザー作成・更新時に指定された `tenantId` のテナント存在確認を追加 (#722)
-  - 存在しないテナントIDでユーザーを作成すると 400 エラーを返す
-  - ユーザー更新時のテナント移動先も同様に検証（`null` への変更は許可）
-  - `UserService` に `TenantService` を注入しバリデーション層で整合性を担保
+- **Breaking**: `write:X` scope no longer implicitly includes `read:X` (#723)
+  - Enables preventing read access in write-only use cases like inquiry forms
+  - `admin:X` → `read:X` / `write:X` inclusion maintained
+  - Explicitly grant `read:X write:X` when both read and write are needed
+- **Fix**: Added tenant existence check for specified `tenantId` on user creation/update (#722)
+  - Returns 400 error when creating user with non-existent tenant ID
+  - Same validation for tenant migration destination on user update (`null` change allowed)
 
 ### 2026-03-12
-- **Fix**: ログイン時のテナントヘッダー（`NGSILD-Tenant` / `Fiware-Service`）フォーマット検証を追加 (issue #708) (#711)
-  - 不正な形式のヘッダー値で 400 エラーを返す
-- **Fix**: テナント名フォーマットバリデーションを Zod スキーマに追加 (issue #709) (#711)
-  - `POST /admin/tenants` および `PATCH /admin/tenants/{tenantId}` で `^[a-z0-9_]+$` を強制
-  - 大文字・ハイフン・スペース等を含む名前は 400 エラー
-- **Feat**: ログイン時の `NGSILD-Tenant` / `Fiware-Service` ヘッダーによるテナント指定をサポート (issue #710) (#711)
-  - 優先順位: `body.tenantId` > `NGSILD-Tenant` ヘッダー > プライマリテナント
-  - ヘッダー値からテナント名でテナントを解決（存在しない場合は 400 エラー）
+- **Fix**: Added tenant header (`NGSILD-Tenant` / `Fiware-Service`) format validation on login (issue #708) (#711)
+  - Returns 400 error for invalid format header values
+- **Fix**: Added tenant name format validation to Zod schema (issue #709) (#711)
+  - Enforces `^[a-z0-9_]+$` in `POST /admin/tenants` and `PATCH /admin/tenants/{tenantId}`
+  - Names containing uppercase / hyphens / spaces etc. return 400 error
+- **Feat**: Support tenant specification via `NGSILD-Tenant` / `Fiware-Service` headers on login (issue #710) (#711)
+  - Priority: `body.tenantId` > `NGSILD-Tenant` header > primary tenant
+  - Resolves tenant by name from header value (400 error if not found)
 
 ### 2026-03-10
-- **Feat**: DPoP (Demonstration of Proof-of-Possession) トークンバインド (#707)
-  - RFC 9449 準拠: ECDSA P-256 鍵ペアによるトークン所有証明
-  - `/oauth/token` で DPoP proof 付きトークン交換 → `token_type: "DPoP"` + JWT `cnf.jkt` バインド
-  - API リクエストごとに DPoP proof を検証（`htm`/`htu`/`ath` チェック）
-  - `dpopRequired` API キーフラグ: DPoP proof なしのトークン交換を拒否
-  - SDK: `crypto.subtle` で非抽出鍵ペア生成、自動 proof 付与
-  - WebSocket: Post-Connect DPoP binding (`dpop_bind` メッセージ)
-  - DPoP-Nonce (RFC 9449 §8): サーバー発行 nonce によるプリコンピュート防止。ステートレス HMAC 方式（TTL: 300秒）
-  - `use_dpop_nonce` エラーコード + `DPoP-Nonce` レスポンスヘッダーによる自動リトライフロー
-  - Bearer フォールバック: DPoP 非対応クライアントは従来通り Bearer トークンで動作
+- **Feat**: DPoP (Demonstration of Proof-of-Possession) token binding (#707)
+  - RFC 9449 compliant: Token ownership proof via ECDSA P-256 key pair
+  - DPoP proof-bearing token exchange at `/oauth/token` → `token_type: "DPoP"` + JWT `cnf.jkt` binding
+  - DPoP proof validation per API request (`htm`/`htu`/`ath` checks)
+  - `dpopRequired` API key flag: rejects token exchange without DPoP proof
+  - SDK: Non-extractable key pair generation via `crypto.subtle`, automatic proof attachment
+  - WebSocket: Post-Connect DPoP binding (`dpop_bind` message)
+  - DPoP-Nonce (RFC 9449 §8): Pre-compute prevention via server-issued nonce. Stateless HMAC method (TTL: 300s)
+  - `use_dpop_nonce` error code + `DPoP-Nonce` response header auto-retry flow
+  - Bearer fallback: Non-DPoP-supporting clients work with traditional Bearer tokens
 
 ### 2026-03-09
-- **Fix**: `POST /admin/api-keys` で `tenantId` を必須バリデーションに変更 (#704)
-  - super_admin が `tenantId` なしでキーを作成すると 400 エラーを返す
-  - スキーマレベルで `null` / 空文字を拒否（`tenant_admin` は省略可、セッションから自動設定）
-  - サービス層で super_admin の `tenantId` 必須チェックを追加
+- **Fix**: Changed `tenantId` to required validation in `POST /admin/api-keys` (#704)
+  - Returns 400 error when super_admin creates key without `tenantId`
+  - Rejects `null` / empty string at schema level (auto-set from session for `tenant_admin`)
+  - Added `tenantId` required check for super_admin in service layer
 
 ### 2026-03-08
-- **Feat**: JS SDK + API キートークン交換エンドポイント (#689)
-  - `POST /auth/nonce`: Nonce + Proof of Work チャレンジ発行（API キー + Origin バインド）
-  - `POST /oauth/token` (`grant_type=api_key`): API キー → セッション JWT 交換
-  - `GET /sdk/v1/geonicdb.js`: ブラウザ用 JavaScript SDK 配信
-  - セキュリティ多層構造: Origin 検証 → HMAC Nonce → PoW → 短命 JWT（1h）
-- **Fix**: `allowedOrigins: []`（空配列）で作成された API キーが一切使用不能になるバグを修正 (issue #678) (#687)
-  - Create/Update 両スキーマに `.min(1)` バリデーションを追加
-  - 全オリジン許可には `["*"]` を使用
-- **Feat**: APIキーの `allowedEntityTypes` ランタイムエンフォースメント (#688)
-  - エンティティ作成・取得・更新・削除時にAPIキーの許可タイプを検証
-  - 一覧取得時に `type` フィルタを自動注入
-  - バッチ操作で全エンティティタイプを一括検証
-  - NGSIv2・NGSI-LD 両APIに対応
+- **Feat**: JS SDK + API key token exchange endpoint (#689)
+  - `POST /auth/nonce`: Nonce + Proof of Work challenge issuance (bound to API key + Origin)
+  - `POST /oauth/token` (`grant_type=api_key`): API key → session JWT exchange
+  - `GET /sdk/v1/geonicdb.js`: Browser JavaScript SDK delivery
+  - Multi-layer security: Origin validation → HMAC Nonce → PoW → short-lived JWT (1h)
+- **Fix**: Fixed bug where API key created with `allowedOrigins: []` (empty array) was completely unusable (issue #678) (#687)
+  - Added `.min(1)` validation to both Create/Update schemas
+  - Use `["*"]` to allow all origins
+- **Feat**: `allowedEntityTypes` runtime enforcement for API keys (#688)
+  - Validates allowed types on entity creation, retrieval, update, deletion
+  - Auto-injects `type` filter on list retrieval
+  - Batch validates all entity types in batch operations
+  - Supports both NGSIv2 and NGSI-LD APIs
 
 ### 2026-03-07
-- **BREAKING**: `super_admin` ロールの権限をプラットフォーム管理操作（`/admin/*`, `/auth/*`）のみに制限 (#674)
-  - データ API（`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`）へのアクセスは 403 Forbidden
-  - MCP ツールのデータ操作も同様に拒否
-  - `AUTH_ENABLED=false` 時の匿名 super_admin は従来通りアクセス可能（後方互換）
-- **Feat**: APIキー認証基盤の追加 (`/admin/api-keys`, `/me/api-keys`) (#676)
-- **Feat**: テナント単位フィーチャーフラグ (`features.apiKeysEnabled`, `features.oauthClientsEnabled`) の追加 (#676)
-- **Feat**: X-Api-Key ヘッダーによる認証のサポート (#676)
-- **BREAKING**: `OAUTH_ENABLED` 環境変数の廃止（OAuth は `AUTH_ENABLED=true` なら常に有効） (#676)
+- **BREAKING**: Restricted `super_admin` role permissions to platform management operations (`/admin/*`, `/auth/*`) only (#674)
+  - Data APIs (`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`) return 403 Forbidden
+  - MCP tool data operations also rejected
+  - Anonymous super_admin when `AUTH_ENABLED=false` maintains backward compatibility
+- **Feat**: Added API key authentication infrastructure (`/admin/api-keys`, `/me/api-keys`) (#676)
+- **Feat**: Added tenant-level feature flags (`features.apiKeysEnabled`, `features.oauthClientsEnabled`) (#676)
+- **Feat**: Support authentication via `X-Api-Key` header (#676)
+- **BREAKING**: Deprecated `OAUTH_ENABLED` environment variable (OAuth always enabled when `AUTH_ENABLED=true`) (#676)
 
 ### 2026-03-06
-- **Fix**: 認証無効時に `/me` エンドポイントが匿名ユーザー情報を返すように修正 (#663)
-- **Feat**: `limit=0` と `count` の組み合わせによるカウントのみクエリをサポート (#664)
-- **Feat**: XACML AuthzRequest に entityType 自動抽出を追加 (#665)
-  - PIP 拡張: `?type=` クエリパラメータまたはリクエストボディの `type`/`@type` フィールドから entityType を自動抽出
-  - パスレベル認可（`requireAuthz`）でもエンティティタイプに基づくアクセス制御が可能に
-  - E2E テスト追加: エンティティタイプによる書き込み拒否・読み取り拒否シナリオ
-- **Fix**: `PATCH /entities/{id}/attrs` で新規属性の追加が可能に & NGSI-LD orderBy テスト追加 (#666)
-- **Feat**: XACML エンティティ単位のオーナーシップ制御 (#650)
-  - `EntityDocument` に `createdBy` フィールドを追加（エンティティ作成者の記録）
-  - PIP（Policy Information Point）拡張: `buildAuthzRequest` にエンティティコンテキスト（`entityId`/`entityType`/`entityOwner`）を渡せるように
-  - PDP（Policy Decision Point）拡張: リソース属性 `entityId`/`entityType`/`entityOwner` のマッチング対応
-  - `${subject.userId}` 等のテンプレート変数展開（XACML AttributeDesignator 相当の簡略化実装）
-  - `requireEntityAuthz` ヘルパー関数追加（エンティティレベル PEP）
-  - 後方互換性: 全フィールド optional、既存ポリシー・既存エンティティへの影響なし
+- **Fix**: Fixed `/me` endpoint to return anonymous user info when auth disabled (#663)
+- **Feat**: Support count-only query with combination of `limit=0` and `count` (#664)
+- **Feat**: Added entity type auto-extraction to XACML AuthzRequest (#665)
+  - PIP extension: Auto-extracts entityType from `?type=` query parameter or `type`/`@type` field in request body
+  - Path-level authorization (`requireAuthz`) also enables entity type-based access control
+  - E2E tests added: write denial / read denial scenarios by entity type
+- **Fix**: Made adding new attributes possible with `PATCH /entities/{id}/attrs` & added NGSI-LD orderBy tests (#666)
+- **Feat**: XACML entity-level ownership control (#650)
+  - Added `createdBy` field to `EntityDocument` (records entity creator)
+  - PIP (Policy Information Point) extension: Pass entity context (`entityId`/`entityType`/`entityOwner`) to `buildAuthzRequest`
+  - PDP (Policy Decision Point) extension: Added resource attribute matching for `entityId`/`entityType`/`entityOwner`
+  - Template variable expansion for `${subject.userId}` etc. (simplified XACML AttributeDesignator equivalent implementation)
+  - Added `requireEntityAuthz` helper function (entity-level PEP)
+  - Backward compatible: all fields optional, no impact on existing policies / entities
 
 ### 2026-03-05
-- **Feat**: ユーザー自身による OAuth Client Credentials セルフサービス (#642)
-  - `POST /me/oauth-clients` — 自分用の OAuth クライアントを作成（シークレットは作成時のみ返却）
-  - `GET /me/oauth-clients` — 自分が作成したクライアント一覧を取得
-  - `DELETE /me/oauth-clients/:id` — 自分が作成したクライアントを削除
-  - `POST /me/oauth-clients/:id/regenerate-secret` — クライアントシークレットの再生成
-  - ユーザーあたり最大5クライアント、ロールベースのスコープ制限（user ロールは resource スコープのみ）
-  - `OAuthClient` に `createdBy` フィールドを追加（所有者追跡）
+- **Feat**: OAuth Client Credentials self-service for users (#642)
+  - `POST /me/oauth-clients` — Create own OAuth client (secret returned only at creation)
+  - `GET /me/oauth-clients` — List clients created by self
+  - `DELETE /me/oauth-clients/:id` — Delete own client
+  - `POST /me/oauth-clients/:id/regenerate-secret` — Regenerate client secret
+  - Max 5 clients per user, role-based scope restrictions (user role: resource scopes only)
+  - Added `createdBy` field to `OAuthClient` (ownership tracking)
 
 ### 2026-03-03
-- **Docs**: CLI リファレンス (`docs/CLI.md`) を追加 (#632)
-  - `@geolonia/geonicdb-cli` (`geonic` コマンド) の全コマンドリファレンス
-  - インストール、認証、設定・プロファイル管理、入出力フォーマット
-  - entities, batch, subscriptions, registrations, temporal, snapshots, rules, admin 等の全コマンド
+- **Docs**: Added CLI reference (`docs/CLI.md`) (#632)
+  - Complete command reference for `@geolonia/geonicdb-cli` (`geonic` command)
+  - Installation, authentication, configuration & profile management, input/output formats
+  - All commands: entities, batch, subscriptions, registrations, temporal, snapshots, rules, admin, etc.
 
 ### 2026-03-02
-- **Fix**: Custom Data Model バリデーションの複数の不具合を修正 (#597)
-  - `validateValueType()` の case mismatch を修正（PascalCase `"String"` 等が lowercase `'string'` と不一致で型チェックが無効化されていた）
-  - `batchCreateEntities` / `batchUpsertEntities` にカスタムデータモデルバリデーションを追加（type 別キャッシュ付き）
-  - `getActiveDataModel()` のフェイルオープン動作を修正（DB 障害時にバリデーションをスキップせずエラーを伝播）
+- **Fix**: Fixed multiple bugs in Custom Data Model validation (#597)
+  - Fixed `validateValueType()` case mismatch (PascalCase `"String"` etc. were mismatched with lowercase `'string'`, disabling type checks)
+  - Added custom data model validation to `batchCreateEntities` / `batchUpsertEntities` (with per-type cache)
+  - Fixed fail-open behavior in `getActiveDataModel()` (now propagates errors instead of skipping validation on DB failure)
 
 ### 2026-02-28
-- **Feat**: Crypto-Shredding と削除完了レポート生成 (#554)
-  - `DELETE /admin/tenants/{tenantId}?shred=true` で暗号化テナントの Crypto-Shredding を実行
-  - KMS CMK の DisableKey → ScheduleKeyDeletion → 全テナントデータ物理削除 → テナント論理削除
-  - 削除完了レポート自動生成（ISMAP/ISO 27001/NIST SP 800-88 準拠）
-  - `GET /admin/tenants/{tenantId}/deletion-report` でレポート取得
-  - CloudTrail 監査イベント取得（best-effort）
-  - テナント論理削除（`status: 'deleted'`）とクエリからの自動除外
-- **Infra**: 単一リージョン Staging デプロイ対応 (#571)
-  - `HasSecondaryRegion` 条件追加: `SecondaryRegion=""` 時に `AWS::DynamoDB::Table` を使用
-  - 3テーブル (DeploymentsTable, TokenInvalidationTable, UsageStatisticsTable) の単一リージョン版を追加
-  - 環境変数・IAM ポリシー参照をネスト `!If` で切り替え
-- **Infra**: Staging パラメータファイル追加 (#572)
-  - `infrastructure/parameters/staging.json` を新規作成 (`Environment: staging`, `LogLevel: INFO`)
-- **CI**: `ci.yml` に `workflow_call` トリガー追加 (#573)
-  - CD ワークフロー (`deploy.yml`) から CI パイプラインを再利用可能に
-- **CI**: CD パイプライン `deploy.yml` 新規作成 (#574, #575)
-  - Staging: `main` マージで自動デプロイ（OIDC 認証、ヘルスチェック、デプロイ記録）
-  - Production: `v*.*.*` タグで手動承認付きマルチリージョンデプロイ（Primary → Secondary → Route53）
-  - `ci.yml` から `push: [main]` トリガーを削除（`deploy.yml` 経由の `workflow_call` に統合）
+- **Feat**: Crypto-Shredding and deletion report generation (#554)
+  - Execute Crypto-Shredding for encrypted tenants with `DELETE /admin/tenants/{tenantId}?shred=true`  - KMS CMK DisableKey → ScheduleKeyDeletion → physical deletion of all tenant data → logical tenant deletion
+  - Automatic deletion report generation (ISMAP/ISO 27001/NIST SP 800-88 compliant)
+  - Retrieve report with `GET /admin/tenants/{tenantId}/deletion-report`  - CloudTrail audit event retrieval (best-effort)
+  - Logical tenant deletion (`status: 'deleted'`) and automatic exclusion from queries
+- **Infra**: Single-region Staging deployment support (#571)
+  - Added `HasSecondaryRegion` condition: use `AWS::DynamoDB::Table` when `SecondaryRegion=""`
+  - Added single-region versions of 3 tables (DeploymentsTable, TokenInvalidationTable, UsageStatisticsTable)
+  - Switch environment variables and IAM policy references with nested `!If`
+- **Infra**: Added Staging parameter file (#572)
+  - Created new `infrastructure/parameters/staging.json` (`Environment: staging`, `LogLevel: INFO`)
+- **CI**: Added `workflow_call` trigger to `ci.yml` (#573)
+  - Made CI pipeline reusable from CD workflow (`deploy.yml`)
+- **CI**: Created new CD pipeline `deploy.yml` (#574, #575)
+  - Staging: auto-deploy on `main` merge (OIDC auth, health check, deployment recording)
+  - Production: manual approval multi-region deploy on `v*.*.*` tag (Primary → Secondary → Route53)
+  - Removed `push: [main]` trigger from `ci.yml` (unified to `workflow_call` via `deploy.yml`)
 
 ### 2026-02-27
-- **Perf**: KMS Decrypt DEK キャッシュと並列数制限の導入 (#578)
-  - 復号済み DEK をキャッシュし、同一エンベロープの繰り返し KMS DecryptCommand 呼び出しを排除
-  - `ConcurrencyLimiter` により KMS API 並列呼び出しを制限（デフォルト: 10）
-  - `entity.repository.ts`, `temporal.repository.ts`, `snapshot.repository.ts` のバッチ復号に適用
-- **Feat**: 暗号化テナントでの時系列集計リクエストにランタイムチェックを追加 (#579)
-  - `aggrMethod` パラメータ指定時に暗号化テナントを検出して 400 Bad Request を返却
-  - 代替手段: `temporalValues` エンドポイントで復号後データを取得し、アプリケーション層で集計
-- **BREAKING**: エンティティ ID の一意制約をテナントスコープ内で `entityId` 単独に変更 (#580)
-  - インデックスを `(tenant, servicePath, entityId, entityType)` → `(tenant, servicePath, entityId)` に変更
-  - 同一 ID で異なる type のエンティティ作成は `409 AlreadyExists` を返却
-  - バッチ Upsert は `entityId` のみでマッチ（type の上書きが可能）
-  - NGSIv2 の `?type=` パラメータによる type disambiguation を廃止
-  - NGSI-LD の ID 一意セマンティクスと統一（GeonicDB 独自拡張）
-- **Feat**: テナント単位 KMS CMK 導入と Envelope Encryption の実装 (#553)
-  - テナント作成時に AWS KMS CMK を自動生成（`encryptionEnabled: true` 設定時）
-  - エンティティ `attributes` フィールドを AES-256-GCM Envelope Encryption で暗号化
-  - データキーキャッシュ（TTL/カウント/バイト制限）による KMS API 呼び出し最適化
-  - テナント削除時の KMS 鍵無効化・削除スケジュール（Crypto-Shredding 対応）
-  - 暗号化/非暗号化テナントの後方互換共存
-  - Temporal/Snapshot リポジトリの暗号化統合
-  - SAM テンプレート: KMS IAM ポリシー、DynamoDB SSE 設定、`EncryptionEnabled` パラメータ追加
-  - 依存追加: `@aws-sdk/client-kms`
+- **Perf**: Introduced KMS Decrypt DEK cache and concurrency limit (#578)
+  - Cache decrypted DEKs to eliminate repeated KMS DecryptCommand calls for the same envelope
+  - Limit KMS API parallel calls with `ConcurrencyLimiter` (default: 10)
+  - Applied to batch decryption in `entity.repository.ts`, `temporal.repository.ts`, `snapshot.repository.ts`
+- **Feat**: Added runtime check for time-series aggregation requests on encrypted tenants (#579)
+  - Detect encrypted tenant when `aggrMethod` parameter is specified and return 400 Bad Request
+  - Alternative: fetch decrypted data from `temporalValues` endpoint and aggregate at application layer
+- **BREAKING**: Changed entity ID unique constraint to `entityId` alone within tenant scope (#580)
+  - Changed index from `(tenant, servicePath, entityId, entityType)` to `(tenant, servicePath, entityId)`
+  - Creating entities with same ID but different type returns `409 AlreadyExists`
+  - Batch Upsert matches by `entityId` only (type can be overwritten)
+  - Removed NGSIv2 type disambiguation via `?type=` parameter
+  - Unified with NGSI-LD ID uniqueness semantics (GeonicDB proprietary extension)
+- **Feat**: Implemented tenant-level KMS CMK and Envelope Encryption (#553)
+  - Auto-generate AWS KMS CMK on tenant creation (when `encryptionEnabled: true` is set)
+  - Encrypt entity `attributes` fields with AES-256-GCM Envelope Encryption
+  - Data key cache (TTL/count/byte limits) for KMS API call optimization
+  - KMS key disable/deletion schedule on tenant deletion (Crypto-Shredding support)
+  - Backward-compatible coexistence of encrypted/non-encrypted tenants
+  - Encryption integration in Temporal/Snapshot repositories
+  - SAM template: KMS IAM policy, DynamoDB SSE settings, `EncryptionEnabled` parameter
+  - Added dependency: `@aws-sdk/client-kms`
 
 ### 2026-02-25
-- **Feat**: マルチリージョン HA アーキテクチャ Phase 1+2 (#557)
-  - Active-Passive 構成 (Primary: ap-northeast-1, Secondary: ap-northeast-3)
-  - ヘルスチェック強化: `/health`, `/health/live`, `/health/ready` に `region`, `regionRole` を追加
-  - `/health/ready` を DynamoDB/EventBridge 深層チェック対応に拡張 (Route 53 フェイルオーバー用)
-  - MongoDB クライアントに `readPreference`, `writeConcern`, `readConcern`, `retryWrites` の HA オプション追加
-  - EventBridge イベントに `sourceRegion` メタデータを自動注入
-  - Change Stream プロセッサのセカンダリリージョン自動無効化
-  - Secrets Manager 統合 (JWT シークレット / MongoDB URI の安全な管理)
-  - SAM テンプレート: `RegionRole` パラメータ、DynamoDB GlobalTable (3テーブル)、WAF、条件付きリソース
-  - Route 53 フェイルオーバースタック (`infrastructure/template-route53.yaml`)
-  - フェイルオーバー自動化 Lambda + SNS 通知
-  - 依存追加: `@aws-sdk/client-secrets-manager`, `@aws-sdk/client-sns`
-- **Feat**: テナント削除時の全関連データ連鎖削除を実装 (#556)
-  - `DELETE /admin/tenants/{tenantId}` で全16コレクションのテナントデータを連鎖削除
-  - Deactivate-first パターン: 削除前にテナントを自動的に `isActive: false` に設定
-  - ユーザー存在チェック撤廃: ユーザーが存在するテナントも一括削除可能に
-  - 削除順序: subscriptions → registrations → entities → snapshots → 設定 → 認証 → users → memberships
-  - 各コレクションの削除件数を監査ログに記録
-  - `TenantDataCleanupService` を独立サービスとして分離（Phase 2-3 Crypto-Shredding 拡張対応）
+- **Feat**: Multi-region HA architecture Phase 1+2 (#557)
+  - Active-Passive configuration (Primary: ap-northeast-1, Secondary: ap-northeast-3)
+  - Enhanced health checks: added `region`, `regionRole` to `/health`, `/health/live`, `/health/ready`
+  - Extended `/health/ready` for DynamoDB/EventBridge deep checks (for Route 53 failover)
+  - Added HA options to MongoDB client: `readPreference`, `writeConcern`, `readConcern`, `retryWrites`
+  - Auto-inject `sourceRegion` metadata in EventBridge events
+  - Auto-disable Change Stream processor in secondary region
+  - Secrets Manager integration (secure JWT secret/MongoDB URI management)
+  - SAM template: `RegionRole` parameter, DynamoDB GlobalTable (3 tables), WAF, conditional resources
+  - Route 53 failover stack (`infrastructure/template-route53.yaml`)
+  - Failover automation Lambda + SNS notifications
+  - Added dependencies: `@aws-sdk/client-secrets-manager`, `@aws-sdk/client-sns`
+- **Feat**: Implemented cascade deletion of all related data on tenant deletion (#556)
+  - Cascade delete tenant data from all 16 collections with `DELETE /admin/tenants/{tenantId}`
+  - Deactivate-first pattern: automatically set tenant to `isActive: false` before deletion
+  - Removed user existence check: tenants with users can now be deleted in bulk
+  - Deletion order: subscriptions → registrations → entities → snapshots → config → auth → users → memberships
+  - Record deletion count for each collection in audit log
+  - Separated `TenantDataCleanupService` as independent service (Phase 2-3 Crypto-Shredding extension support)
 
 ### 2026-02-24
-- **Feat**: ReactiveCore Rules に `appendToTemporal` アクションタイプを追加 (#549)
-  - エンティティ変更時にルールベースで Temporal API (Time Series Collection) へ自動追記
-  - `attributes` で記録対象の属性を明示的に指定可能（省略時は `changedAttributes` を使用）
-  - `TemporalService.recordEntityChange()` を内部的に呼び出し
+- **Feat**: Added `appendToTemporal` action type to ReactiveCore Rules (#549)
+  - Auto-append to Temporal API (Time Series Collection) based on rules when entity changes
+  - Explicitly specify recording target attributes with `attributes` (uses `changedAttributes` if omitted)
+  - Internally calls `TemporalService.recordEntityChange()`
 
 ### 2026-02-21
-- **Fix**: minimatch ReDoS 脆弱性を修正 (Dependabot #5) (#537)
-  - `minimatch` の npm override を追加し全インスタンスを `^10.2.1` に統一
-  - ajv@6.12.6 (eslint devDependency) は 6.x 系にパッチなし、tolerable_risk として dismiss
+- **Fix**: Fixed minimatch ReDoS vulnerability (Dependabot #5) (#537)
+  - Added npm override for `minimatch` to unify all instances to `^10.2.1`
+  - ajv@6.12.6 (eslint devDependency) has no patch in 6.x series, dismissed as tolerable_risk
 
 ### 2026-02-20
-- **Feat**: リソーススコープ付きトークン Phase 1 (#536)
-  - JWT にリソーススコープを埋め込み、エンティティタイプ/ID パターン/属性/操作レベルの細粒度アクセス制御を実現
-  - `POST /auth/login` に `resourceScopes` パラメータ追加
-  - OAuth `POST /oauth/token` に `resource_scopes` パラメータ追加
-  - 書き込み操作の事前チェック（`checkResourceScopes`）: 許可外のエンティティ書き込みを 403 で拒否
-  - 読み取りレスポンスの事後フィルタ（`filterByResourceScopes`）: 許可外のエンティティ/属性を除外
-  - 後方互換: `resourceScopes` なし = 従来通りフルアクセス
-- **Feat**: XACML ポリシー管理の tenant_admin 開放 (#531)
-  - `/admin/policies` と `/admin/policy-sets` を `tenant_admin` に開放
-  - ルーティング層の認証を `requireSuperAdminAuth` → `requireAdminAuth` に変更
-  - サービス層の既存テナントスコープ制御により安全に制限（自テナントのみ）
-  - `tenant_admin` が自テナントの `user` ロール向け XACML ポリシーを管理可能に
-- **Feat**: マルチテナントメンバーシップ + テナントスコープトークン (#527)
-  - FIWARE Keyrock Organization モデル準拠: 1ユーザーが複数テナントに所属可能
-  - `tenant_memberships` コレクション追加（`userId + tenantId` ユニーク制約）
-  - テナントメンバーシップ管理 API 4エンドポイント追加（PUT/DELETE/GET members, GET user tenants）
-  - テナントスコープログイン: `POST /auth/login` に `tenantId` パラメータ追加
-  - ユーザー作成時に自動メンバーシップ作成、テナント/ユーザー削除時にカスケード削除
-  - JWT `tenantId` 単一値を維持し、既存認可ミドルウェアへの影響ゼロ
-- **Feat**: `tenant_admin` が自テナント内のユーザー管理（CRUD）を実行可能に (#527)
-  - FIWARE Keyrock の Organization Owner と同等の権限委譲モデルを採用
-  - `/admin/users` パスの認証を `requireSuperAdminAuth` → `requireAdminAuth` に変更
-  - サービス層の既存権限チェック（`checkCanCreateUser` 等）により安全に制限
-  - `tenant_admin` は `user` ロールのみ作成可能（`super_admin` / `tenant_admin` 作成は 403）
-  - 他テナントのユーザーへの操作は禁止（既存のテナント分離ロジック）
+- **Feat**: Resource-scoped tokens Phase 1 (#536)
+  - Embed resource scopes in JWT for fine-grained access control at entity type/ID pattern/attribute/operation level
+  - Added `resourceScopes` parameter to `POST /auth/login`
+  - Added `resource_scopes` parameter to OAuth `POST /oauth/token`
+  - Pre-check for write operations (`checkResourceScopes`): reject unauthorized entity writes with 403
+  - Post-filter for read responses (`filterByResourceScopes`): exclude unauthorized entities/attributes
+  - Backward compatible: no `resourceScopes` = full access as before
+- **Feat**: Opened XACML policy management to tenant_admin (#531)
+  - Opened `/admin/policies` and `/admin/policy-sets` to `tenant_admin`
+  - Changed routing layer auth from `requireSuperAdminAuth` to `requireAdminAuth`
+  - Safely restricted by existing tenant scope control in service layer (own tenant only)
+  - `tenant_admin` can manage XACML policies for `user` role in own tenant
+- **Feat**: Multi-tenant membership + tenant-scoped tokens (#527)
+  - FIWARE Keyrock Organization model compliant: 1 user can belong to multiple tenants
+  - Added `tenant_memberships` collection (`userId + tenantId` unique constraint)
+  - Added 4 tenant membership management API endpoints (PUT/DELETE/GET members, GET user tenants)
+  - Tenant-scoped login: added `tenantId` parameter to `POST /auth/login`
+  - Auto-create membership on user creation, cascade delete on tenant/user deletion
+  - Maintain single `tenantId` value in JWT, zero impact on existing authz middleware
+- **Feat**: `tenant_admin` can perform user management (CRUD) within own tenant (#527)
+  - Adopted permission delegation model equivalent to FIWARE Keyrock Organization Owner
+  - Changed `/admin/users` path auth from `requireSuperAdminAuth` to `requireAdminAuth`
+  - Safely restricted by existing permission checks in service layer (`checkCanCreateUser` etc.)
+  - `tenant_admin` can only create `user` role (`super_admin` / `tenant_admin` creation returns 403)
+  - Operations on other tenant users are prohibited (existing tenant isolation logic)
 
 ### 2026-02-19
-- **Fix**: 認証付きローカルサーバー動作検証で発見されたバグ6件を修正 (#524)
-  - ローカルサーバーに `express.urlencoded()` ミドルウェアを追加（OAuth フォームエンコードリクエスト対応）
-  - XACML PDP の `matchFunction` 未指定時に glob パターン（`*` を含む matchValue）を自動検出するよう修正
-  - XACML XML インポートで AttributeDesignator の属性順序に依存しないパーサーに改修
-  - `PATCH /admin/policies/{policyId}` ルートを追加（405 → 200）
-  - OAuth クライアントレスポンスのフィールド名を `client_secret` → `clientSecret` に統一（Admin API camelCase 規約）
-  - ブルートフォース保護の `recordFailedAttempt()` からプログレッシブ遅延を削除（`checkLoginAllowed()` でのみ遅延を適用）
-- **Fix**: XACML 仕様準拠レビューで発見された不適合を修正 (#524)
-  - XACML エクスポートで glob matchFunction を `string-regexp-match` に正規表現変換して出力（XACML 3.0 に glob 関数は存在しないため）
-  - glob 自動検出を GeonicDB 独自拡張として明示的にドキュメント化
-- **Fix**: XACML ポリシー PDP の glob `/**` パターンがベースパス自体にマッチしないバグを修正
-  - `/v2/entities/**` が `/v2/entities` にマッチしなかった問題 — 標準 glob 仕様では `/**` は「0個以上のパスセグメント」を意味する
-  - `policy.pdp.ts` の glob 変換ロジックを `/.*` → `(/.*)?` に修正
-- **Test**: XACML セキュリティ E2E テスト 22 シナリオ追加（`xacml-security.feature`）
-  - バッチ操作・NGSI-LD 固有エンドポイント・PATCH/PUT/DELETE メソッド施行
-  - ポリシー無効化・動的変更・クロス API 漏洩防止
-  - ポリシー優先度競合・デフォルト決定エッジケース・email 属性制御
-  - `/rules` エンドポイント施行・テナント分離 + XACML 複合テスト
+- **Fix**: Fixed 6 bugs discovered in authenticated local server verification (#524)
+  - Added `express.urlencoded()` middleware to local server (OAuth form-encoded request support)
+  - Fixed XACML PDP to auto-detect glob patterns (matchValue containing `*`) when `matchFunction` is unspecified
+  - Improved XACML XML import parser to not depend on AttributeDesignator attribute order
+  - Added `PATCH /admin/policies/{policyId}` route (405 → 200)
+  - Unified OAuth client response field name from `client_secret` to `clientSecret` (Admin API camelCase convention)
+  - Removed progressive delay from brute-force protection `recordFailedAttempt()` (apply delay only in `checkLoginAllowed()`)
+- **Fix**: Fixed XACML spec compliance issues discovered in review (#524)
+  - Convert glob matchFunction to `string-regexp-match` regex in XACML export (no glob function exists in XACML 3.0)
+  - Explicitly documented glob auto-detection as GeonicDB proprietary extension
+- **Fix**: Fixed bug where XACML policy PDP glob `/**` pattern did not match base path itself
+  - `/v2/entities/**` did not match `/v2/entities` - standard glob spec defines `/**` as "zero or more path segments"
+  - Fixed glob conversion logic in `policy.pdp.ts` from `/.*` to `(/.*)?`
+- **Test**: Added 22 XACML security E2E test scenarios (`xacml-security.feature`)
+  - Batch operations, NGSI-LD specific endpoints, PATCH/PUT/DELETE method enforcement
+  - Policy disable, dynamic changes, cross-API leak prevention
+  - Policy priority conflicts, default decision edge cases, email attribute control
+  - `/rules` endpoint enforcement, tenant isolation + XACML composite tests
 
 ### 2026-02-18
-- **Fix**: E2Eテストで見逃された仕様準拠バグ10件を修正 (#520)
-  - **[BREAKING]** NGSIv2 `Fiware-Total-Count` ヘッダーが `options=count` 指定時のみ返されるよう修正（仕様: NGSIv2 spec "Pagination" section）(#520)
-  - **[BREAKING]** NGSI-LD `NGSILD-Results-Count` ヘッダーが `count=true` 指定時のみ返されるよう修正（仕様: ETSI GS CIM 009）(#520)
-  - NGSIv2 `POST /v2/op/query` に `options=values`/`options=unique` サポートを追加（仕様: NGSIv2 spec "Representation Formats"）(#520)
-  - NGSIv2 `POST /v2/op/query` に `orderBy` サポートを追加（仕様: NGSIv2 spec "Ordering Results"）(#520)
-  - NGSIv2 `POST /v2/op/query` に `expression.mq` サポートを追加（仕様: NGSIv2 spec "Batch Operations"）(#520)
-  - NGSIv2 `POST /v2/op/notify` を Zod スキーマバリデーションに移行（`Ngsiv2NotifySchema` 適用）(#520)
-  - NGSIv2 `GET /v2/types?options=values` がタイプ名文字列配列を返すよう修正（仕様: NGSIv2 spec "Entity Types"）(#520)
-  - NGSI-LD temporal controller の `AlreadyExistsError` → `AlreadyExistsLdError` に修正（仕様: ETSI GS CIM 009 §5.5.1）(#520)
-  - NGSI-LD コントローラーのエラータイプを ETSI 仕様に準拠: JSON パースエラーは `InvalidRequest`、データバリデーションエラーは `BadRequestData`（仕様: ETSI GS CIM 009 §5.5.1, Orion-LD/Stellio 互換）(#520)
-  - NGSI-LD batch 207 レスポンスの Content-Type を `application/json` に修正（仕様: ETSI GS CIM 009 §5.6.7/5.6.8）(#520)
+- **Fix**: Fixed 10 spec compliance bugs missed in E2E tests (#520)
+  - **[BREAKING]** Fixed NGSIv2 `Fiware-Total-Count` header to return only when `options=count` is specified (spec: NGSIv2 spec "Pagination" section) (#520)
+  - **[BREAKING]** Fixed NGSI-LD `NGSILD-Results-Count` header to return only when `count=true` is specified (spec: ETSI GS CIM 009) (#520)
+  - Added `options=values`/`options=unique` support to NGSIv2 `POST /v2/op/query` (spec: NGSIv2 spec "Representation Formats") (#520)
+  - Added `orderBy` support to NGSIv2 `POST /v2/op/query` (spec: NGSIv2 spec "Ordering Results") (#520)
+  - Added `expression.mq` support to NGSIv2 `POST /v2/op/query` (spec: NGSIv2 spec "Batch Operations") (#520)
+  - Migrated NGSIv2 `POST /v2/op/notify` to Zod schema validation (applied `Ngsiv2NotifySchema`) (#520)
+  - Fixed NGSIv2 `GET /v2/types?options=values` to return array of type name strings (spec: NGSIv2 spec "Entity Types") (#520)
+  - Fixed NGSI-LD temporal controller `AlreadyExistsError` to `AlreadyExistsLdError` (spec: ETSI GS CIM 009 §5.5.1) (#520)
+  - Made NGSI-LD controller error types spec-compliant: JSON parse errors are `InvalidRequest`, data validation errors are `BadRequestData` (spec: ETSI GS CIM 009 §5.5.1, Orion-LD/Stellio compatible) (#520)
+  - Fixed NGSI-LD batch 207 response Content-Type to `application/json` (spec: ETSI GS CIM 009 §5.6.7/5.6.8) (#520)
 
-- **Fix**: ReactiveCore Rules の条件評価でエンティティレベルフィールド（`id`, `type`）を `attributeName` に指定できるよう修正（Issue #513）(#516)
-  - `value` 条件と `pattern` 条件で `attributeName: "id"` / `"type"` をサポート (#516)
-  - PATCH 後にルールアクションが実行されない問題を解消 (#516)
-- **Security**: OWASP API Security 一括修正 — 8件のセキュリティ指摘対応 (#515)
-  - クロステナント Subscription 通知データ漏洩を修正 — `findMatchingSubscriptions` にテナントフィルタ追加 (#515)
-  - MCP ツールの OAuth スコープ検証・XACML 認可バイパスを修正 — `requireMcpScope` 追加、エンドポイントをレート制限後に移動 (#515)
-  - OAuth token エンドポイントにブルートフォース保護を追加 — `LoginProtectionService` を `clientId` ベースで適用 (#515)
-  - CSource 通知・Rule Webhook・Registration に DNS Rebinding 対策（`validateResolvedDns`）追加 (#515)
-  - `/admin/cadde`, `/admin/metrics`, `/rules`, `/custom-data-models` に OAuth スコープ要求を追加 (#515)
-  - PasswordSchema を `PASSWORD_POLICY.MIN_LENGTH` に統一、`SUPER_ADMIN_PASSWORD` 最低長チェック追加、WebSocket メッセージにトークン再検証追加 (#515)
-  - クエリパラメータにリソース制限追加 — IDリスト100件、ポリゴン頂点1000、クエリ条件50上限 (#515)
-  - Temporal/Federation の正規表現パターンに ReDoS 対策（`validateRegexPattern`）追加 (#515)
-- **Security**: OWASP API Security M-3〜M-7 — リソース枯渇・レート制限バイパス防止 (#495)
-  - Pagination offset 上限追加（MAX_OFFSET: 10000、API4対策）(M-3)
-  - Temporal API `timerel=between` の時間範囲上限追加（366日、API4対策）(M-4)
-  - OAuth scope ミドルウェアのセキュリティ設計を明確化（JWT RBAC/OAuth scope分離、API5対策）(M-5)
-  - Subscription throttling 最小値チェック追加（MIN_THROTTLING_SECONDS: 1、API6対策）(M-6)
-  - 通知の並行送信をチャンク化（MAX_CONCURRENT: 10、API4/API6対策）(M-7)
-- **Security**: SSRF脆弱性一括修正 — IPv4-mapped IPv6バイパス、DNS Rebinding、通知/コンテキストURL検証 (#490, #493, #495)
-  - IPv4-mapped/compatible IPv6アドレスによるSSRFバイパスを防止（`[::ffff:127.0.0.1]`等）(#490)
-  - IPv6 ULA（fc00::/7）アドレスをブロック対象に追加 (#490)
-  - `validateResolvedDns()` によるDNS Rebinding攻撃対策を追加 (#493)
-  - フェデレーション（Context Provider）のfetch前にDNS解決結果を検証 (#493)
-  - 通知送信（notifier）にSSRFバリデーションを追加、プライベートIPへの送信を阻止 (#495 M-1)
-  - NGSI-LD `@context` URLにdefense-in-depthバリデーションを追加 (#495 M-2)
-- **Tests**: SSRF防御のユニットテスト追加（IPv4-mapped IPv6、DNS Rebinding、通知SSRF）(#490, #493, #495)
-- **Tests**: E2Eシナリオ追加（IPv4-mapped IPv6 / ULAでのサブスクリプション・レジストレーション拒否）(#490)
-
-### 2026-02-17
-- **Security**: `validateExternalUrl` の SSRF バイパス脆弱性を修正 (#490)
-  - IPv4-mapped IPv6 アドレス（`[::ffff:127.0.0.1]` 等）による内部ネットワークアクセスをブロック
-  - 10進数/8進数/16進数 IPv4 表記のバイパスに対するテストを追加（Node.js URL パーサーの正規化で防御済み）
-  - IPv6 unique-local アドレス（`fc00::/7`）をブロック対象に追加
-- **Security**: template.yaml デフォルト値のセキュリティ強化 (#491)
-  - `AuthEnabled` のデフォルトを `false` → `true` に変更（認証デフォルト有効化）
-  - `AuthzDefaultDecision` のデフォルトを `Permit` → `Deny` に変更（fail-closed）
-  - `getAuthzDefaultDecision()` のフォールバックを `Deny` に変更（環境変数未設定時もfail-closed）
-  - `AUTH_ENABLED=false` 明示設定時に警告ログを出力
-- **Security**: 本番環境でのスタックトレース漏洩防止 (#494)
-  - `NODE_ENV=production` 時はエラーログからスタックトレースを除外
-  - クライアントレスポンスには内部情報を含めない（既存動作を維持）
-- **Security**: OWASP API Security Top 10:2023 監査指摘 MEDIUM 7件を修正 (#475, #476, #477, #478, #479, #481, #482)
-  - Policy/PolicySet のテナントスコープチェック追加（BOLA 対策, #475）
-  - ストレージクォータを作成時に強制（エンティティ/サブスクリプション/レジストレーション, #476）
-  - リクエストボディサイズのプラン別制限を強制（#477）
-  - `/admin/oauth-clients` に `requireScope('admin:oauth-clients')` を適用（BFLA 対策, #478）
-  - Webhook URL テンプレート置換後の SSRF 検証を追加（#479）
-  - `/statistics`, `/cache/statistics`, `/metrics` エンドポイントを認証必須化（#481）
-  - `/oauth/token` を API Gateway Event に登録（#482）
-- **Security**: OWASP API Security Top 10:2023 監査指摘の MEDIUM 4件を修正 (#474)
-  - JWT署名検証に `timingSafeEqual` を使用（タイミング攻撃防止）
-  - スーパー管理者パスワード比較に `timingSafeEqual` を使用（タイミング攻撃防止）
-  - XACMLポリシーの `string-regexp` マッチに ReDoS 検証を追加
-  - 予期しないエラーの内部メッセージ漏洩を防止（汎用メッセージに統一）
-- **Security**: Subscription/Registration オーナーシップ検証機能を追加（OWASP API1:2023 対策）(#467)
-  - `createdBy` フィールドによるリソースオーナーシップ追跡
-  - write操作（UPDATE/DELETE）時に作成者とリクエストユーザーを照合
-  - `super_admin`/`tenant_admin` はオーナーシップチェックをバイパス
-  - `createdBy` 未設定の既存データは後方互換で誰でも操作可能
-  - read操作（GET/LIST）は制限なし（NGSI仕様準拠のテナント隔離のみ）
-- **Tests**: オーナーシップ検証のユニットテスト追加（Subscription/Registration サービス）(#467)
-- **Tests**: オーナーシップ検証のE2Eテスト追加（ownership.feature: 4シナリオ）(#467)
-
-### 2026-02-16
-- **Security**: WebSocket認証トークンをURLクエリパラメータから`Authorization`ヘッダー / `Sec-WebSocket-Protocol`ヘッダーへ移行（#464）(#472)
-  - `Authorization: Bearer <token>` ヘッダー（推奨）
-  - `Sec-WebSocket-Protocol: access_token, <token>` ヘッダー（ブラウザクライアント向け）
-  - クエリパラメータは後方互換として維持（deprecation warning付き）
-- **Security**: レスポンスボディサイズ制限の適用（#466）(#472)
-  - テナントのクォータプラン別 `maxResponseBodyBytes` をAPIハンドラで強制
-  - 制限超過時に `ResponseTooLargeError` (413) を返却
-- **Security**: フェデレーション（Context Provider）レスポンスのスキーマ検証強化（#468）(#472)
-  - `Content-Length` ヘッダーによるレスポンスサイズ検証（上限5MB）
-  - JSONネスト深度制限（最大10階層）
-  - レスポンス内エンティティ数制限（最大1000件、超過分は切り詰め）
-- **Security**: トークン無効化（ブラックリスト）機能を追加（OWASP API2:2023 対策）(#460)
-  - `POST /auth/logout` エンドポイント追加（全セッション無効化）
-  - パスワード変更時に既存トークンを自動無効化
-  - ユーザー単位の無効化タイムスタンプ方式（DynamoDB / インメモリフォールバック）
-  - リフレッシュトークンの無効化チェック追加
-- **Security**: OWASP API2:2023 (Broken Authentication) 対応のブルートフォース保護機能を追加 (#459)
-  - メールアドレスベースのログイン試行回数追跡
-  - プログレッシブ遅延（2回目以降: 2秒→4秒→8秒）
-  - 自動アカウントロック（5回失敗後、60秒間ロック）
-  - ロック中は正しいパスワードでもログイン不可
-  - ログイン成功時にカウンターを自動リセット
-  - Lambda最適化: `429 Too Many Requests` + `Retry-After` ヘッダーで応答（sleep不使用）
-- **API**: `POST /admin/users/{userId}/unlock` エンドポイント追加（管理者によるロック解除）(#459)
-- **Infrastructure**: `loginAttempts` コレクション追加（email ユニークインデックス + TTL 自動クリーンアップ）(#459)
-- **Tests**: ユニットテスト追加（service, repository, controller, auth.service統合）、E2Eテスト追加（brute-force.feature）(#459)
-- **Security**: JWT `verifyToken()` に `alg` ヘッダー明示チェックを追加（`alg:none` 攻撃対策）(#462, #469)
-- **Security**: デフォルトパスワード最小長を 8→12 文字に強化（NIST SP 800-63B 準拠）(#463, #469)
-- **Security**: HTTP セキュリティヘッダー追加: `X-Content-Type-Options: nosniff`、`X-Frame-Options: DENY`、`Strict-Transport-Security`(#465, #469)
-- **Security**: フェデレーションリクエストに `redirect: manual` を設定し、リダイレクト先を `validateExternalUrl()` で SSRF 再検証（最大1回）(#461, #469)
-- **Feature**: デプロイメント設定の読み取り専用解決機能を追加 (#458)
-  - DynamoDB `geonicdb-deployments` テーブルからホスト名ベースのデプロイメント設定を取得
-  - キャッシュ付きService（5分TTL、ネガティブキャッシュ対応）
-  - DynamoDB障害時はnullフォールバックで既存動作を維持
-- **Feature**: `ConnectionManager` クラスを追加（マルチデータベース接続管理）(#458)
-- **Feature**: ホスト名抽出ミドルウェアをリクエストパイプラインに組み込み (#458)
-- **Infrastructure**: SAMテンプレートに `DeploymentsTable` DynamoDBリソースとIAMポリシーを追加 (#458)
-- **Security**: Admin APIエンドポイントにOAuthスコープベースのアクセス制御を追加 (#457)
-  - `admin:users` スコープでユーザー管理API (`/admin/users`) にアクセス可能
-  - `admin:tenants` スコープでテナント管理API (`/admin/tenants`) にアクセス可能
-  - `admin:policies` スコープでポリシー管理API (`/admin/policies`) にアクセス可能
-  - OAuthトークンはスコープベース、通常JWTはロールベースで後方互換性を維持
-- **Tests**: Admin routesスコープ強制ユニットテスト23件追加、E2Eの`@wip`タグ2件を解除 (#457)
-- **Feature**: GeonicDBをnpmパッケージとして利用可能に (#453)
-  - `createServer()` プログラマティックAPIでサーバーをプログラムから起動・停止
-  - `npx geonicdb` CLIコマンドでスタンドアロン起動
-  - `--proxy` オプションで非マッチURLをアプリ側dev serverに透過転送（URL重複時はGeonicDB優先）
-  - `--silent` オプションでコンソール出力抑制
-- **Build**: `tsc-alias` 導入でビルド時にパスエイリアスを相対パスに解決 (#453)
-- **Package**: `bin`, `types`, `files`, `peerDependencies` 設定でnpmパッケージ対応 (#453)
-
-### 2026-02-15
-- **Documentation**: `docs/INSTRUCTION.md` のカスタムデータモデルセクション（14.9）を大幅に拡充 (#445)
-  - `isActive` フラグの詳細な説明を追加（バリデーション、OpenAPI、一覧取得への影響）
-  - Smart Data Models との違いを明記（用途、バリデーション、管理方法の比較表）
-  - バリデーションの詳細とタイミングを追加（部分バリデーション、required チェック、エラー形式）
-  - 既存エンティティへの影響を説明（データモデル作成・更新時の挙動）
-  - 制限事項とベストプラクティスを追加（ReDoS 対策、推奨値、段階的ロールアウト）
-  - エラーハンドリングの詳細を追加（ステータスコード、409 Conflict、エラーメッセージの読み方）
-- **API**: `/admin/cadde` エンドポイント追加（GET/PUT/DELETE）(#439)
-- **Backend**: CADDE設定をMongoDB管理に移行、環境変数を廃止 (#439)
-- **MCP**: CADDE設定をconfig toolsに追加 (#439)
-- **Critical**: OpenAPI/メタ情報の完全欠落を修正 (#418)
-  - Snapshots API (7エンドポイント) を `meta.controller.ts` に追加
-  - Quotas/Usage API (3エンドポイント) を `meta.controller.ts` に追加
-  - APIドキュメント・OpenAPI仕様・AI Toolsドキュメントに反映
-- **Documentation**: NGSIv2 ドキュメント拡充 (`docs/API_NGSIV2.md`) (#418)
-  - `id`, `typePattern`, `options=upsert/append/keyValues` パラメータ追加
-  - HTTPエラー 411/413/422 のドキュメント追加
-  - `orderBy`/`metadata` の仕様差異を「GeonicDB 独自拡張」として明記
-- **Documentation**: NGSI-LD ドキュメント拡充 (`docs/API_NGSILD.md`) (#418)
-  - Multi-Attribute (datasetId) の全操作詳述 (CREATE/UPDATE/RETRIEVE/DELETE)
-  - Temporal API `lastN` パラメータ追加
-  - `id` 複数指定、`NGSILD-EntityMap` ヘッダー追加
-  - `NGSILD-Results-Count` ヘッダーの記述修正（「常に返却」）
-- **Documentation**: REACTIVCORE_RULES.md チュートリアル修正 (#418)
-  - 古い構文 (`trigger`/`action`) を正しい構文 (`conditions`/`actions`) に修正
-- **Testing**: instruction.feature 拡充 (31 → 46シナリオ) (#418)
-  - セクション10 (時系列データ管理) のテストシナリオ追加
-  - セクション5.4 (NGSIv2属性操作) のテストシナリオ追加
-  - セクション9.3 (バッチ全アクション) のテストシナリオ追加
-  - セクション3.7 (NGSI-LD q パラメータ検索) のテストシナリオ追加
-  - INSTRUCTION.md との整合性を60%から大幅に向上
-- **Testing**: spec-compliance.feature 拡充 (#418)
-  - NGSIv2: 4シナリオ追加 (orderBy, Subscription throttling, Batch appendStrict)
-  - NGSI-LD: 8シナリオ追加 (Multi-Attribute CRUD, Subscription/Registration PATCH, lastN)
-- **Bug Fix**: `api.json` temporal section のメソッド不整合修正 (#418)
-  - `/temporal/entities/{entityId}` に PATCH メソッド追加
-  - `/temporal/.../attrs/{attrName}/{instanceId}` に DELETE メソッド追加
-- **Bug Fix**: OpenAPI spec 修正 (#418)
-  - temporal attribute instance の DELETE operation 追加
-  - 未定義タグ4件追加 (NGSI-LD Attributes, Info, JSON-LD Context Management, Rules)
-- **Bug Fix**: コメント・パス参照修正 (#418)
-  - `rules.feature`: `docs/RULES.md` → `docs/REACTIVCORE_RULES.md`
-  - `instruction.feature`: セクション番号ずれ修正
-- **Bug Fix**: NGSIv2 appendStrict 仕様準拠修正 (#418)
-  - 既存属性を含む場合に422 Unprocessableを返すように修正（仕様準拠）
-  - 従来は既存属性を黙って上書きする仕様違反の動作だった
-  - バッチ操作の全件失敗時に422を返すように修正
-  - 仕様違反のテストを削除、仕様準拠のテストを追加
-- **Bug Fix**: Change Stream の watch オプションに `fullDocument: 'updateLookup'` を追加 (#442)
-  - update 操作時に `fullDocument: null` となりルールエンジンが発火しなかった問題を修正
-  - `src/local-server.ts`（ローカル開発サーバー）と `src/handlers/streams/change-stream.ts`（Lambda ハンドラー）の両方を修正
-  - ユニットテストに `fullDocument: 'updateLookup'` オプションの検証を追加
-- **Testing**: ユニットテストカバレッジを大幅に向上 (#440)
-  - Lines: 90.97% → 99.08%（+8.11ポイント）
-  - Statements: 90.68% → 98.84%（+8.16ポイント）
-  - Branches: 84.05% → 93.99%（+9.94ポイント）
-  - Functions: 91.75% → 96.88%（+5.13ポイント）
-  - テスト数: 6015件（200スイート）
-- **Testing**: 新規テストファイル追加 (#440)
-  - Admin API: tenants, policies, metrics, users, oauth-clients コントローラーテスト、routes テスト
-  - MCP: entity.tools, batch.tools, config.tools, admin.tools テスト拡充
-  - NGSI-LD: tiles, attributes, types, entity-maps, snapshots コントローラーテスト拡充
-  - NGSIv2: tiles コントローラーテスト、entities.controller 追加カバレッジ
-  - Core: rules, subscriptions, custom-data-models, auth, geo, temporal サービステスト拡充
-  - Handlers: matcher, notifier テスト拡充
-  - Infrastructure: template-parser, mqtt client, audit logger テスト拡充
-- **Documentation**: CLAUDE.md にカバレッジ検証の必須チェックリストを追加 (#440)
-  - Pre-Push Verification セクション追加
-  - Documentation Update Checklist にカバレッジ検証を追加
-  - Endpoint Implementation Checklist にカバレッジ確認ステップを追加
-- **依存関係**: `eslint` を 9.39.2 → 10.0.0 にメジャーアップグレード (#438)
-- **依存関係**: `typescript-eslint` を 8.55.0 → 8.55.1-alpha.4 に更新（ESLint 10 対応 canary 版）(#438)
-- **依存関係**: `@typescript-eslint/eslint-plugin`、`@typescript-eslint/parser` を直接依存から削除（`typescript-eslint` ラッパーに統合）(#438)
-
-### 2026-02-14
-- **Infrastructure**: Lambda Runtime を `nodejs20.x` → `nodejs24.x` に更新（Node.js 24 LTS に統一）(#437)
-- **CI**: Dependabot で `@types/node` のメジャーバージョンアップを抑制（LTS以外への更新を防止）(#437)
-- **Branding**: プロダクト名を VelaOS から GeonicDB に変更 (#436)
-  - ソースコード、ドキュメント、テスト全体のリネーム
-  - Prometheus メトリクスプレフィックス: `vela_` → `geonicdb_`
-  - DynamoDB テーブル名デフォルト: `vela-rate-limits` → `geonicdb-rate-limits`
-  - GitHub リポジトリ URL: `geolonia/vela` → `geolonia/geonicdb`
-- **依存関係**: AWS SDK グループを 3.985.0 → 3.990.0 に更新 (#435)
-  - `@aws-sdk/client-apigatewaymanagementapi`, `client-dynamodb`, `client-eventbridge`, `client-sqs`, `lib-dynamodb`
-- **依存関係**: OpenTelemetry グループを更新 (#435)
-  - `sdk-node` 0.211.0 → 0.212.0, `exporter-trace-otlp-http` 0.211.0 → 0.212.0
-  - `sdk-trace-base`, `resources`, `context-async-hooks` 2.5.0 → 2.5.1
-- **依存関係**: `typescript-eslint` グループを 8.54.0 → 8.55.0 に更新 (#435)
-- **依存関係**: `@types/node` を 25.2.2 → 24.10.13 にダウングレード（Node 24 ランタイムに合わせて v24 系に変更）(#435)
-- **Changed**: プロジェクトライセンスを GPL-3.0 から AGPL-3.0 に変更 (#424)
-  - `LICENSE.md` を AGPL-3.0 全文に差替え
-  - 全ソースファイル（530+ファイル）のライセンスヘッダーを一括更新
-  - `package.json`、`README.md`、`CLAUDE.md`、各ドキュメントのライセンス記述を更新
-  - OpenAPI仕様のライセンス情報を更新
-  - E2Eテストのライセンス検証シナリオを更新
-- **Enhancement**: ローカル開発サーバーのポートを柔軟に設定可能に (#423)
-  - `--port` CLI引数対応（`npm start -- --port 3001`）
-  - `PORT` 環境変数対応（`PORT=3001 npm start`）
-  - デフォルトポート（3000）が使用中の場合、自動的に空きポートを選択（最大10ポート探索）
-  - ポートフォールバック時にコンソールへ警告メッセージを表示
-  - git worktree との併用で複数インスタンスの同時起動が可能に
-- **Added**: CEL式でカスタム関数 `distance()`, `within()`, `now()`, `dayOfWeek()` を利用可能に (#422)
-  - `distance(location1, location2)` — Haversine formula による2点間距離計算（メートル）
-  - `within(location, polygon)` — Ray casting による Point-in-Polygon 判定
-  - `now()` — 現在UTC時刻（ISO 8601文字列）
-  - `dayOfWeek()` — 現在の曜日（0=日〜6=土、UTCベース）
-- **Changed**: CEL評価を `evaluate()` から `Environment` ベースに切り替え、カスタム関数登録に対応 (#422)
-- **Documentation**: `docs/REACTIVCORE_RULES.md` にカスタム関数の仕様・使用例を追加 (#422)
-- **Testing**: ユニットテスト32件、E2Eテスト5シナリオを追加 (#422)
-- **Feature**: テナントごとに独自の IP アドレス制限を設定可能に (#395)
-  - GET/PUT/DELETE `/admin/tenants/:tenantId/ip-restrictions` エンドポイント追加
-  - `admin`（管理APIのみ）と `all`（全API）の2つのスコープに対応
-  - テナント設定未設定時はグローバル設定（`ADMIN_ALLOWED_IPS`）にフォールバック
-  - 既存の認証ミドルウェアをテナント対応に更新
-- **Added**: ReactiveCore Rules に CEL (Common Expression Language) 式条件タイプを追加 (#387)
-  - `celExpression` 条件タイプ: 複雑な計算、文字列操作、複数属性評価が可能
-  - CEL コンテキスト変数: `entity.id`, `entity.type`, `attribute.<name>.value`, `attribute.<name>.type`
-  - 式の最大長制限 (1000文字)、構文バリデーション、非 boolean 結果のハンドリング
-  - `@marcbachmann/cel-js` ライブラリ使用 (ゼロ依存、TypeScript 対応)
-- **OpenAPI**: `CelExpressionCondition` スキーマを `/openapi.json` に追加 (#387)
-- **Documentation**: `docs/REACTIVCORE_RULES.md` に CEL 式条件の仕様・使用例を追加 (#387)
-
-### 2026-02-13
-- **Documentation**: ReactiveCore Rules に不快指数（DI）による熱中症アラート通知の使用例を追加 (#419)
-  - `docs/REACTIVCORE_RULES.md` — 例6: CEL式による不快指数計算、sendNotification/Webhookアクション
-  - `docs/INSTRUCTION.md` — セクション13.7 例4: ステップバイステップの導入手順
-- **Testing**: 不快指数アラートのE2Eテストシナリオを7件追加（`@rules-discomfort-index`タグ）(#419)
-  - WARNING（DI > 75）/DANGER（DI > 80）レベルのルール実行テスト
-  - 閾値以下でのルール非トリガー確認
-  - 優先度制御と範囲条件（75 < DI <= 80）の動作確認
-  - sendNotification/webhookアクションの構成検証
-- **Added**: CADDEコネクタv4 API エンドポイントを追加 (#409)
-  - `GET /cadde/api/v4/catalog` — カタログ検索（横断検索/詳細検索）
-  - `GET /cadde/api/v4/entities` — NGSIデータ交換（NGSIv2/NGSI-LD形式対応）
-- **Added**: カタログ横断検索（`x-cadde-search: meta`）— キーワードフィルタ付きCKAN形式レスポンス (#409)
-- **Added**: カタログ詳細検索（`x-cadde-search: detail`）— データセット個別取得 (#409)
-- **Added**: CADDE固有メタデータフィールド（`caddec_dataset_id_for_detail`、`caddec_provider_id`、`caddec_resource_type`）(#409)
-- **Added**: `x-cadde-resource-url` からクエリパラメータ解析によるエンティティ取得 (#409)
-- **Added**: `x-cadde-resource-api-type` による NGSIv2/NGSI-LD レスポンス形式切替 (#409)
-- **Added**: CADDE v4エンドポイントの来歴ヘッダー（provenance headers）付与 (#409)
-- **Added**: CADDEエラーレスポンス形式（`{ detail, status }`）(#409)
-- **Added**: `x-cadde-search` ヘッダー定数を `CADDE_HEADERS` に追加 (#409)
-- **Infrastructure**: SAM テンプレートに CADDE v4 APIルートを追加 (#409)
-- **OpenAPI**: `/openapi.json` に Rule Engine の詳細スキーマを追加 (#410)
-  - `RulePublic`、`CreateRuleInput`、`UpdateRuleInput` スキーマを追加
-  - `RuleCondition`（8種類の条件型）、`RuleAction`（5種類のアクション型）スキーマを追加
-  - `/rules` 系エンドポイントの定義を `$ref` によるスキーマ参照に更新
-- **BREAKING CHANGE**: カスタムデータモデル管理エンドポイントを `/admin/data-models` から `/custom-data-models` に変更 (#376)
-  - テナント固有のリソースのため Admin API から独立した API として再編成
-  - ルートパスの変更に伴い、エンドポイントは `/custom-data-models` および `/custom-data-models/:type` に
-- **BREAKING CHANGE**: Phase 2 の自動生成機能（`POST /admin/data-models/generate`）を削除 (#376)
-  - AI ツールを使った生成機能は Phase 3 で再設計予定
-- **Changed**: 認証・認可の変更 (#376)
-  - `requireAdminAuth()` から `requireAuth()` + XACML ポリシーベース認可に変更
-  - `tenant_admin` および `user` ロールもテナント内のカスタムデータモデルを管理可能（ポリシー設定による）
-- **Added**: カスタムデータモデル管理機能 Phase 1 (#376)
-  - `GET /custom-data-models` - データモデル一覧取得
-  - `POST /custom-data-models` - データモデル作成
-  - `GET /custom-data-models/:type` - データモデル取得
-  - `PATCH /custom-data-models/:type` - データモデル更新
-  - `DELETE /custom-data-models/:type` - データモデル削除
-  - テナントごとに独自のデータモデルを定義可能
-  - Version 管理機能（作成時 = 1、更新時に自動インクリメント）
-  - 19 種類の既存 Smart Data Models に加えて、カスタムデータモデルをサポート
-- **Added**: ExtendedPropertyDetail 型定義 - PropertyDetail を拡張し defaultValue、validation、indexed をサポート (#376)
-- **Added**: MCP ツールに custom data models 統合 (#376)
-  - `config` ツールの `data_models` リソースに新アクション追加
-  - list, get, create, update, delete（認証必須）
-  - Smart Data Models（カタログ）とカスタムデータモデル（テナント固有）を統合検索
-- **Added**: Phase 3 - エンティティバリデーション・@context 解決拡張・JSON Schema 生成 (#376)
-  - カスタムデータモデルに基づくエンティティの自動バリデーション（作成・更新時）
-  - 型チェック（string, number, integer, boolean, array, object, GeoJSON）
-  - バリデーションルール: minLength, maxLength, minimum, maximum, pattern, enum
-  - 必須フィールド（`required`）チェック
-  - NGSI-LD @context 解決をカスタムデータモデルの `contextUrl` に拡張
-  - カスタムデータモデルから JSON Schema (Draft 2020-12) を自動生成
-  - `jsonSchema` フィールドをカスタムデータモデルレスポンスに追加
-- **Added**: Phase 4 - エンティティテンプレート生成・OpenAPI 動的統合 (#376)
-  - MCP `config` ツールに `generate_template` アクション追加 - カスタムデータモデルからエンティティテンプレートを自動生成
-  - テンプレートは `defaultValue`、`example`、`valueType` に基づきプレースホルダ値を含む NGSI-LD 形式で生成
-  - `contextUrl` が定義されている場合は `@context` も自動付与
-  - OpenAPI 仕様 (`/openapi.json`) にカスタムデータモデルの JSON Schema を動的統合
-  - 認証済みユーザーのテナントに紐づくアクティブなカスタムデータモデルが `components/schemas` に自動追加
-- **Tests**: E2E テスト 7 シナリオ追加（CRUD、ページネーション、権限、テナント分離、バリデーション、フィルタリング、バージョニング）(#376)
-
-### 2026-02-11
-- **Documentation**: ドキュメントを30ファイルから17ファイルに統合（43%削減）(#405)
-  - PAGINATION.md、STATUS_CODES.md、DEPLOYMENT.md を DEVELOPMENT.md に統合
-  - WEBAPP_INTEGRATION.md を EVENT_STREAMING.md に統合
-  - CATALOG.md、TELEMETRY.md を INTEGRATIONS.md に統合
-  - AUTH_ADMIN.md、AUTH_OAUTH.md、AUTH_SCENARIOS.md を AUTH.md に統合
-  - API_ENDPOINTS*.md を API.md、API_NGSIV2.md、API_NGSILD.md に統合
-  - RULES.md を REACTIVCORE_RULES.md にリネーム
-  - SUBSCRIPTIONS.md を新規作成 - HTTP/MQTT 通知の実践例を含む包括的ガイド
-- **BREAKING**: `AUTHZ_ENABLED` 環境変数を削除。XACMLポリシー評価は `AUTH_ENABLED=true` の場合に自動的に有効化されるよう変更 (#403)
-- **Changed**: `/rules` エンドポイントは `AUTH_ENABLED` 設定に関わらずアクセス可能に（`/v2/*` および `/ngsi-ld/*` エンドポイントと同様）(#403)
-
-### 2026-02-10
-- **MCP**: MCP ツール構造を再編成 - 8ツールから5ツールに統合して保守性を向上 (#402)
-- `rules` と `contexts`（JSON-LD コンテキストと Smart Data Models）を新しい `config` ツールに移動 (#402)
-- `admin` ツールはユーザー、テナント、ポリシーの管理のみに集中 (#402)
-
-### 2026-02-08
-- **BREAKING**: Rules API を `/admin/rules` から `/rules` に移動し、XACML ベースの認可を導入 (#401)
-- Rules エンドポイントはロールベース認証ではなく XACML ポリシーで保護されるようになり、きめ細かなアクセス制御が可能に (#401)
-
-### 2026-02-07
-- **Documentation**: GeonicDB 取扱説明書（docs/INSTRUCTION.md）を追加 (#400)
-- PDF 生成スクリプトを追加（`npm run docs:pdf`）(#400)
-- INSTRUCTION.md の全サンプルを検証する E2E テスト（tests/e2e/features/common/instruction.feature）を追加 (#400)
-
-### 2026-02-05
-- **Fixed**: ローカルサーバーの MongoDB シャットダウン時のエラーメッセージを抑制 (#394)
-
-### 2026-02-04
-- **Changed**: バージョン番号を集約し、package.json からインポートするよう変更 (#393)
-
-### 2026-02-03
-- **Added**: MCP (Model Context Protocol) サーバー統合 (#392)
-  - AI 駆動型エンティティ管理のための5つの統合ツール
-  - エンティティ CRUD 操作
-  - バッチ操作
-  - 時系列クエリ
-  - JSON-LD コンテキスト管理
-  - 管理操作
-
-### 2026-02-02
-- **Fixed**: クォータシステムのバグ修正 (#391)
-  - Retry-After ヘッダーの修正
-  - 負数カウントバイパスの修正
-  - 時間単位の不一致を解決
-
-### 2026-02-01
-- **Added**: ReactiveCore Rules - パターンマッチング、条件式、アクションを備えた自動エンティティ処理ルールエンジン (#389)
-  - エンティティタイプ、ID、属性名のパターンマッチング
-  - 論理演算子（AND/OR）を使用した条件式
-  - 複数のアクション: createEntity、updateEntity、deleteEntity、sendNotification
-  - 無限ループ防止機構
-  - リアルタイムイベント処理のための Change Stream 統合
-  - `npm start` によるローカルテストサポート
-
-### 2026-01-28
-- **Documentation**: 包括的な AWS デプロイ手順を含む DEPLOYMENT.md を追加 (#382)
-
-### 2026-01-25
-- **Added**: Smart Data Models サポートを強化 (#373)
-  - プロパティ詳細を含む19の標準データモデル
-  - AI 駆動型エンティティ作成ガイダンス
-  - 全モデルの propertyDetails メタデータ
-
-### 2026-01-24
-- **Documentation**: 新規ユーザー向け QUICKSTART.md ガイドを追加 (#372)
-
-### 2026-01-23
-- **Fixed**: NGSI-LD スキーマ検証を強化 (#370)
-
-### 2026-01-22
-- **Security**: エンティティ ID（256文字）、タイプ（256文字）、属性名（256文字）の長さ制限を追加 (#369)
-
-### 2026-01-20
-- **Fixed**: NGSI-LD URI パターンの不整合を解決 (#364)
-
-### 2026-01-18
-- **Added**: 全 API エンドポイントの Zod v4 ランタイム型検証を追加 (#358)
-
-### 2026-01-17
-- **Changed**: 設定値を `src/config/defaults.ts` に集約 (#357)
-
-### 2026-01-16
-- **Added**: SaaS ローンチ向けの包括的なクォータシステム (#356)
-  - リクエストクォータ（レート制限、日次/月次制限）
-  - ストレージクォータ（エンティティ/属性数）
-  - DynamoDB によるリアルタイム監視
-  - テナント固有のクォータ設定
-  - レート制限レスポンスの Retry-After ヘッダー
-
-### 初期実装（〜2026-01-15）
-- GeonicDB 初回実装 - AWS Lambda 上で動作する FIWARE Orion 互換 Context Broker
-- NGSIv2 API 実装
-  - エンティティ CRUD 操作
-  - サブスクリプション
-  - レジストレーション
-  - バッチ操作
-  - クエリ言語サポート（q、mq パラメータ）
-- NGSI-LD API 実装
-  - エンティティ操作
-  - サブスクリプション
-  - コンテキストソースレジストレーション
-  - バッチ操作
-  - クエリ言語サポート（q、scopeQ、pick、omit、lang パラメータ）
-- NGSIv2 と NGSI-LD API 間の完全な相互運用性
-- Fiware-Service ヘッダーによるマルチテナンシーサポート
-- コンテキストプロバイダ転送によるフェデレーション機能
-- 空間 ID を使用した地理空間クエリサポート
-- JWT 認証・認可
-- テナントおよびユーザー管理のための管理 API
-- レプリカセット対応の MongoDB ストレージ
-- SAM テンプレートによる AWS Lambda デプロイ
-- サブスクリプションマッチングのための EventBridge 統合
-- 通知配信のための SQS FIFO キュー
-- 通知のための MQTT サポート
-- 包括的な E2E テストスイート（Cucumber.js）
-- 単体テストカバレッジ 〜99%（Jest）
-- インメモリ MongoDB を使用したローカル開発サーバー（`npm start`）
-- Node.js 要件: >=24.13.0
-- MongoDB 要件: 7.1.0
-- テストフレームワーク: Cucumber.js（Gherkin 日本語）
-- ベクタータイル生成 API
-- 時系列データの Temporal API
-- エンティティスナップショット機能
-- JSON-LD コンテキスト管理
-- データカタログ API（CKAN/DCAT 互換）
-- CADDE（データ連携）サービス統合
-- セキュリティ強化のためのテナント単位の IP ホワイトリスト
-- ReDoS（正規表現サービス拒否）防止
-- 全 API エンドポイントの入力検証
-
+### 2026-02-18
+- **Fix**: Fixed ReactiveCore Rules condition evaluation to allow entity-level fields (`id`, `type`) in `attributeName` (Issue #513) (#516)
+  - Support `attributeName: "id"` / `"type"` in `value` and `pattern` conditions (#516)
+  - Fixed issue where rule actions were not executed after PATCH (#516)
+- **Security**: OWASP API Security batch fix - addressed 8 security issues (#515)
+  - Fixed cross-tenant Subscription notification data leak - added tenant filter to `findMatchingSubscriptions` (#515)
+  - Fixed MCP tool OAuth scope validation and XACML authz bypass - added `requireMcpScope`, moved endpoints after rate limiting (#515)
+  - Added brute-force protection to OAuth token endpoint - applied `LoginProtectionService` based on `clientId` (#515)
+  - Added DNS Rebinding protection (`validateResolvedDns`) to CSource notifications, Rule Webhooks, Registration (#515)
+  - Added OAuth scope requirements to `/admin/cadde`, `/admin/metrics`, `/rules`, `/custom-data-models` (#515)
+  - Unified PasswordSchema to `PASSWORD_POLICY.MIN_LENGTH`, added `SUPER_ADMIN_PASSWORD` minimum length check, added token revalidation to WebSocket messages (#515)
+  - Added resource limits to query parameters - ID list 100 items, polygon vertices 1000, query conditions 50 max (#515)
+  - Added ReDoS protection (`validateRegexPattern`) to Temporal/Federation regex patterns (#515)


### PR DESCRIPTION
Closes https://github.com/geolonia/geonicdb-docs/issues/115

## 変更内容

- **docs/en/changelog.md**: 上流 `geolonia/geonicdb` の CHANGELOG.md（日本語）が sync-geonicdb-docs.ts によって直接コピーされていたため、英語ファイルに日本語コンテンツが混入していた問題を修正。全文を英語翻訳に置換
- **CHANGELOG.md**: 修正エントリを追加

## PR#103 CR Thread 対応

| Thread | ファイル | 対応 |
|--------|---------|------|
| Thread 1-3 | docs/ja/ai-integration/*.md (パス改行欠落) | 次回 sync run で再評価（返信済み） |
| Thread 4 | docs/ja/getting-started/installation.md | cmd_340 PR#109 で削除済・自動解決（返信済み） |
| Thread 5 | docs/ja/changelog.md (構造崩れ) | 次回 sync run で再評価（返信済み） |
| Thread 6 | **docs/en/changelog.md (日本語混入)** | **本 PR で即修正** |
| Thread 7 | docs/ja/changelog.md (%%LIST 混入) | 次回 sync run で再評価（返信済み） |

## 根本原因

1. 上流 `geolonia/geonicdb` の `CHANGELOG.md` は全て日本語で記述されている
2. `sync-geonicdb-docs.ts` は「Source docs (English) are copied to docs/en/」と前提しているが、CHANGELOG.md は日本語
3. CHANGELOG.md の `nonAsciiThreshold: 0.40` が緩すぎて P-A5 チェックを通過

## 検証

- `grep -P '[\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}]' docs/en/changelog.md` → 0件確認
- `npm test` → 126 tests passed, 0 skipped