### PR TITLE
fix: glossary block 違反 hotfix — ブローカー do_not_use 除外（cmd_353 HF2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 - fix: PR#127 CR Minor 後追い — tenant-admin-user.md ステップ重複解消 + ::: details 空行修正（cmd_356）(Closes #129)
+- fix: cmd_350 HF — glossary block 違反 hotfix（Context Broker do_not_use.ja から「ブローカー」除外 — MQTT broker 等一般語との衝突を解消）(Closes #128)
 - fix: MAPPING_TABLE から DEVELOPMENT.md / DEPLOYMENT.md 孤児エントリ削除（cmd_340 hotfix）(Closes #121)
 - fix: docs/en/changelog.md 日本語混入修正（PR#103 残存 CR Thread 6 対応）(Closes #115)
 - fix(translate-pipeline): SF2 embedded fence cascade violations — `fixEmbeddedFences` in `fix-doc-quality.ts` detects and splits `prose```lang` merged lines (`.```[a-z]` pattern); applied as pre-fix in `fixBareCodeBlocks` and as post-process in `translate-protected.ts` after restore steps. `ensureFenceSpacing` pre-processes input to insert blank lines before code fence starts at chunk boundaries, preventing LLM merging. Eliminates bare block cascade violations seen in PR#97. (Closes #104)

--- a/glossary.yaml
+++ b/glossary.yaml
@@ -100,7 +100,8 @@ terms:
       en: Context Broker
       ja: コンテキストブローカー
     do_not_use:
-      ja: ["コンテキストブローカ", "ブローカー"]
+      ja: ["コンテキストブローカ"]
+      # 「ブローカー」は MQTT broker / Message broker 等の一般語にも使われるため do_not_use から除外（cmd_353 HF2）
 
   - canonical: tenant
     type: domain


### PR DESCRIPTION
Closes https://github.com/geolonia/geonicdb-docs/issues/128

## 変更内容

- **glossary.yaml**: Context Broker `do_not_use.ja` から「ブローカー」削除（`コンテキストブローカ` は維持）
  - 「ブローカー」は MQTT broker / Message broker 等の一般語にも使われるため、Context Broker 専用 do_not_use に含めるべきでなかった
  - MQTT broker 等の技術翻訳で sync workflow が block 違反を起こす真因を解消
- **CHANGELOG.md**: Unreleased/Fixed に本 hotfix エントリを追記

## 背景

cmd_350 軍師策定 Q1=A 殿確定。sync workflow run 25248267351 が `Context Broker` do_not_use.ja の「ブローカー」block tier 違反で failure。
「ブローカー」は MQTT broker など Context Broker と無関係な一般技術語にも使われるため、block 化が正当な翻訳まで禁止していた。

## 検証

- `npx @geolonia/yuuhitsu glossary check docs/ja --severity-filter block` → 46 ファイル違反 0 件 ✅
- `pnpm docs:build` 成功 ✅
- `npm test` 7 ファイル 126 テスト全 PASS ✅
- `/code-review-expert --auto` P0/P1: 0 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * Context Broker の用語設定を更新し、誤解を招く単語を除外リストから削除しました。
* **ドキュメント**
  * 変更内容をCHANGELOGに追記しました（未リリースの修正として記載）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->