### PR TITLE
feat(fix-doc-quality): Subscription 動詞 sed safety net — fixGlossaryBlockViolations() 追加（cmd_365）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- [feat] Subscription 動詞 sed safety net — fix-doc-quality.ts に fixGlossaryBlockViolations() 追加（cmd_365）(Closes #142)
+
 ### Changed
 - [glossary] Context Broker hybrid 形式化 — 「ブローカー」を except_after で復活、MQTT/Message/Event broker 文脈を許容（cmd_361）(Closes #137)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.13 → 0.1.14 (SF6 context_exception hybrid schema) (Closes #136)

--- a/scripts/fix-doc-quality.ts
+++ b/scripts/fix-doc-quality.ts
@@ -124,6 +124,61 @@ export function fixGlossaryViolations(
   return { content: result.join('\n'), count }
 }
 
+// ---------------------------------------------------------------------------
+// Glossary block-tier violation replacement (Subscription verb safety net)
+// ---------------------------------------------------------------------------
+
+function applySubscriptionReplacements(text: string): string {
+  return text
+    .replace(/購読する/g, 'サブスクライブする')
+    .replace(/購読し([てたなれる])/g, 'サブスクライブし$1')
+    .replace(/購読中/g, 'サブスクライブ中')
+    .replace(/購読/g, 'サブスクリプション')
+}
+
+/**
+ * Fix Subscription verb block-tier glossary violations in Japanese markdown.
+ * Replaces 購読 patterns with canonical terms, skipping fenced code blocks
+ * and inline code (backtick-quoted segments).
+ *
+ * @param content - Markdown content to process
+ * @returns Fixed content string
+ */
+export function fixGlossaryBlockViolations(content: string): string {
+  const lines = content.split('\n')
+  let inFencedBlock = false
+
+  const result = lines.map(line => {
+    const trimmed = line.trimStart()
+
+    // Track fenced code block boundaries (``` or ~~~)
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      inFencedBlock = !inFencedBlock
+      return line
+    }
+
+    // Skip lines inside fenced code blocks
+    if (inFencedBlock) return line
+
+    // Protect inline code segments: split by `...`, apply replacements only to non-code parts
+    const parts: string[] = []
+    const inlineCodeRegex = /`[^`]*`/g
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+
+    while ((match = inlineCodeRegex.exec(line)) !== null) {
+      parts.push(applySubscriptionReplacements(line.slice(lastIndex, match.index)))
+      parts.push(match[0])
+      lastIndex = match.index + match[0].length
+    }
+    parts.push(applySubscriptionReplacements(line.slice(lastIndex)))
+
+    return parts.join('')
+  })
+
+  return result.join('\n')
+}
+
 /**
  * Infer language identifier from code block content.
  * Priority order: JSON → bash → SQL → HTTP → text
@@ -407,6 +462,15 @@ export function runQualityFixes(baseDir: string = process.cwd()): QualityFixResu
       changed = true
       glossaryFixes += glossaryCount
       console.log(`  [glossary] Fixed ${glossaryCount} term(s): ja/${relPath}`)
+    }
+
+    // Fix Subscription verb block-tier violations (safety net: 購読 → サブスクライブ/サブスクリプション)
+    const blockFixed = fixGlossaryBlockViolations(jaContent)
+    if (blockFixed !== jaContent) {
+      jaContent = blockFixed
+      changed = true
+      glossaryFixes++
+      console.log(`  [glossary-block] Fixed Subscription verb violation(s): ja/${relPath}`)
     }
 
     // Fix missing frontmatter title

--- a/tests/unit/fix-doc-quality.test.ts
+++ b/tests/unit/fix-doc-quality.test.ts
@@ -10,6 +10,7 @@ import {
   addFrontmatterTitle,
   hasFrontmatterTitle,
   fixGlossaryViolations,
+  fixGlossaryBlockViolations,
   runQualityFixes,
 } from '../../scripts/fix-doc-quality.js'
 
@@ -437,6 +438,67 @@ describe('fixGlossaryViolations', () => {
     // コンテキストブローカ (without ー) → コンテキストブローカー
     // コンテキストブローカー (with ー) is preserved
     expect(result).toBe('コンテキストブローカー への接続と、コンテキストブローカー を使用します。')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fixGlossaryBlockViolations
+// ---------------------------------------------------------------------------
+describe('fixGlossaryBlockViolations', () => {
+  it('replaces 購読する with サブスクライブする (verb form)', () => {
+    const content = 'エンティティの変更を購読することができます。'
+    expect(fixGlossaryBlockViolations(content)).toBe('エンティティの変更をサブスクライブすることができます。')
+  })
+
+  it('replaces 購読し variants with サブスクライブし variants', () => {
+    const content = '購読して通知を受け取ります。購読した内容を確認。'
+    expect(fixGlossaryBlockViolations(content)).toBe('サブスクライブして通知を受け取ります。サブスクライブした内容を確認。')
+  })
+
+  it('replaces 購読中 with サブスクライブ中', () => {
+    const content = '現在購読中のエンティティ一覧です。'
+    expect(fixGlossaryBlockViolations(content)).toBe('現在サブスクライブ中のエンティティ一覧です。')
+  })
+
+  it('replaces noun form 購読 with サブスクリプション as fallback', () => {
+    const content = 'サブスクリプションの購読を管理します。'
+    // 「サブスクリプションの購読」→「サブスクリプションのサブスクリプション」
+    expect(fixGlossaryBlockViolations(content)).toBe('サブスクリプションのサブスクリプションを管理します。')
+  })
+
+  it('does not replace 購読 inside inline code (backtick-quoted)', () => {
+    const content = '`購読する` メソッドを呼び出します。'
+    expect(fixGlossaryBlockViolations(content)).toBe('`購読する` メソッドを呼び出します。')
+  })
+
+  it('does not replace 購読 inside fenced code block', () => {
+    const content = [
+      '以下のコードで購読することができます:',
+      '```typescript',
+      '// 購読する処理',
+      'db.subscribe(...)',
+      '```',
+      '購読が完了しました。',
+    ].join('\n')
+    const result = fixGlossaryBlockViolations(content)
+    const lines = result.split('\n')
+    // Line 0: outside block → replaced (購読する → サブスクライブする)
+    expect(lines[0]).toBe('以下のコードでサブスクライブすることができます:')
+    // Line 2: inside block → preserved
+    expect(lines[2]).toBe('// 購読する処理')
+    // Line 5: outside block → replaced (noun fallback 購読 → サブスクリプション)
+    expect(lines[5]).toBe('サブスクリプションが完了しました。')
+  })
+
+  it('handles mixed inline code and prose on the same line', () => {
+    const content = '`subscribe` で購読するか、購読中リストを確認してください。'
+    const result = fixGlossaryBlockViolations(content)
+    expect(result).toBe('`subscribe` でサブスクライブするか、サブスクライブ中リストを確認してください。')
+  })
+
+  it('returns content unchanged when no 購読 patterns are present', () => {
+    const content = '## サブスクリプション\n\nWebSocket でリアルタイムにデータを受信します。'
+    expect(fixGlossaryBlockViolations(content)).toBe(content)
   })
 })
 


### PR DESCRIPTION
## Summary

- `scripts/fix-doc-quality.ts` に `fixGlossaryBlockViolations()` 関数を追加（cmd_365 Phase 1）
- 翻訳後 MD で `購読` パターンが再混入するのを防ぐ post-process safety net を実装
- fenced code block / inline code 内はスキップし、prose のみ自動置換

## 実装詳細

### 置換パターン
| 元 | 置換後 |
|---|---|
| `購読する` | `サブスクライブする` |
| `購読し（て/た/な/れ/る）` | `サブスクライブし（て/た/な/れ/る）` |
| `購読中` | `サブスクライブ中` |
| `購読`（名詞形 fallback） | `サブスクリプション` |

### コード保護
- Fenced code block（``` 〜 ```）内: スキップ ✓
- Inline code（`` ` ` ``）内: スキップ ✓

## Test plan

- [x] `pnpm test` 全 134 件 PASS、SKIP=0
- [x] `fixGlossaryBlockViolations` テスト 8 件追加（動詞形・名詞形・inline code 保護・fenced block 保護・混在行）
- [x] `npx @geolonia/yuuhitsu@0.1.14 glossary check --severity-filter block` → docs/ja 全ファイル 0 件
- [x] `/code-review-expert --auto` → P0/P1: 0

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 日本語ドキュメントの用語統一機能が追加されました。サブスクリプション関連の用語が自動的に正規化され、より一貫性のある品質基準が適用されるようになりました。コード例やインライン引用部分は除外されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->