### PR TITLE
fix: MAPPING_TABLE 孤児エントリ削除（DEVELOPMENT/DEPLOYMENT）— cmd_340 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - feat(docs): SaaS 中心 docs 再編 Phase 1 — docs/{en,ja}/getting-started/installation.md 削除、VitePress config GitHub 関連削除（socialLinks / nav GitHub / sidebar Installation）、index.md hero CTA → Sign Up(brand)/Quick Start/API Reference、changelog GitHub compare/tag URL 削除、本文 git clone / GitHub URL 削除（orion-to-geonicdb.md は Phase 2 範囲ゆえ除外）(Closes #108)
 
 ### Fixed
+- fix: MAPPING_TABLE から DEVELOPMENT.md / DEPLOYMENT.md 孤児エントリ削除（cmd_340 hotfix）(Closes #121)
 - fix: docs/en/changelog.md 日本語混入修正（PR#103 残存 CR Thread 6 対応）(Closes #115)
 - fix(translate-pipeline): SF2 embedded fence cascade violations — `fixEmbeddedFences` in `fix-doc-quality.ts` detects and splits `prose```lang` merged lines (`.```[a-z]` pattern); applied as pre-fix in `fixBareCodeBlocks` and as post-process in `translate-protected.ts` after restore steps. `ensureFenceSpacing` pre-processes input to insert blank lines before code fence starts at chunk boundaries, preventing LLM merging. Eliminates bare block cascade violations seen in PR#97. (Closes #104)
 

--- a/scripts/sync-geonicdb-docs.ts
+++ b/scripts/sync-geonicdb-docs.ts
@@ -114,9 +114,6 @@ const MAPPING_TABLE: Record<string, MappingEntry[]> = {
   'STATUS_CODES.md': [
     { dest: 'api-reference/status-codes.md', title: 'Status Codes', description: 'API response status codes' },
   ],
-  'DEVELOPMENT.md': [
-    { dest: 'getting-started/installation.md', title: 'Developer Guide', description: 'Development environment setup and installation' },
-  ],
   'DEMO_SCENARIO.md': [
     { dest: 'getting-started/demo-app.md', title: 'Demo App', description: 'Demo scenarios and apps' },
     { dest: 'getting-started/first-entity.md', title: 'First Entity', description: 'Entity CRUD tutorial' },
@@ -126,9 +123,6 @@ const MAPPING_TABLE: Record<string, MappingEntry[]> = {
   ],
   'FAQ.md': [
     { dest: 'faq.md', title: 'FAQ', description: 'Frequently asked questions' },
-  ],
-  'DEPLOYMENT.md': [
-    { dest: 'getting-started/deployment.md', title: 'Deployment', description: 'Deployment guide' },
   ],
   'TELEMETRY.md': [
     { dest: 'features/telemetry.md', title: 'Telemetry', description: 'OpenTelemetry support' },


### PR DESCRIPTION
Closes https://github.com/geolonia/geonicdb-docs/issues/121

## 変更内容
- `scripts/sync-geonicdb-docs.ts`: MAPPING_TABLE から `DEVELOPMENT.md` / `DEPLOYMENT.md` 孤児エントリ削除

## 背景
cmd_340 Phase 1 (PR#109) で `installation.md` 等を削除したが MAPPING_TABLE が未修正。
手動 sync run 25241755960 で `installation.md` 復活を確認（HF3 validateCodeBlocks で防御済）。
本 PR でシンク実行時にファイルが再生成される設計欠陥を解消する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* APIリファレンスにHTTPステータスコード情報を新規追加しました
* ドキュメント同期の設定を改善し、不要なマッピングを削除

## バグ修正
* ドキュメント同期設定から孤立したエントリを削除しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->