### PR TITLE
fix: PR#127 CR Minor 後追い — tenant-admin-user.md ステップ重複解消 + ::: details 空行修正（cmd_356）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - feat(docs): SaaS 中心 docs 再編 Phase 1 — docs/{en,ja}/getting-started/installation.md 削除、VitePress config GitHub 関連削除（socialLinks / nav GitHub / sidebar Installation）、index.md hero CTA → Sign Up(brand)/Quick Start/API Reference、changelog GitHub compare/tag URL 削除、本文 git clone / GitHub URL 削除（orion-to-geonicdb.md は Phase 2 範囲ゆえ除外）(Closes #108)
 
 ### Fixed
+- fix: PR#127 CR Minor 後追い — tenant-admin-user.md ステップ重複解消 + ::: details 空行修正（cmd_356）(Closes #129)
 - fix: MAPPING_TABLE から DEVELOPMENT.md / DEPLOYMENT.md 孤児エントリ削除（cmd_340 hotfix）(Closes #121)
 - fix: docs/en/changelog.md 日本語混入修正（PR#103 残存 CR Thread 6 対応）(Closes #115)
 - fix(translate-pipeline): SF2 embedded fence cascade violations — `fixEmbeddedFences` in `fix-doc-quality.ts` detects and splits `prose```lang` merged lines (`.```[a-z]` pattern); applied as pre-fix in `fixBareCodeBlocks` and as post-process in `translate-protected.ts` after restore steps. `ensureFenceSpacing` pre-processes input to insert blank lines before code fence starts at chunk boundaries, preventing LLM merging. Eliminates bare block cascade violations seen in PR#97. (Closes #104)

--- a/docs/en/saas/tenant-admin-user.md
+++ b/docs/en/saas/tenant-admin-user.md
@@ -10,7 +10,7 @@ Step 4 of the SaaS onboarding flow: use the `geonic` CLI to create a tenant and 
 
 ::: tip Step 4 of the SaaS onboarding flow
 1. ~~[Contact Sales](/en/saas/sign-up)~~
-2. ~~[Geolonia contacts you + credentials delivered](/en/saas/onboarding)~~
+2. ~~[Geolonia contacts you (review & approval)](/en/saas/onboarding)~~
 3. ~~Account credentials delivered~~
 4. **Create a tenant admin user** ← *you are here*
 5. [Create an API key](/en/saas/api-key)

--- a/docs/ja/saas/tenant-admin-user.md
+++ b/docs/ja/saas/tenant-admin-user.md
@@ -10,7 +10,7 @@ SaaS オンボーディングフローのステップ 4：`geonic` CLI を使用
 
 ::: tip SaaS オンボーディングフローのステップ 4
 1. ~~[Contact Sales（お問い合わせ）](/ja/saas/sign-up)~~
-2. ~~[Geolonia からの連絡 + 認証情報の提供](/ja/saas/onboarding)~~
+2. ~~[Geolonia からの連絡](/ja/saas/onboarding)~~
 3. ~~アカウント情報の提供~~
 4. **テナント管理ユーザーの作成** ← *現在のステップ*
 5. [API キーの作成](/ja/saas/api-key)
@@ -80,10 +80,12 @@ geonic admin tenants list
 ```
 
 ::: details テナント作成でエラーが出た場合
+
 | エラー | 原因 | 対処 |
 |-------|------|------|
 | `401 Unauthorized` | 認証トークンが無効または期限切れ | `geonic auth login` で再ログイン |
 | `409 Conflict` | 同じ ID のテナントが既に存在する | 別のテナント ID を使用するか、既存テナントを確認 |
+
 :::
 
 ## テナント管理ユーザーの作成
@@ -125,11 +127,13 @@ geonic admin users list
 ```
 
 ::: details ユーザー作成でエラーが出た場合
+
 | エラー | 原因 | 対処 |
 |-------|------|------|
 | `401 Unauthorized` | 認証トークンが無効または期限切れ | `geonic auth login` で再ログイン |
 | `409 Conflict` | 同じユーザー名が既に存在する | 別のユーザー名を使用するか、既存ユーザーを確認 |
 | `400 Bad Request` | リクエスト形式が不正（JSON 構文エラー等） | JSON の形式を確認してから再実行 |
+
 :::
 
 ## 次のステップ


### PR DESCRIPTION
Closes https://github.com/geolonia/geonicdb-docs/issues/129

## 変更内容

- `docs/ja/saas/tenant-admin-user.md`: L13 ステップ重複解消（「Geolonia からの連絡 + 認証情報の提供」→「Geolonia からの連絡」）
- `docs/en/saas/tenant-admin-user.md`: 日英整合性のため同様修正（「+ credentials delivered」→「(review & approval)」）
- `docs/ja/saas/tenant-admin-user.md`: `::: details` ブロック内テーブル前後に空行追加（MD058/MD055/MD056 対応）

## 背景

PR#127 (cmd_352) マージ時、CodeRabbit review 完了前に reviewThreads を確認したため、Minor 2 件が unresolved のまま残存。本 PR で後追い修正。

## テスト

- `pnpm run docs:build` — build complete（dead link 0）
- `npm test` — 126 tests passed, SKIP=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * チェンジログに修正内容を追加しました
  * 英語版オンボーディングドキュメントのステップ4の表記を更新しました
  * 日本語版オンボーディングドキュメントのステップ4の表示内容を更新し、エラーメッセージ表の体裁を改善しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->