### PR TITLE
feat(saas): Phase 2 — R-SAM-DEPLOY + R-ENV-ADMIN + R-ENV-TABLE rules (cmd_372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- [feat] Phase 2 — saas-rewrite-rules.yaml に R-SAM-DEPLOY + R-ENV-ADMIN + R-ENV-TABLE 3 rules 追加 + unit tests 9 件（cmd_372）(Closes #154)
 - [feat] Phase 1 — saas-docs-rewrite.ts + YAML rule config (R-DEV-MD + R-SAM-BATCH) 実装（cmd_371）(Closes #152)
 
 ### Changed

--- a/scripts/config/saas-rewrite-rules.yaml
+++ b/scripts/config/saas-rewrite-rules.yaml
@@ -69,3 +69,51 @@ rules:
       - pattern: '、最大 10,000 まで設定可能'
         replacement: ''
         scope: ['docs/ja/api-reference/ngsiv2.md']
+
+  # ---- R-SAM-DEPLOY: EventStreamingEnabled SAM deploy 手順 → SaaS では既定で有効 ----
+  - id: R-SAM-DEPLOY
+    description: "EventStreamingEnabled SAM deploy block → SaaS default enabled note (en/ja)"
+    enabled: true
+    skip_in_code: false
+    skip_in_changelog: true
+    matchers:
+      - pattern: 'Set the `EventStreamingEnabled` parameter to `true` in the SAM template and deploy\.\s*```bash\s*sam deploy -t infrastructure/template\.yaml \\\s*--parameter-overrides EventStreamingEnabled=true\s*```'
+        replacement: 'Event streaming is enabled by default in GeonicDB SaaS. No additional configuration is required.'
+        scope: ['docs/en/features/subscriptions.md']
+      - pattern: 'SAM テンプレートで `EventStreamingEnabled` パラメータを `true` に設定してデプロイします。\s*```bash\s*sam deploy -t infrastructure/template\.yaml \\\s*--parameter-overrides EventStreamingEnabled=true\s*```'
+        replacement: 'GeonicDB SaaS ではイベントストリーミングは既定で有効です。追加の設定は不要です。'
+        scope: ['docs/ja/features/subscriptions.md']
+
+  # ---- R-ENV-ADMIN: ADMIN_ALLOWED_IPS env var 言及に SaaS 注記追加 ----
+  - id: R-ENV-ADMIN
+    description: "ADMIN_ALLOWED_IPS env var section → prepend SaaS note (en/ja, admin+endpoints)"
+    enabled: true
+    skip_in_code: true
+    skip_in_changelog: true
+    matchers:
+      - pattern: 'Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable\.'
+        replacement: "**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.\n\nRestrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable."
+        scope: ['docs/en/api-reference/admin.md']
+      - pattern: 'By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API \(`/admin/\*`\) to specific IP addresses:'
+        replacement: "**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.\n\nBy setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:"
+        scope: ['docs/en/api-reference/endpoints.md']
+      - pattern: '`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
+        replacement: "**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。\n\n`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。"
+        scope: ['docs/ja/api-reference/admin.md']
+      - pattern: '`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API \(`/admin/\*`\) へのアクセスを特定の IP アドレスに制限できます:'
+        replacement: "**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。\n\n`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:"
+        scope: ['docs/ja/api-reference/endpoints.md']
+
+  # ---- R-ENV-TABLE: endpoints.md env var 表に SaaS 注記追加 ----
+  - id: R-ENV-TABLE
+    description: "endpoints.md env var table → append SaaS note after ADMIN_ALLOWED_IPS row (en/ja)"
+    enabled: true
+    skip_in_code: true
+    skip_in_changelog: true
+    matchers:
+      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| IPs/CIDRs allowed to access the Admin API \(comma-separated\) \|'
+        replacement: "| `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |\n\n> **SaaS users**: These environment variables are managed via the GeonicDB SaaS console. Direct configuration is not required."
+        scope: ['docs/en/api-reference/endpoints.md']
+      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| 管理 API へのアクセスを許可する IP/CIDR\(カンマ区切り\) \|'
+        replacement: "| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |\n\n> **SaaS 利用者の方へ**: これらの環境変数は GeonicDB SaaS コンソールで管理されます。直接設定は不要です。"
+        scope: ['docs/ja/api-reference/endpoints.md']

--- a/tests/unit/saas-docs-rewrite.test.ts
+++ b/tests/unit/saas-docs-rewrite.test.ts
@@ -426,6 +426,22 @@ describe('processFile — R-ENV-ADMIN (JA)', () => {
     const origIdx = result.indexOf('`ADMIN_ALLOWED_IPS` 環境変数を使用して')
     expect(noteIdx).toBeLessThan(origIdx)
   })
+
+  it('prepends JA SaaS note before ADMIN_ALLOWED_IPS description in endpoints.md', () => {
+    const input =
+      '`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/ja/api-reference/endpoints.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toContain('**SaaS 利用者の方へ**')
+    expect(result).toContain('`ADMIN_ALLOWED_IPS` 環境変数を設定することで')
+    const noteIdx = result.indexOf('**SaaS 利用者の方へ**')
+    const origIdx = result.indexOf('`ADMIN_ALLOWED_IPS` 環境変数を設定することで')
+    expect(noteIdx).toBeLessThan(origIdx)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/saas-docs-rewrite.test.ts
+++ b/tests/unit/saas-docs-rewrite.test.ts
@@ -291,6 +291,203 @@ describe('ConfigSchema — enabled: false', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 9. R-SAM-DEPLOY: EventStreamingEnabled SAM deploy block → SaaS note (EN)
+// ---------------------------------------------------------------------------
+describe('processFile — R-SAM-DEPLOY (EN)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-SAM-DEPLOY')!
+
+  it('replaces EN SAM deploy block with SaaS note', () => {
+    const input = [
+      'Set the `EventStreamingEnabled` parameter to `true` in the SAM template and deploy.',
+      '',
+      '```bash',
+      'sam deploy -t infrastructure/template.yaml \\',
+      '  --parameter-overrides EventStreamingEnabled=true',
+      '```',
+    ].join('\n')
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/en/features/subscriptions.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toBe(
+      'Event streaming is enabled by default in GeonicDB SaaS. No additional configuration is required.'
+    )
+    expect(result).not.toContain('sam deploy')
+  })
+
+  it('does not modify an out-of-scope file for R-SAM-DEPLOY', () => {
+    const input = [
+      'Set the `EventStreamingEnabled` parameter to `true` in the SAM template and deploy.',
+      '',
+      '```bash',
+      'sam deploy -t infrastructure/template.yaml \\',
+      '  --parameter-overrides EventStreamingEnabled=true',
+      '```',
+    ].join('\n')
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/en/other/page.md'
+    )
+    expect(result).toBe(input)
+    expect(changes).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 10. R-SAM-DEPLOY: EventStreamingEnabled SAM deploy block → SaaS note (JA)
+// ---------------------------------------------------------------------------
+describe('processFile — R-SAM-DEPLOY (JA)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-SAM-DEPLOY')!
+
+  it('replaces JA SAM deploy block with SaaS note', () => {
+    const input = [
+      'SAM テンプレートで `EventStreamingEnabled` パラメータを `true` に設定してデプロイします。',
+      '',
+      '```bash',
+      'sam deploy -t infrastructure/template.yaml \\',
+      '  --parameter-overrides EventStreamingEnabled=true',
+      '```',
+    ].join('\n')
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/ja/features/subscriptions.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toBe(
+      'GeonicDB SaaS ではイベントストリーミングは既定で有効です。追加の設定は不要です。'
+    )
+    expect(result).not.toContain('sam deploy')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 11. R-ENV-ADMIN: ADMIN_ALLOWED_IPS SaaS note prepended (EN admin.md)
+// ---------------------------------------------------------------------------
+describe('processFile — R-ENV-ADMIN (EN admin.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-ADMIN')!
+
+  it('prepends EN SaaS note before ADMIN_ALLOWED_IPS description in admin.md', () => {
+    const input =
+      'Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable.'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/en/api-reference/admin.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toContain('**SaaS users**: This is configured via the tenant settings API.')
+    expect(result).toContain('Restrict admin API access to specific IP addresses')
+    // SaaS note comes before the original text
+    const noteIdx = result.indexOf('**SaaS users**')
+    const origIdx = result.indexOf('Restrict admin API access')
+    expect(noteIdx).toBeLessThan(origIdx)
+  })
+
+  it('prepends EN SaaS note before ADMIN_ALLOWED_IPS description in endpoints.md', () => {
+    const input =
+      'By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/en/api-reference/endpoints.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toContain('**SaaS users**: This is configured via the tenant settings API.')
+    expect(result).toContain('By setting the `ADMIN_ALLOWED_IPS`')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 12. R-ENV-ADMIN: ADMIN_ALLOWED_IPS SaaS note prepended (JA)
+// ---------------------------------------------------------------------------
+describe('processFile — R-ENV-ADMIN (JA)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-ADMIN')!
+
+  it('prepends JA SaaS note before ADMIN_ALLOWED_IPS description in admin.md', () => {
+    const input =
+      '`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/ja/api-reference/admin.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toContain('**SaaS 利用者の方へ**')
+    expect(result).toContain('`ADMIN_ALLOWED_IPS` 環境変数を使用して')
+    const noteIdx = result.indexOf('**SaaS 利用者の方へ**')
+    const origIdx = result.indexOf('`ADMIN_ALLOWED_IPS` 環境変数を使用して')
+    expect(noteIdx).toBeLessThan(origIdx)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 13. R-ENV-TABLE: env var table SaaS note appended (EN endpoints.md)
+// ---------------------------------------------------------------------------
+describe('processFile — R-ENV-TABLE (EN)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-TABLE')!
+
+  it('appends EN SaaS note after ADMIN_ALLOWED_IPS table row', () => {
+    const input =
+      '| `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/en/api-reference/endpoints.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toContain('> **SaaS users**: These environment variables are managed via the GeonicDB SaaS console.')
+    // Original table row still present
+    expect(result).toContain('| `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |')
+    // SaaS note comes after the table row
+    const rowIdx = result.indexOf('| `ADMIN_ALLOWED_IPS`')
+    const noteIdx = result.indexOf('> **SaaS users**')
+    expect(rowIdx).toBeLessThan(noteIdx)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 14. R-ENV-TABLE: env var table SaaS note appended (JA endpoints.md)
+// ---------------------------------------------------------------------------
+describe('processFile — R-ENV-TABLE (JA)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-TABLE')!
+
+  it('appends JA SaaS note after ADMIN_ALLOWED_IPS table row', () => {
+    const input =
+      '| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/ja/api-reference/endpoints.md'
+    )
+    expect(changes).toBe(1)
+    expect(result).toContain('> **SaaS 利用者の方へ**: これらの環境変数は GeonicDB SaaS コンソールで管理されます。')
+    expect(result).toContain('| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |')
+  })
+
+  it('does not modify an out-of-scope file for R-ENV-TABLE', () => {
+    const input =
+      '| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |'
+    const { content: result, changes } = processFile(
+      input,
+      rule,
+      'docs/ja/api-reference/admin.md'
+    )
+    expect(result).toBe(input)
+    expect(changes).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // matchesScope
 // ---------------------------------------------------------------------------
 describe('matchesScope', () => {


### PR DESCRIPTION
## Summary

- `R-SAM-DEPLOY`: EventStreamingEnabled SAM deploy block を SaaS 既定有効の注記に置換 (en/ja)
- `R-ENV-ADMIN`: ADMIN_ALLOWED_IPS 環境変数セクションの冒頭に SaaS 注記を追加 (en/ja, admin.md + endpoints.md)
- `R-ENV-TABLE`: endpoints.md の env var 表 ADMIN_ALLOWED_IPS 行の後に SaaS 注記を追加 (en/ja)
- unit tests: +9 件 (151 件全 PASS)
- dry-run 検証済: 3 rules × 10 files マッチ確認

## Test plan

- [x] `pnpm test` — 151 tests PASS (142 既存 + 9 新規)
- [x] `pnpm run docs:build` — PASS
- [x] `npx tsx scripts/saas-docs-rewrite.ts docs/en docs/ja --dry-run` — 10 files, 3 rules マッチ確認
- [ ] CI PASS 確認
- [ ] CodeRabbit Actionable ゼロ確認

Closes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * SaaS向けドキュメントの更新ルールを3つ追加しました
  * イベントストリーミングがデフォルトで有効である旨の説明を追加
  * ADMIN_ALLOWED_IPS環境変数に関するSaaSユーザー向け注記を複数箇所に追加

* **Tests**
  * 新しいドキュメント更新ルールをカバーする9件のユニットテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->