### PR TITLE
docs: sync and translate from geonicdb/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - chore(deps): bump @geolonia/yuuhitsu 0.1.13 → 0.1.14 (SF6 context_exception hybrid schema) (Closes #136)
 
 ### Fixed
+- [fix] cmd_376 — PR#161 残課題 3 種 hotfix: bare fence 55 件修正 (11 merged lines in 7 files)、geonicdb 小文字 prose 露出解消（Glossary Check 修正と共通原因）、smart-data-models.md heading 連結分離 (Closes #162)
 - [fix] cmd_373 — PR#155 ja list/heading 連結 + アンカー hotfix（ngsild.md 11箇所 list 分離 + ngsiv2-vs-ngsild.md heading/hr 分離 + #federation → #フェデレーション）(Closes #157)
 - [fix] PR#146 close + bare fence 修正 (6 ja files) + DEVELOPMENT.md 参照暫定削除（cmd_368）(Closes #148)
   ※ cmd_370 で DEVELOPMENT.md 参照の適切リンク整備予定

--- a/docs/en/api-reference/admin.md
+++ b/docs/en/api-reference/admin.md
@@ -860,6 +860,8 @@ geonicdb_request_duration_seconds_bucket{le="0.1"} 1300000
 
 ### IP Restrictions
 
+**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.
+
 Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable.
 
 ```text

--- a/docs/en/api-reference/endpoints.md
+++ b/docs/en/api-reference/endpoints.md
@@ -347,6 +347,8 @@ Authentication is disabled by default. It can be enabled with the following envi
 | `SUPER_ADMIN_PASSWORD` | - | Super admin password set via environment variable |
 | `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |
 
+> **SaaS users**: These environment variables are managed via the GeonicDB SaaS console. Direct configuration is not required.
+
 ### Roles and Permissions
 
 | Role | Description | Permissions |
@@ -687,6 +689,8 @@ Authorization: Bearer <accessToken>
 > **Note**: The custom data model API has moved to `/custom-data-models`. See the [Custom Data Models API](#custom-data-models-api) section for details.
 
 ### IP Restrictions
+
+**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.
 
 By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:
 

--- a/docs/en/features/subscriptions.md
+++ b/docs/en/features/subscriptions.md
@@ -49,12 +49,7 @@ EventBridge ─┬─> SubscriptionMatcher -> SQS -> HTTP/MQTT  [existing]
 
 ### Enabling
 
-Set the `EventStreamingEnabled` parameter to `true` in the SAM template and deploy.
-
-```bash
-sam deploy -t infrastructure/template.yaml \
-  --parameter-overrides EventStreamingEnabled=true
-```
+Event streaming is enabled by default in GeonicDB SaaS. No additional configuration is required.
 
 ### Environment Variables
 

--- a/docs/ja/ai-integration/examples.md
+++ b/docs/ja/ai-integration/examples.md
@@ -251,7 +251,10 @@ API キーで利用可能なスコープ:
 
 Claude Desktop 設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
 {
   "mcpServers": {
     "geonicdb": {

--- a/docs/ja/ai-integration/examples.md
+++ b/docs/ja/ai-integration/examples.md
@@ -45,8 +45,7 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -252,8 +251,7 @@ API キーで利用可能なスコープ:
 
 Claude Desktop 設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -423,7 +421,9 @@ curl -X POST http://localhost:3000/mcp \
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
 - **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
 - **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。## JSON スキーマとカスタムデータモデル
+- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
+
+## JSON スキーマとカスタムデータモデル
 
 カスタムデータモデルは、作成時に JSON スキーマ (Draft 2020-12) が自動的に生成されます。この JSON スキーマは、AI ツールで以下の目的に活用できます。
 
@@ -585,7 +585,9 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向け�
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完がすぐに利用できます。詳細は SDK ドキュメントを参照してください。## A2A (Agent-to-Agent Protocol) サポート
+別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完がすぐに利用できます。詳細は SDK ドキュメントを参照してください。
+
+## A2A (Agent-to-Agent Protocol) サポート
 
 GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
 

--- a/docs/ja/ai-integration/overview.md
+++ b/docs/ja/ai-integration/overview.md
@@ -251,7 +251,10 @@ API キーの利用可能なスコープ:
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
 {
   "mcpServers": {
     "geonicdb": {

--- a/docs/ja/ai-integration/overview.md
+++ b/docs/ja/ai-integration/overview.md
@@ -45,8 +45,7 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -252,8 +251,7 @@ API キーの利用可能なスコープ:
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -423,7 +421,9 @@ curl -X POST http://localhost:3000/mcp \
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) および `DELETE /mcp` (セッション終了) は 405 を返します。
 - **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
 - **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。## JSON Schema とカスタムデータモデル
+- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
+
+## JSON Schema とカスタムデータモデル
 
 カスタムデータモデルは作成時に、JSON Schema (Draft 2020-12) が自動的に生成されます。この JSON Schema は、以下の目的で AI ツールに活用できます。
 
@@ -585,7 +585,9 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向け�
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがそのまま利用できます。詳細は SDK ドキュメントを参照してください。## A2A (Agent-to-Agent Protocol) サポート
+別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがそのまま利用できます。詳細は SDK ドキュメントを参照してください。
+
+## A2A (Agent-to-Agent Protocol) サポート
 
 GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
 

--- a/docs/ja/ai-integration/tools-json.md
+++ b/docs/ja/ai-integration/tools-json.md
@@ -45,8 +45,7 @@ MCP ツールは、属性値から NGSI-LD タイプを自動的に推論しま�
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -252,8 +251,7 @@ API キーで利用可能なスコープ:
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -423,7 +421,9 @@ curl -X POST http://localhost:3000/mcp \
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
 - **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
 - **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。## JSON Schema とカスタムデータモデル
+- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
+
+## JSON Schema とカスタムデータモデル
 
 カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は AI ツールで以下の目的に利用できます。
 
@@ -586,7 +586,9 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに�
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取り
 4. AI が文書化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細は SDK ドキュメントを参照してください。## A2A (Agent-to-Agent プロトコル) サポート
+別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細は SDK ドキュメントを参照してください。
+
+## A2A (Agent-to-Agent プロトコル) サポート
 
 GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
 

--- a/docs/ja/ai-integration/tools-json.md
+++ b/docs/ja/ai-integration/tools-json.md
@@ -251,7 +251,10 @@ API キーで利用可能なスコープ:
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
 {
   "mcpServers": {
     "geonicdb": {

--- a/docs/ja/api-reference/admin.md
+++ b/docs/ja/api-reference/admin.md
@@ -860,6 +860,8 @@ geonicdb_request_duration_seconds_bucket{le="0.1"} 1300000
 
 ### IP 制限
 
+**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。
+
 `ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。
 
 ```text

--- a/docs/ja/api-reference/endpoints.md
+++ b/docs/ja/api-reference/endpoints.md
@@ -489,7 +489,9 @@ Origin: https://example.com
 {"api_key": "gdb_your_api_key_here"}
 ```
 
-**レスポンス**: `200 OK````json
+**レスポンス**: `200 OK`
+
+```json
 {
   "nonce": "base64url_timestamp.hmac_signature",
   "challenge": "sha256_challenge_string",
@@ -514,7 +516,9 @@ Origin: https://example.com
 }
 ```
 
-**レスポンス**: `200 OK````json
+**レスポンス**: `200 OK`
+
+```json
 {
   "access_token": "<session_jwt>",
   "token_type": "Bearer",

--- a/docs/ja/api-reference/endpoints.md
+++ b/docs/ja/api-reference/endpoints.md
@@ -354,6 +354,8 @@ curl -i "http://localhost:3000/v2/entities" \
 | `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定するスーパー管理者のパスワード |
 | `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |
 
+> **SaaS 利用者の方へ**: これらの環境変数は GeonicDB SaaS コンソールで管理されます。直接設定は不要です。
+
 ### ロールと権限
 
 | ロール | 説明 | 権限 |
@@ -462,8 +464,7 @@ Content-Type: application/json
 }
 ```
 
-**レスポンス**: `204 No Content`
-**注意**: パスワードを変更すると、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
+**レスポンス**: `204 No Content`**注意**: パスワードを変更すると、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
 
 ### ログアウト
 
@@ -474,8 +475,7 @@ Authorization: Bearer <accessToken>
 
 すべてのセッションを無効化します。このユーザーに対して発行されたすべてのアクセストークンとリフレッシュトークンが即座に無効化されます。
 
-**レスポンス**: `204 No Content`
-### API キー トークン交換
+**レスポンス**: `204 No Content`### API キー トークン交換
 
 #
 
@@ -489,8 +489,7 @@ Origin: https://example.com
 {"api_key": "gdb_your_api_key_here"}
 ```
 
-**レスポンス**: `200 OK`
-```json
+**レスポンス**: `200 OK````json
 {
   "nonce": "base64url_timestamp.hmac_signature",
   "challenge": "sha256_challenge_string",
@@ -515,8 +514,7 @@ Origin: https://example.com
 }
 ```
 
-**レスポンス**: `200 OK`
-```json
+**レスポンス**: `200 OK````json
 {
   "access_token": "<session_jwt>",
   "token_type": "Bearer",
@@ -717,9 +715,11 @@ Authorization: Bearer <accessToken>
 
 ### カスタムデータモデル管理
 
-> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#custom-data-models-api) セクションを参照してください。
+> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
 
 ### IP 制限
+
+**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。
 
 `ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:
 
@@ -924,7 +924,8 @@ OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine�
 
 **主要なエンドポイント:**
 - `POST /auth/nonce` - Nonce と PoW チャレンジのリクエスト（API キーと Origin ヘッダーが必要）
-- `POST /oauth/token`（`grant_type=api_key`）- API キー + nonce + PoW 証明をセッション JWT に交換
+- `POST /oauth/token`（`grant_type=api_key`）
+- API キー + nonce + PoW 証明をセッション JWT に交換
 
 **JavaScript SDK:** `npm install @geolonia/geonicdb-sdk` — トークン交換、DPoP、WebSocket、再接続を自動的に処理します。
 
@@ -947,8 +948,7 @@ GET /llms.txt
 AI フレンドリーな [llms.txt](https://llmstxt.org/) フォーマットで API ドキュメントを返します。AI エージェントや LLM が理解しやすい Markdown フォーマットで構造化されています。
 
 **レスポンス**
-- Content-Type: `text/markdown; charset=utf-8`
-### API ドキュメント（JSON フォーマット）
+- Content-Type: `text/markdown; charset=utf-8`### API ドキュメント（JSON フォーマット）
 
 ```http
 GET /api.json

--- a/docs/ja/api-reference/ngsild.md
+++ b/docs/ja/api-reference/ngsild.md
@@ -679,7 +679,9 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 
 `options=temporalValues` を指定すると、各属性が `values` 配列 (`[value, timestamp]` のペア) を含む簡易形式で返されます。
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues````json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues`
+
+```json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -701,7 +703,9 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 | `aggrMethods` | string | 集計メソッド (カンマ区切り): `totalCount`, `distinctCount`, `sum`, `avg`, `min`, `max`, `stddev`, `sumsq` |
 | `aggrPeriodDuration` | string | ISO 8601 期間 (例: `PT1H` は 1 時間)。`aggrMethods` 指定時に必須 |
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z````json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z`
+
+```json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",

--- a/docs/ja/api-reference/ngsild.md
+++ b/docs/ja/api-reference/ngsild.md
@@ -171,10 +171,8 @@ Content-Type: application/ld+json
 ```
 
 **レスポンス**
-- ステータス: `201 Created`
-- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関係なく)
-- ヘッダー: `Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Room:001`
-> **注意**: エンティティ ID はテナントとServicePathスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成すると `409 AlreadyExists` が返されます。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
+- ステータス: `201 Created`- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関係なく)
+- ヘッダー: `Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Room:001`> **注意**: エンティティ ID はテナントとServicePathスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成すると `409 AlreadyExists` が返されます。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
 #
 
@@ -205,8 +203,7 @@ PUT /ngsi-ld/v1/entities/{entityId}
 
 エンティティのすべての属性を置き換えます。リクエストボディに含まれない属性は削除されます。
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### エンティティの更新
 
@@ -219,8 +216,7 @@ PATCH /ngsi-ld/v1/entities/{entityId}
 - プロパティ値として `urn:ngsi-ld:null` を指定すると、その属性が削除されます。
 - クエリパラメータ `options=keyValues` または `options=concise` を指定すると、簡略化された入力形式を使用できます。
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### 属性の追加
 
@@ -235,8 +231,7 @@ Content-Type: application/ld+json
 |-----------|------|
 | `options=noOverwrite` | 既存の属性を上書きしない(既存の属性は保持され、新しい属性のみが追加されます) |
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### 複数属性の部分更新
 
@@ -258,8 +253,7 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### エンティティの削除
 
@@ -267,8 +261,7 @@ Content-Type: application/ld+json
 DELETE /ngsi-ld/v1/entities/{entityId}
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### エンティティのすべての属性を取得
 
@@ -278,8 +271,7 @@ GET /ngsi-ld/v1/entities/{entityId}/attrs
 
 エンティティのすべての属性を取得します。
 
-**レスポンス**: `200 OK`
-#
+**レスポンス**: `200 OK`#
 
 ### 単一属性の取得
 
@@ -289,8 +281,7 @@ GET /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 
 エンティティの特定の属性を取得します。
 
-**レスポンス**: `200 OK`
-#
+**レスポンス**: `200 OK`#
 
 ### 属性の上書き (PUT)
 
@@ -310,8 +301,7 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### 属性の置換
 
@@ -331,8 +321,7 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### 属性の部分更新
 
@@ -350,8 +339,7 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`
-> **注意**: エンティティまたは属性が存在しない場合、`404 Not Found` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.6.4)。この操作は既存の属性の部分更新のみを実行し、新しい属性は作成しません。
+**レスポンス**: `204 No Content`> **注意**: エンティティまたは属性が存在しない場合、`404 Not Found` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.6.4)。この操作は既存の属性の部分更新のみを実行し、新しい属性は作成しません。
 
 #
 
@@ -368,8 +356,7 @@ DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 | `datasetId` | string | 削除するマルチ属性インスタンスの datasetId |
 | `deleteAll` | boolean | `true` の場合、すべてのインスタンスを削除します |
 
-**レスポンス**: `204 No Content`
-### マルチ属性 (datasetId)
+**レスポンス**: `204 No Content`### マルチ属性 (datasetId)
 
 > **ETSI GS CIM 009 リファレンス**: Section 4.5.3 - Multi-Attribute
 
@@ -475,9 +462,7 @@ Content-Type: application/ld+json
 ```
 
 **レスポンス**
-- すべて成功: `201 Created`
-- 部分的に成功: `207 Multi-Status`
-#
+- すべて成功: `201 Created`- 部分的に成功: `207 Multi-Status`#
 
 ### バッチアップサート
 
@@ -493,8 +478,7 @@ POST /ngsi-ld/v1/entityOperations/upsert
 
 **レスポンス**
 - すべて成功: `201 Created` (新規作成) または `204 No Content` (更新)
-- 部分的に成功: `207 Multi-Status`
-#
+- 部分的に成功: `207 Multi-Status`#
 
 ### バッチ更新
 
@@ -503,9 +487,7 @@ POST /ngsi-ld/v1/entityOperations/update
 ```
 
 **レスポンス**
-- すべて成功: `204 No Content`
-- 部分的に成功: `207 Multi-Status`
-#
+- すべて成功: `204 No Content`- 部分的に成功: `207 Multi-Status`#
 
 ### バッチ削除
 
@@ -524,9 +506,7 @@ Content-Type: application/json
 ```
 
 **レスポンス**
-- すべて成功: `204 No Content`
-- 部分的に成功: `207 Multi-Status`
-#
+- すべて成功: `204 No Content`- 部分的に成功: `207 Multi-Status`#
 
 ### エンティティパージ
 
@@ -544,9 +524,7 @@ Content-Type: application/json
 | `type` | string | 削除するエンティティタイプ (必須) |
 
 **レスポンス**
-- 成功: `204 No Content`
-- タイプが指定されていない: `400 Bad Request`
-#
+- 成功: `204 No Content`- タイプが指定されていない: `400 Bad Request`#
 
 ### バッチクエリ
 
@@ -603,9 +581,7 @@ Merge-Patch セマンティクスを使用して、複数のエンティティ�
 | `options=noOverwrite` | 既存の属性を上書きしない |
 
 **レスポンス**
-- すべて成功: `204 No Content`
-- 部分的な成功: `207 Multi-Status`
----
+- すべて成功: `204 No Content`- 部分的な成功: `207 Multi-Status`---
 
 ### 時系列・バッチ操作 (NGSI-LD)
 
@@ -626,8 +602,7 @@ Content-Type: application/ld+json
 
 時系列エンティティを一括作成します。リクエストボディは時系列エンティティの配列です。
 
-**レスポンス**: すべて成功した場合は `201 Created`、部分的に失敗した場合は `207 Multi-Status`
-#
+**レスポンス**: すべて成功した場合は `201 Created`、部分的に失敗した場合は `207 Multi-Status`#
 
 ### 時系列・バッチアップサート
 
@@ -638,8 +613,7 @@ Content-Type: application/ld+json
 
 時系列エンティティを一括作成または更新します (既存のエンティティに属性を追加します)。
 
-**レスポンス**: すべて成功した場合は `204 No Content`、部分的に失敗した場合は `207 Multi-Status`
-#
+**レスポンス**: すべて成功した場合は `204 No Content`、部分的に失敗した場合は `207 Multi-Status`#
 
 ### 時系列・バッチ削除
 
@@ -650,8 +624,7 @@ Content-Type: application/ld+json
 
 時系列エンティティを一括削除します。リクエストボディはエンティティ ID の配列です。
 
-**レスポンス**: すべて成功した場合は `204 No Content`、部分的に失敗した場合は `207 Multi-Status`
-#
+**レスポンス**: すべて成功した場合は `204 No Content`、部分的に失敗した場合は `207 Multi-Status`#
 
 ### 時系列・バッチクエリ
 
@@ -706,8 +679,7 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 
 `options=temporalValues` を指定すると、各属性が `values` 配列 (`[value, timestamp]` のペア) を含む簡易形式で返されます。
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues`
-```json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues````json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -729,8 +701,7 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 | `aggrMethods` | string | 集計メソッド (カンマ区切り): `totalCount`, `distinctCount`, `sum`, `avg`, `min`, `max`, `stddev`, `sumsq` |
 | `aggrPeriodDuration` | string | ISO 8601 期間 (例: `PT1H` は 1 時間)。`aggrMethods` 指定時に必須 |
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z`
-```json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z````json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -936,9 +907,7 @@ NGSI-LD では、エンドポイント URI に `mqtt://` または `mqtts://` �
 - `watchedAttributes` と `timeInterval` は相互排他的です。両方を同時に指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.8.1)
 
 **レスポンス**
-- ステータス: `201 Created`
-- ヘッダー: `Location: /ngsi-ld/v1/subscriptions/{subscriptionId}`
-#
+- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/subscriptions/{subscriptionId}`#
 
 ### サブスクリプション一覧
 
@@ -982,8 +951,7 @@ GET /ngsi-ld/v1/subscriptions/{subscriptionId}
 PATCH /ngsi-ld/v1/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### サブスクリプションの削除
 
@@ -991,8 +959,7 @@ PATCH /ngsi-ld/v1/subscriptions/{subscriptionId}
 DELETE /ngsi-ld/v1/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### 所有権検証 (GeonicDB 拡張)
 
@@ -1059,9 +1026,7 @@ Content-Type: application/ld+json
 | `mode` | string | - | モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`) |
 
 **レスポンス**
-- ステータス: `201 Created`
-- ヘッダー: `Location: /ngsi-ld/v1/csourceRegistrations/{registrationId}`
-#
+- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/csourceRegistrations/{registrationId}`#
 
 ### レジストレーション一覧の取得
 
@@ -1121,8 +1086,7 @@ PATCH /ngsi-ld/v1/csourceRegistrations/{registrationId}
 }
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### レジストレーションの削除
 
@@ -1130,8 +1094,7 @@ PATCH /ngsi-ld/v1/csourceRegistrations/{registrationId}
 DELETE /ngsi-ld/v1/csourceRegistrations/{registrationId}
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### 所有権の検証 (GeonicDB 拡張)
 
@@ -1268,8 +1231,7 @@ GET /ngsi-ld/v1/entityMaps
 | `limit` | integer | 最大結果数 (デフォルト: 20、最大: 1000) |
 | `offset` | integer | スキップする結果数 (デフォルト: 0) |
 
-**レスポンス**: `200 OK`
-#
+**レスポンス**: `200 OK`#
 
 ### EntityMap の取得
 
@@ -1277,8 +1239,7 @@ GET /ngsi-ld/v1/entityMaps
 GET /ngsi-ld/v1/entityMaps/{entityMapId}
 ```
 
-**レスポンス**: `200 OK`
-#
+**レスポンス**: `200 OK`#
 
 ### EntityMap の更新
 
@@ -1287,8 +1248,7 @@ PATCH /ngsi-ld/v1/entityMaps/{entityMapId}
 Content-Type: application/ld+json
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### EntityMap の削除
 
@@ -1296,8 +1256,7 @@ Content-Type: application/ld+json
 DELETE /ngsi-ld/v1/entityMaps/{entityMapId}
 ```
 
-**レスポンス**: `204 No Content`
-### リンクエンティティの取得 (join/joinLevel)
+**レスポンス**: `204 No Content`### リンクエンティティの取得 (join/joinLevel)
 
 エンティティ取得エンドポイント (`GET /ngsi-ld/v1/entities` と `GET /ngsi-ld/v1/entities/{entityId}`) では、`join` と `joinLevel` のクエリパラメータを使用してリンクされたエンティティを取得できます。
 
@@ -1359,9 +1318,7 @@ Content-Type: application/ld+json
 | `isActive` | boolean | - | アクティブ状態 (デフォルト: true) |
 
 **レスポンス**
-- ステータス: `201 Created`
-- ヘッダー: `Location: /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}`
-#
+- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}`#
 
 ### CSR サブスクリプションリストの取得
 
@@ -1418,8 +1375,7 @@ PATCH /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 }
 ```
 
-**レスポンス**: `204 No Content`
-#
+**レスポンス**: `204 No Content`#
 
 ### CSR サブスクリプションの削除
 
@@ -1427,8 +1383,7 @@ PATCH /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 DELETE /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`
-### JSON-LD Context 管理
+**レスポンス**: `204 No Content`### JSON-LD Context 管理
 
 ETSI GS CIM 009 Section 5.12 に準拠した JSON-LD context 管理 API です。ユーザー定義の JSON-LD context の登録と管理が可能です。
 
@@ -1454,9 +1409,7 @@ Content-Type: application/json
 ```
 
 **レスポンス**
-- ステータス: `201 Created`
-- ヘッダー: `Location: /ngsi-ld/v1/jsonldContexts/{contextId}`
-#
+- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/jsonldContexts/{contextId}`#
 
 ### JSON-LD Context リストの取得
 
@@ -1471,8 +1424,7 @@ GET /ngsi-ld/v1/jsonldContexts
 | `limit` | integer | 取得する結果の最大数 | 20 |
 | `offset` | integer | スキップする結果の数 | 0 |
 
-**レスポンス**: `200 OK`
-#
+**レスポンス**: `200 OK`#
 
 ### JSON-LD Context の取得
 
@@ -1497,8 +1449,7 @@ GET /ngsi-ld/v1/jsonldContexts/{contextId}
 | `If-None-Match` | ETag が一致する場合 `304 Not Modified` を返す |
 | `If-Modified-Since` | 指定日時以降に変更がない場合 `304 Not Modified` を返す |
 
-**レスポンス**: `200 OK` / `304 Not Modified`
-#
+**レスポンス**: `200 OK` / `304 Not Modified`#
 
 ### JSON-LD Context の削除
 
@@ -1506,8 +1457,7 @@ GET /ngsi-ld/v1/jsonldContexts/{contextId}
 DELETE /ngsi-ld/v1/jsonldContexts/{contextId}
 ```
 
-**レスポンス**: `204 No Content`
-### Vector Tiles (NGSI-LD)
+**レスポンス**: `204 No Content`### Vector Tiles (NGSI-LD)
 
 地図可視化のためにエンティティデータを GeoJSON ベクタータイルとして提供します。TileJSON 3.0 準拠のメタデータと、ズームレベルおよびタイル座標による GeoJSON タイルの取得をサポートします。
 
@@ -1593,8 +1543,7 @@ ETSI NGSI-LD 互換 Context Broker API。
 
 ### 共通仕様
 
-- **Content-Type**: `application/ld+json` または `application/json`
-- **認証**: `AUTH_ENABLED=true` の場合は必須
+- **Content-Type**: `application/ld+json` または `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
 - **テナント分離**: `NGSILD-Tenant` または `Fiware-Service` ヘッダー
 - **ページネーション**: `limit`/`offset` パラメータ、総数は常に `NGSILD-Results-Count` ヘッダーで返されます
 - **OPTIONS メソッド**: すべての NGSI-LD エンドポイントは OPTIONS メソッドをサポートします。`Allow` および `Accept-Patch` ヘッダーと共に 204 レスポンスを返します

--- a/docs/ja/api-reference/ngsiv2.md
+++ b/docs/ja/api-reference/ngsiv2.md
@@ -19,35 +19,35 @@ GET /v2/entities
 
 | パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
-| `id` | string | エンティティ ID でフィルタ (複数の値をカンマ区切りのリストとして指定可能) | - |
+| `id` | string | エンティティ ID でフィルタ (カンマ区切りで複数指定可) | - |
 | `limit` | integer | 取得する結果の数 (最大: 1000) | 20 |
 | `offset` | integer | オフセット (ページネーション用) | 0 |
-| `orderBy` | string | ソート条件 (`entityId`, `entityType`, `modifiedAt`, または属性名)。降順の場合は FIWARE Orion 互換の `!` プレフィックス (例: `!temperature`) | - |
-| `orderDirection` | string | ソート方向 (`asc`, `desc`)。**GeonicDB 拡張** (公式仕様では `!` プレフィックスのアプローチのみをサポート) | `asc` |
+| `orderBy` | string | ソート条件 (`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順指定可能 (例: `!temperature`) | - |
+| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張** (公式仕様では `!` プレフィックス方式のみサポート) | `asc` |
 | `type` | string | エンティティタイプでフィルタ | - |
 | `typePattern` | string | エンティティタイプの正規表現パターン | - |
 | `idPattern` | string | エンティティ ID の正規表現パターン | - |
 | `q` | string | 属性値でフィルタ ([クエリ言語](./endpoints.md#query-language) を参照) | - |
 | `mq` | string | メタデータでフィルタ ([クエリ言語](./endpoints.md#query-language) を参照) | - |
 | `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`, `off`)。**GeonicDB 拡張** (公式仕様では `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
+| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張** (公式仕様では `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
 | `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries) を参照) | - |
 | `geometry` | string | ジオメトリタイプ | - |
-| `coords` | string | 座標 (緯度,経度形式、セミコロン区切り) | - |
+| `coords` | string | 座標 (緯度,経度 形式、セミコロン区切り) | - |
 | `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search) を参照) | - |
 | `spatialIdDepth` | integer | 空間 ID 階層展開の深さ (0-4) | 0 |
 | `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs) を参照) | `EPSG:4326` |
-| `options` | string | `keyValues`, `values`, `count`, `geojson`, `sysAttrs`, `unique` | - |
+| `options` | string | `keyValues`、`values`、`count`、`geojson`、`sysAttrs`、`unique` | - |
 
 **組み込み属性**
 
-`attrs` パラメータは、ユーザー定義属性に加えて、以下の組み込み属性をサポートしています:
+`attrs` パラメータは、ユーザー定義属性に加えて以下の組み込み属性をサポートします:
 
 | 組み込み属性 | 型 | 説明 |
 |---|---|---|
 | `dateCreated` | DateTime | エンティティ作成タイムスタンプ (`options=sysAttrs` でも利用可能) |
 | `dateModified` | DateTime | 最終更新タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateExpires` | DateTime | 一時的なエンティティの有効期限タイムスタンプ |
+| `dateExpires` | DateTime | 一時的エンティティの有効期限タイムスタンプ |
 | `servicePath` | Text | エンティティが保存されているServicePath (作成時の `Fiware-ServicePath` ヘッダー値) |
 
 例: `GET /v2/entities?attrs=temperature,servicePath`**レスポンス例**
@@ -119,7 +119,7 @@ curl "http://localhost:3000/v2/entities?type=Store" \
 }
 ```
 
-レスポンスヘッダーには `Content-Type: application/geo+json` が設定されます。
+レスポンスヘッダーに `Content-Type: application/geo+json` が設定されます。
 
 ### エンティティの作成
 
@@ -167,8 +167,10 @@ POST /v2/entities
 
 **レスポンス**
 - ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
-- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関係なく)
-- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID は、テナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細については、[エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。### 単一エンティティの取得
+- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関わらず)
+- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID は、テナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
+
+### 単一エンティティの取得
 
 ```http
 GET /v2/entities/{entityId}
@@ -178,8 +180,8 @@ GET /v2/entities/{entityId}
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
-| `type` | string | エンティティタイプ(オプションのフィルタ; エンティティ ID は一意であるため、タイプの曖昧さ解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension)を参照) |
-| `attrs` | string | 取得する属性名(カンマ区切り) |
+| `type` | string | エンティティタイプ (オプションフィルタ; エンティティ ID は一意であるため、タイプの曖昧性解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
+| `attrs` | string | 取得する属性名 (カンマ区切り) |
 | `options` | string | `keyValues`、`values` |
 
 ### エンティティの更新 (PATCH)
@@ -213,7 +215,7 @@ PATCH /v2/entities/{entityId}/attrs
 PUT /v2/entities/{entityId}/attrs
 ```
 
-すべての属性を置き換えます(指定されていない属性は削除されます)。
+すべての属性を置き換えます (指定されていない属性は削除されます)。
 
 **クエリパラメータ**
 
@@ -227,16 +229,16 @@ PUT /v2/entities/{entityId}/attrs
 POST /v2/entities/{entityId}/attrs
 ```
 
-新しい属性を追加します(既存の属性は上書きされます)。
+新しい属性を追加します (既存の属性は上書きされます)。
 
-`options=append` を指定すると、既存の属性は上書きされず、新しい属性のみが追加されます(厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
+`options=append` が指定された場合、既存の属性は上書きされず、新しい属性のみが追加されます (厳格な追加モード)。すでに存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
 
 **クエリパラメータ**
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
 | `type` | string | エンティティタイプ |
-| `options` | string | `append`: 既存の属性の上書きを禁止(厳密な追加モード) |
+| `options` | string | `append`: 既存属性の上書きを禁止 (厳格な追加モード) |
 
 **レスポンス**: `204 No Content`### エンティティの削除
 
@@ -254,7 +256,7 @@ DELETE /v2/entities/{entityId}
 
 ## 属性操作### エンティティ属性の取得
 
-エンティティのすべての属性を取得します (`id` と `type` フィールドは含まれません)。
+エンティティのすべての属性を取得します (`id` および `type` フィールドは含まれません)。
 
 ```http
 GET /v2/entities/{entityId}/attrs
@@ -295,7 +297,7 @@ GET /v2/entities/{entityId}/attrs
 }
 ```
 
-> **注**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` と `type` フィールドが含まれません。属性のみが必要な場合に使用します。
+> **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` および `type` フィールドが含まれません。属性のみが必要な場合に使用してください。
 
 ### 単一属性の取得
 
@@ -372,12 +374,12 @@ GET /v2/entities/{entityId}/attrs/{attrName}/value
 
 | 値のタイプ | Content-Type | 例 |
 |------------|--------------|---------|
-| String | `text/plain` | `hello world` |
-| Number | `text/plain` | `23.5` |
-| Boolean | `text/plain` | `true` |
+| 文字列 | `text/plain` | `hello world` |
+| 数値 | `text/plain` | `23.5` |
+| ブール値 | `text/plain` | `true` |
 | null | `text/plain` | `null` |
-| Object | `application/json` | `{"lat": 35.68, "lon": 139.76}` |
-| Array | `application/json` | `[1, 2, 3]` |
+| オブジェクト | `application/json` | `{"lat": 35.68, "lon": 139.76}` |
+| 配列 | `application/json` | `[1, 2, 3]` |
 
 **使用例**
 
@@ -431,11 +433,13 @@ curl -X PUT "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -d '{"type":"Point","coordinates":[140.0,36.0]}'
 ```
 
-**レスポンス**: `204 No Content`**注意**: この操作では、既存の属性の型やメタデータは変更されません — これらは保持されます。
+**レスポンス**: `204 No Content`**注意**: この操作は既存の属性の型やメタデータを変更しません — それらは保持されます。
 
----## バッチ操作
+---
 
-> **注意**: バッチ操作は、1回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100)。この制限を超えるリクエストは `400 Bad Request` エラーとなります。
+## バッチ操作
+
+> **注意**: バッチ操作は、1 リクエストあたり最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100)。この制限を超えるリクエストは `400 Bad Request` エラーとなります。
 
 ### バッチ更新
 
@@ -524,7 +528,7 @@ POST /v2/op/query
 POST /v2/op/notify
 ```
 
-外部の Context Broker からの通知を受信し、append でエンティティを処理します (存在しない場合は作成、既に存在する場合は更新)。
+外部の Context Broker からの通知を受信し、append でエンティティを処理します (存在しない場合は作成、すでに存在する場合は更新)。
 
 **リクエストボディ**
 
@@ -605,9 +609,9 @@ POST /v2/subscriptions
 
 **httpCustom のフィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `url` | string | ✓ | 通知先の URL |
+| `url` | string | ✓ | 通知の送信先 URL |
 | `method` | string | - | HTTP メソッド (GET, POST, PUT, PATCH, DELETE)。デフォルト: POST |
 | `headers` | object | - | カスタム HTTP ヘッダー |
 | `qs` | object | - | クエリ文字列パラメータ (`${...}` マクロ置換をサポート) |
@@ -617,7 +621,7 @@ POST /v2/subscriptions
 
 `${...}` 構文を使用して、`payload` と `qs` の値にエンティティデータを埋め込むことができます:
 
-| マクロ | 置換される値 |
+| マクロ | 置換値 |
 |-------|-------------------|
 | `${id}` | エンティティ ID |
 | `${type}` | エンティティタイプ |
@@ -654,14 +658,14 @@ POST /v2/subscriptions
 
 **MQTT 通知の設定**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `url` | string | ✓ | MQTT ブローカーの URL (`mqtt://` または `mqtts://`) |
-| `topic` | string | ✓ | 通知先のトピック |
+| `url` | string | ✓ | MQTT ブローカー URL (`mqtt://` または `mqtts://`) |
+| `topic` | string | ✓ | 通知の送信先トピック |
 | `qos` | integer | - | QoS レベル (0, 1, 2)。デフォルト: 0 |
-| `retain` | boolean | - | メッセージ保持フラグ。デフォルト: false |
-| `user` | string | - | 認証用ユーザー名 |
-| `passwd` | string | - | 認証用パスワード |
+| `retain` | boolean | - | メッセージ retain フラグ。デフォルト: false |
+| `user` | string | - | 認証ユーザー名 |
+| `passwd` | string | - | 認証パスワード |
 
 **リクエストボディ**
 
@@ -693,18 +697,18 @@ POST /v2/subscriptions
 
 **attrsFormat のタイプ**
 
-| フォーマット | 説明 |
+| 形式 | 説明 |
 |--------|-------------|
-| `normalized` | 標準の NGSIv2 フォーマット (デフォルト) |
-| `keyValues` | 簡略化されたキーバリューフォーマット |
+| `normalized` | 標準 NGSIv2 形式 (デフォルト) |
+| `keyValues` | 簡略化されたキーバリュー形式 |
 
-**通知属性のフィルタリング**
+**通知の属性フィルタリング**
 
-| フィールド | タイプ | 説明 |
+| フィールド | 型 | 説明 |
 |-------|------|-------------|
 | `attrs` | string[] | 通知に含める属性名のリスト |
 | `exceptAttrs` | string[] | 通知から除外する属性名のリスト |
-| `onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせて使用できます。 |
+| `onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせることができます。 |
 
 **レスポンス**
 - ステータス: `201 Created`- ヘッダー: `Location: /v2/subscriptions/{subscriptionId}`### サブスクリプションの一覧取得
@@ -715,11 +719,11 @@ GET /v2/subscriptions
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
+| パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
 | `limit` | integer | 取得する結果の数 | 20 |
 | `offset` | integer | オフセット | 0 |
-| `status` | string | ステータスによるフィルタ (`active`、`inactive`) | - |
+| `status` | string | ステータスでフィルタ (`active`, `inactive`) | - |
 
 ### サブスクリプションの取得
 
@@ -741,21 +745,24 @@ PATCH /v2/subscriptions/{subscriptionId}
 }
 ```
 
-**レスポンス**: `204 No Content`### サブスクリプションの削除
+**レスポンス**: `204 No Content`
+### サブスクリプションの削除
 
 ```http
 DELETE /v2/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張機能)
+**レスポンス**: `204 No Content`### 所有権検証 (GeonicDB 拡張機能)
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
 
----## レジストレーション
+---
 
-レジストレーション (Registration) は、外部コンテキストプロバイダを登録し、エンティティ情報のソースを管理します。
+## 登録
 
-### レジストレーションの作成
+登録は外部コンテキストプロバイダーを登録し、エンティティ情報のソースを管理します。
+
+### 登録の作成
 
 ```http
 POST /v2/registrations
@@ -786,16 +793,16 @@ POST /v2/registrations
 
 | フィールド | タイプ | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `description` | string | - | レジストレーションの説明 |
+| `description` | string | - | 登録の説明 |
 | `dataProvided.entities` | array | ✓ | 対象エンティティ (id, idPattern, type) |
 | `dataProvided.attrs` | array | - | 提供する属性名 |
-| `provider.http.url` | string | ✓ | プロバイダの URL |
+| `provider.http.url` | string | ✓ | プロバイダー URL |
 | `expires` | string | - | 有効期限 (ISO 8601 形式) |
 | `status` | string | - | ステータス (`active` / `inactive`)。デフォルト: `active` |
 | `mode` | string | - | 転送モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`)。NGSI-LD 互換拡張 |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /v2/registrations/{registrationId}`### レジストレーションの一覧取得
+- ステータス: `201 Created`- ヘッダー: `Location: /v2/registrations/{registrationId}`### 登録の一覧取得
 
 ```http
 GET /v2/registrations
@@ -827,13 +834,13 @@ GET /v2/registrations
 ]
 ```
 
-### レジストレーションの取得
+### 登録の取得
 
 ```http
 GET /v2/registrations/{registrationId}
 ```
 
-### レジストレーションの更新
+### 登録の更新
 
 ```http
 PATCH /v2/registrations/{registrationId}
@@ -847,23 +854,25 @@ PATCH /v2/registrations/{registrationId}
 }
 ```
 
-**レスポンス**: `204 No Content`### レジストレーションの削除
+**レスポンス**: `204 No Content`### 登録の削除
 
 ```http
 DELETE /v2/registrations/{registrationId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`### 所有権検証 (GeonicDB 拡張)
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、レジストレーションの更新 (PATCH) および削除 (DELETE) 操作は、`createdBy` フィールドに基づいて所有権の検証を行います。作成者以外のユーザがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールは、この検証をバイパスできます。詳細は AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
 
----## フェデレーション (クエリ転送 / 更新転送)
+---
 
-登録に基づいて、GeonicDB はクエリを外部コンテキストプロバイダーに転送し、結果を統合して、更新を転送します。
+## フェデレーション (クエリ転送 / 更新転送)
 
-### フェデレーションの仕組み
+レジストレーションに基づき、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合して、更新を転送します。
 
-エンティティをクエリする際、一致する登録が存在する場合、クエリはそのプロバイダーにも並行して送信され、結果がマージされて返されます。
+### フェデレーションの動作
+
+エンティティをクエリする際、一致するレジストレーションが存在する場合、そのプロバイダーにも並行してクエリが送信され、結果がマージされて返されます。
 
 ```text
 Client → Context Broker
@@ -875,18 +884,18 @@ Client → Context Broker
                         └── Results merged → returned to client
 ```
 
-### 登録モード
+### レジストレーションモード
 
 | モード | 動作 |
 |------|----------|
 | `inclusive` | ローカルとリモートの両方の結果を返す (デフォルト) |
 | `exclusive` | リモートの結果のみを返す (ローカルデータは無視される) |
 | `redirect` | 303 リダイレクト URL を返す |
-| `auxiliary` | ローカルデータを優先し、リモートで不足データを補完する |
+| `auxiliary` | ローカルデータが優先され、リモートが不足データを補完する |
 
 ### フェデレーションの例
 
-1. 外部プロバイダーを登録する:
+1. 外部プロバイダーを登録:
 
 ```bash
 curl -X POST "http://localhost:3000/v2/registrations" \
@@ -904,7 +913,7 @@ curl -X POST "http://localhost:3000/v2/registrations" \
   }'
 ```
 
-2. クエリ時にフェデレーションが自動的に実行される:
+2. クエリ実行時に自動的にフェデレーションが行われる:
 
 ```bash
 curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
@@ -915,7 +924,7 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 ### 更新転送
 
-エンティティを更新または削除する際、一致する登録が存在する場合、更新もそのプロバイダーに並行して転送されます。
+エンティティを更新または削除する際、一致するレジストレーションが存在する場合、更新もそのプロバイダーに並行して転送されます。
 
 **サポートされる更新操作**
 
@@ -942,13 +951,13 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 |----------|----------|
 | プロバイダー接続失敗 | 警告をログに記録し、ローカル結果のみを返す |
 | プロバイダータイムアウト | 警告をログに記録し、ローカル結果のみを返す |
-| 排他モードですべてのプロバイダーが失敗 | 502 エラーを返す (オプション) |
+| 排他モードで全プロバイダーが失敗 | 502 エラーを返す (オプション) |
 
 ---
 
 ## エンティティタイプ
 
-### タイプ一覧の取得
+### タイプ一覧
 
 ```http
 GET /v2/types
@@ -995,48 +1004,50 @@ GET /v2/types/{typeName}
 }
 ```
 
----## HTTP Cache Control
+---
+
+## HTTP キャッシュ制御
 
 GET エンドポイントは、エンドポイントのクラスごとにキャッシュ関連のヘッダーを返します:
 
-### データエンドポイント (entities, subscriptions, registrations) — 完全な RFC 7232 + RFC 7234 サポート
+### データエンドポイント (エンティティ、サブスクリプション、登録) — RFC 7232 + RFC 7234 の完全サポート
 
-| Header | Value | Purpose |
+| ヘッダー | 値 | 目的 |
 |--------|-------|---------|
-| `ETag` | `W/"..."` | 弱い検証子。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
+| `ETag` | `W/"..."` | 弱い検証子。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと合計カウント、スコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
 | `Last-Modified` | RFC 1123 HTTP-date | 結果セット内の最新の `modifiedAt` のタイムスタンプ。 |
-| `Cache-Control` | `private, no-cache` | `private` は共有/中間キャッシュストレージをブロックし、`no-cache` はプライベートキャッシュからの再検証を強制します。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュのためのテナント + 認証 + コンテンツネゴシエーション分離。 |
+| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制します。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュのためのテナント + 認証 + コンテンツネゴシエーションの分離。 |
 
 条件付きリクエストがサポートされています:
 
-| Request Header | Behavior |
+| リクエストヘッダー | 動作 |
 |----------------|----------|
 | `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified` (空のボディ) を返します。 |
 | `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。 |
-| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` でオーバーライドします。 |
+| `Cache-Control: no-store` | サーバーがレスポンスの `Cache-Control` を `no-store` に上書きします。 |
 
-### メタエンドポイント (types) — Cache-Control + Vary のみ (ETag なし / 304 なし)
+### メタエンドポイント (タイプ) — Cache-Control + Vary のみ (ETag なし / 304 なし)
 
-| Header | Value | Purpose |
+| ヘッダー | 値 | 目的 |
 |--------|-------|---------|
 | `Cache-Control` | `max-age=60, stale-while-revalidate=120` | バックグラウンド再検証を伴う短期キャッシング。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント/認証分離。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証の分離。 |
 
-メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
+メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` の条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
 
-完全なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
+詳細なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
 
 ---
 
 ## HTTP エラーレスポンス
 
-| Status Code | Error Code | Description |
+| ステータスコード | エラーコード | 説明 |
 |-------------|------------|-------------|
 | 400 | BadRequest | 無効なリクエストパラメータまたはボディ |
-| 400 | InvalidModification | 無効な属性の変更 (例: id または type の変更) |
+| 400 | InvalidModification | 無効な属性の変更 (例: id や type の変更) |
 | 401 | Unauthorized | 認証が必要、またはトークンが無効 |
-| 403 | Forbidden | 権限が不足 |
+| 403 | Forbidden | 権限不足 |
 | 404 | NotFound | エンティティ、サブスクリプションなどが見つかりません |
 | 405 | MethodNotAllowed | HTTP メソッドが許可されていません |
 | 409 | AlreadyExists | エンティティがすでに存在します (POST 作成時) |
@@ -1044,11 +1055,11 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 | 411 | ContentLengthRequired | Content-Length ヘッダーが必要です |
 | 413 | RequestEntityTooLarge | リクエストボディが大きすぎます |
 | 415 | UnsupportedMediaType | サポートされていない Content-Type |
-| 422 | Unprocessable | エンティティ形式が無効です |
+| 422 | Unprocessable | エンティティの形式が無効です |
 | 429 | TooManyRequests | レート制限を超過しました |
 | 500 | InternalError | 内部サーバーエラー |
 
-**エラーレスポンス形式**
+**エラーレスポンスフォーマット**
 
 ```json
 {
@@ -1057,9 +1068,11 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 }
 ```
 
----## エンドポイント リファレンス
+---
 
-FIWARE NGSIv2 互換 Context Broker API。
+## エンドポイント・リファレンス
+
+FIWARE NGSIv2 互換コンテキストブローカー API。
 
 ### 共通仕様
 
@@ -1071,53 +1084,53 @@ FIWARE NGSIv2 互換 Context Broker API。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/entities` | GET | エンティティ一覧を取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/entities` | POST | エンティティを作成 | 201 | 400, 401, 409, 415 | - |
-| `/v2/entities/{entityId}` | GET | エンティティを取得 | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}` | DELETE | エンティティを削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | GET | 属性のみを取得(id/type フィールドなし) | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | PATCH | 属性を更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | POST | 属性を追加 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | PUT | 属性を置換 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | GET | 属性を取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | PUT | 属性を更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | DELETE | 属性を削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET | 属性値を取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT | 属性値を更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities` | GET | エンティティ一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/entities` | POST | エンティティ作成 | 201 | 400, 401, 409, 415 | - |
+| `/v2/entities/{entityId}` | GET | エンティティ取得 | 200 | 400, 401, 404 | - |
+| `/v2/entities/{entityId}` | DELETE | エンティティ削除 | 204 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs` | GET | 属性のみ取得 (id/type フィールドなし) | 200 | 400, 401, 404 | - |
+| `/v2/entities/{entityId}/attrs` | PATCH | 属性更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs` | POST | 属性追加 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs` | PUT | 属性置換 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}` | GET | 属性取得 | 200 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}` | PUT | 属性更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}` | DELETE | 属性削除 | 204 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET | 属性値取得 | 200 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT | 属性値更新 | 204 | 400, 401, 404, 415 | - |
 
 ### タイプ操作
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/types` | GET | タイプ一覧を取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/types/{typeName}` | GET | タイプ詳細を取得 | 200 | 401, 404 | - |
+| `/v2/types` | GET | タイプ一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/types/{typeName}` | GET | タイプ詳細取得 | 200 | 401, 404 | - |
 
 ### サブスクリプション操作
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/subscriptions` | GET | サブスクリプション一覧を取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/subscriptions` | POST | サブスクリプションを作成 | 201 | 400, 401, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | GET | サブスクリプションを取得 | 200 | 401, 404 | - |
-| `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプションを更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプションを削除 | 204 | 401, 404 | - |
+| `/v2/subscriptions` | GET | サブスクリプション一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/subscriptions` | POST | サブスクリプション作成 | 201 | 400, 401, 415 | - |
+| `/v2/subscriptions/{subscriptionId}` | GET | サブスクリプション取得 | 200 | 401, 404 | - |
+| `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプション更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプション削除 | 204 | 401, 404 | - |
 
 ### 登録操作 (フェデレーション)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/registrations` | GET | 登録一覧を取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/registrations` | POST | 登録を作成 | 201 | 400, 401, 415 | - |
-| `/v2/registrations/{registrationId}` | GET | 登録を取得 | 200 | 401, 404 | - |
-| `/v2/registrations/{registrationId}` | PATCH | 登録を更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/registrations/{registrationId}` | DELETE | 登録を削除 | 204 | 401, 404 | - |
+| `/v2/registrations` | GET | 登録一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/registrations` | POST | 登録作成 | 201 | 400, 401, 415 | - |
+| `/v2/registrations/{registrationId}` | GET | 登録取得 | 200 | 401, 404 | - |
+| `/v2/registrations/{registrationId}` | PATCH | 登録更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/registrations/{registrationId}` | DELETE | 登録削除 | 204 | 401, 404 | - |
 
 ### バッチ操作
 
-> **注意**: バッチ操作 (クエリを除く) は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています (デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
+> **注意**: バッチ操作 (クエリを除く) はリクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています (デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/v2/op/update` | POST | バッチ更新 (最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
 | `/v2/op/query` | POST | バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
-| `/v2/op/notify` | POST | 通知を受信 | 200 | 400, 401, 415 | - |
+| `/v2/op/notify` | POST | 通知受信 | 200 | 400, 401, 415 | - |

--- a/docs/ja/changelog.md
+++ b/docs/ja/changelog.md
@@ -23,7 +23,9 @@ outline: deep
     - **strict tsconfig 環境を再現** した consumer プロジェクトを `tmpdir` に組み立て、`tsc --project` で実コンパイルし、各エラークラス / public type の named import (`import { ... }` および `import type { ... }`) が **TS2614 にならないこと** を assertion
     - 公開 d.ts に `export * from` 形式が混入しないことを正規表現で禁止
     - `src/sdk/index.ts` ソースの export 名と公開 d.ts の export 名が一致することを drift guard で検証
-  - ドキュメント: `docs/SDK.md` / `src/sdk/README.md` に「TypeScript」節を追加し、strict tsconfig でも named import が解決できる旨を明記## [0.7.0] — 2026-05-02
+  - ドキュメント: `docs/SDK.md` / `src/sdk/README.md` に「TypeScript」節を追加し、strict tsconfig でも named import が解決できる旨を明記
+
+## [0.7.0] — 2026-05-02
 
 ### 2026-05-02
 - **改善**: ReactiveCore Rules の SLO 超過に対する協調キャンセルを実装 (issue #1122) (#1123)
@@ -56,7 +58,8 @@ outline: deep
     - `tests/e2e/features/auth/rules-auto-fire.feature` で「entity 作成 API のみで Rule action が自動実行される」シナリオを 2 つ追加 (`triggerRuleExecution` を介さない再現テスト)
     - `tests/unit/infrastructure/sam-template.test.ts` で `infrastructure/template.yaml` の最小構造を検証 (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction が EventBridgeRule で 3 種の detail-type を listen していることを機械的に確認)
     - `tests/unit/handlers/rules/processor.test.ts` で新規 handler 単体の挙動 (3 種イベント委譲・secondary region スキップ・エラー握り潰し・タイムアウト) を検証
-  - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`## [0.6.0] — 2026-05-01
+  - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
+## [0.6.0] — 2026-05-01
 
 ### 2026-05-01
 - **認可**: WebSocket 配信時の XACML AuthzRequest に `entityOwner` / `entityId` を inject (issue #1107) (#1116)
@@ -243,7 +246,9 @@ outline: deep
     - `local-server.ts` — Express の自動 ETag 生成を `app.set('etag', false)` で無効化。ローカル開発でも本番 (API Gateway + Lambda) と同じ挙動を再現
     - **追加カバレッジ**: NGSIv2 / NGSI-LD の attribute-level GET エンドポイント (`/v2/entities/{id}/attrs`, `/v2/entities/{id}/attrs/{name}`, `/v2/entities/{id}/attrs/{name}/value`, `/ngsi-ld/v1/entities/{id}/attrs/{name}`) も `applyCacheHeaders` 経由で ETag/Last-Modified/Cache-Control/Vary を返すよう追加。Express auto-ETag 無効化に伴うキャッシュ無し状態を回避
   - **テスト** (#1054): cache-control middleware unit test に scope 検証 11 ケース追加。`http-cache-control.feature` に B-1 / B-2 / B-3 / B-4 シナリオ 7 件追加。`head-requests.feature` を 200 期待形に書き換え (HEAD が GET 等価で動作することを検証)
-  - **ドキュメント** (#1054): `docs/API.md` に Temporal クラス追加、ETag scope (path + Accept) の説明追加、HEAD サポート明記、attribute-level エンドポイント追加## [0.4.0] — 2026-04-27
+  - **ドキュメント** (#1054): `docs/API.md` に Temporal クラス追加、ETag scope (path + Accept) の説明追加、HEAD サポート明記、attribute-level エンドポイント追加
+
+## [0.4.0] — 2026-04-27
 
 ### 2026-04-27
 - **Feature**: SDK クライアントキャッシュ Phase A — `@geolonia/geonicdb-sdk` に in-memory cache + ETag/304 自動ハンドリング + リクエスト重複排除 + ETag ベースの `poll()` API を追加 (#1043)
@@ -619,8 +624,7 @@ outline: deep
   - 暗号化/非暗号化テナントの後方互換共存
   - Temporal/Snapshot リポジトリの暗号化統合
   - SAM テンプレート: KMS IAM ポリシー、DynamoDB SSE 設定、`EncryptionEnabled` パラメータ追加
-  - 依存追加: `@aws-sdk/client-kms`
-### 2026-02-25
+  - 依存追加: `@aws-sdk/client-kms`### 2026-02-25
 - **Feat**: マルチリージョン HA アーキテクチャ Phase 1+2 (#557)
   - Active-Passive 構成 (Primary: ap-northeast-1, Secondary: ap-northeast-3)
   - ヘルスチェック強化: `/health`、`/health/live`、`/health/ready` に `region`、`regionRole` を追加

--- a/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
+++ b/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
@@ -5,19 +5,19 @@ outline: deep
 ---
 # NGSIv2 / NGSI-LD プロトコル分離
 
-GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートします。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルごとに分離されています** -- NGSIv2 で作成されたエンティティは NGSIv2 でのみアクセス可能で、NGSI-LD についても同様です。
+GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートしています。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルによって分離されています** -- NGSIv2 で作成されたエンティティは NGSIv2 経由でのみアクセス可能であり、NGSI-LD についても同様です。
 
 ## 目次
 
 - [概要](#概要)
-- [統一された内部形式](#統一された内部形式)
+- [統一内部形式](#統一内部形式)
 - [プロトコル分離](#プロトコル分離)
 - [属性タイプマッピングテーブル](#属性タイプマッピングテーブル)
 - [システム属性の違い](#システム属性の違い)
 - [出力形式の違い](#出力形式の違い)
 - [共有機能](#共有機能)
 - [NGSI-LD 固有の機能](#ngsi-ld-固有の機能)
-- [エンティティ ID の考慮事項](#エンティティ-id-の考慮事項)
+- [エンティティ ID に関する考慮事項](#エンティティ-id-に関する考慮事項)
 - [フェデレーション](#フェデレーション)
 - [ユースケースとベストプラクティス](#ユースケースとベストプラクティス)
 
@@ -25,7 +25,7 @@ GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API 
 
 ## 概要
 
-GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートします。各エンティティは、それを作成したプロトコルでタグ付けされ、2 つの API 間の厳格な分離を保証します。
+GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートしています。各エンティティは、それを作成したプロトコルでタグ付けされ、2 つの API 間の厳密な分離が保証されます。
 
 ### アーキテクチャ
 
@@ -36,20 +36,20 @@ NGSI-LD API (/ngsi-ld/v1) ──> [protocol: 'ngsild'] ┘
 ```
 
 - 両方の API は同じ MongoDB ストレージと統一された内部形式を共有します
-- 各エンティティは作成時に設定される `protocol` フィールド (`'ngsiv2'` または `'ngsild'`) を持ちます
+- 各エンティティには、作成時に設定される `protocol` フィールド (`'ngsiv2'` または `'ngsild'`) があります
 - クエリはプロトコルでフィルタリングされます: NGSIv2 API は `protocol: 'ngsiv2'` エンティティのみを返し、NGSI-LD API は `protocol: 'ngsild'` エンティティのみを返します
 - `protocol` フィールドを持たない既存のエンティティは `'ngsild'` として扱われます
 
-### 利点
+### メリット
 
 - **プロトコル分離** - 明確な境界により、意図しないプロトコル間のデータ漏洩を防ぎ、各 API が仕様に準拠したエンティティのみを返すことを保証します
 - **仕様準拠** - 各 API は独自の仕様内で厳密に動作し、形式変換によるエッジケースを回避します
-- **既存システムとの統合** - NGSIv2 と NGSI-LD のワークロードを干渉なく並行して実行できます
-- **API 選択の自由** - 各ユースケースに最適な API を選択でき、プロトコル間の連携にはフェデレーションを使用します
+- **既存システムとの統合** - NGSIv2 と NGSI-LD のワークロードを干渉なしに並行して実行できます
+- **API 選択の自由** - 各ユースケースに最適な API を選択でき、プロトコル間のニーズにはフェデレーションを使用します
 
 ---
 
-## 統一された内部形式
+## 統一内部形式
 
 GeonicDB は、両方の API からのデータを統一された内部形式に変換します。
 
@@ -117,17 +117,17 @@ interface EntityDocument {
 | 操作 | NGSIv2 エンティティ (`protocol: 'ngsiv2'`) | NGSI-LD エンティティ (`protocol: 'ngsild'`) |
 |-----------|--------------------------------------|---------------------------------------|
 | NGSIv2 GET/LIST | 表示される | 表示されない |
-| NGSIv2 UPDATE/DELETE | 許可 | 見つからない (404) |
+| NGSIv2 UPDATE/DELETE | 許可される | 見つからない (404) |
 | NGSI-LD GET/LIST | 表示されない | 表示される |
-| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可 |
+| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可される |
 
 ### レガシーエンティティ
 
-プロトコル分離が導入される前に作成されたエンティティ(つまり、データベースに `protocol` フィールドがないもの)は、`'ngsild'` として扱われます。これらは NGSI-LD API 経由でのみアクセス可能です。
+プロトコル分離が導入される前に作成されたエンティティ(つまり、データベースに `protocol` フィールドがないもの)は、`'ngsild'` として扱われます。これらは NGSI-LD API を介してのみアクセス可能です。
 
-### フェデレーションによるプロトコル間アクセス
+### フェデレーションによるクロスプロトコルアクセス
 
-直接的なプロトコル間アクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション**(コンテキストソース登録)を使用して、1 つの GeonicDB インスタンスを他のプロトコルのコンテキストプロバイダーとして登録してください。詳細については、[フェデレーション](#フェデレーション)セクションを参照してください。
+直接的なクロスプロトコルアクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション**(コンテキストソース登録)を使用して、1 つの GeonicDB インスタンスを他のプロトコルのコンテキストプロバイダーとして登録してください。詳細については、[フェデレーション](#federation) セクションを参照してください。
 
 ### 例: プロトコル分離の動作
 
@@ -180,9 +180,9 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ### NGSI-LD 固有タイプ
 
-以下の NGSI-LD 固有タイプは内部的に保持されますが、NGSIv2 API では `Property` として扱われます。
+以下の NGSI-LD 固有タイプは内部的には保持されますが、NGSIv2 API では `Property` として扱われます。
 
-| NGSI-LD タイプ | 内部タイプ | NGSIv2 変換 | 説明 |
+| NGSI-LD タイプ | 内部タイプ | NGSIv2 への変換 | 説明 |
 |--------------|---------------|-------------------|-------------|
 | `Relationship` | `Relationship` | `Relationship` (カスタムタイプ) | エンティティ参照 (`object` プロパティを含む) |
 | `LanguageProperty` | `LanguageProperty` | `StructuredValue` | 多言語文字列 (`languageMap` プロパティを含む) |
@@ -203,7 +203,7 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ## システム属性の違い
 
-エンティティのメタデータ (作成および変更のタイムスタンプ) は、API によって異なる名前を使用します。
+エンティティメタデータ (作成および変更タイムスタンプ) は、API によって異なる名前を使用します。
 
 ### NGSIv2 システム属性
 
@@ -212,7 +212,7 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 | `dateCreated` | `DateTime` | エンティティ作成タイムスタンプ (ISO 8601) |
 | `dateModified` | `DateTime` | エンティティ最終更新タイムスタンプ (ISO 8601) |
 
-**例 (NGSIv2 レスポンス、`options=dateCreated,dateModified` を使用):**
+**例 (NGSIv2 レスポンスで `options=dateCreated,dateModified` を使用):**
 
 ```json
 {
@@ -240,7 +240,7 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 | `createdAt` | ISO 8601 文字列 | エンティティ作成タイムスタンプ |
 | `modifiedAt` | ISO 8601 文字列 | エンティティ最終更新タイムスタンプ |
 
-**注:** `pick` パラメータを使用する場合、レスポンスには明示的にリクエストされた属性と、常に存在する `@context`、`id`、`type` が含まれます。ただし、`createdAt` と `modifiedAt` は、`pick` を使用しても返されません — これらのシステム属性には `sysAttrs` オプションが必要です。
+**注意:** `pick` パラメータを使用する場合、レスポンスには明示的にリクエストされた属性と、常に存在する `@context`、`id`、`type` が含まれます。しかし、`createdAt` と `modifiedAt` は `pick` を使用しても返されません — これらのシステム属性には `sysAttrs` オプションが必要です。
 
 **例 (NGSI-LD レスポンス、システム属性は常に含まれる):**
 
@@ -276,12 +276,12 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 各 API は複数のレスポンス形式をサポートしています。
 
-### NGSIv2 の出力形式
+### NGSIv2 出力形式
 
 | 形式 | options パラメータ | 説明 |
 |--------|-------------------|-------------|
 | **normalized** (デフォルト) | (なし) | 型とメタデータを含む完全な形式 |
-| **keyValues** | `options=keyValues` | キーと値のペアのみ (メタデータなし) |
+| **keyValues** | `options=keyValues` | キーと値のペアのみ(メタデータなし) |
 | **values** | `options=values` | 属性値の配列のみ |
 
 **例:**
@@ -297,12 +297,12 @@ curl http://localhost:3000/v2/entities/Room1?options=keyValues
 curl 'http://localhost:3000/v2/entities?type=Room&options=values&attrs=temperature,humidity'
 ```
 
-### NGSI-LD の出力形式
+### NGSI-LD 出力形式
 
 | 形式 | Accept ヘッダー | 説明 |
 |--------|---------------|-------------|
 | **normalized** (デフォルト) | `application/ld+json` | 型とメタデータを含む完全な形式 |
-| **concise** | `application/ld+json` + `options=concise` | 簡潔な形式 (省略表記) |
+| **concise** | `application/ld+json` + `options=concise` | 簡潔な形式(省略表記) |
 | **keyValues** | `application/ld+json` + `options=keyValues` | キーと値のペアのみ |
 
 **例:**
@@ -332,7 +332,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1?options=k
 | **メタデータクエリ** | `mq` パラメータ | `q` パラメータ (メタデータもクエリ可能) | メタデータフィルタ |
 | **スコープクエリ** | `Fiware-ServicePath` ヘッダー (スコープから独立) | `scopeQ` パラメータ | スコープ階層フィルタ |
 
-**基本的な例:**
+**基本例:**
 
 ```bash
 # NGSIv2: Entities with temperature greater than 20
@@ -344,7 +344,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?type=Room&q=temperature>20'
 
 #### メタデータクエリ (mq) の詳細
 
-NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートしています。
+NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートします。
 
 **サポートされている演算子:**
 
@@ -354,7 +354,7 @@ NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリ�
 | `!=` | 等しくない | `mq=temperature.accuracy!=0` |
 | `>`, `<`, `>=`, `<=` | 比較演算子 | `mq=temperature.accuracy>0.9` |
 | `~=` | パターンマッチ | `mq=temperature.unit~=Cel.*` |
-| `..` | 範囲 (包含) | `mq=temperature.accuracy==0.9..1.0` |
+| `..` | 範囲 (両端を含む) | `mq=temperature.accuracy==0.9..1.0` |
 | `,` | リスト (OR) | `mq=temperature.unit==Celsius,Fahrenheit` |
 | `;` | AND 条件 | `mq=temperature.accuracy>0.9;temperature.unit==Celsius` |
 | `|` | OR 条件 | `mq=temperature.accuracy>0.9|humidity.accuracy>0.8` |
@@ -377,15 +377,15 @@ curl 'http://localhost:3000/v2/entities?type=Room&mq=temperature.accuracy>0.9;te
 
 #### スコープクエリ (scopeQ) の詳細
 
-NGSI-LD の `scopeQ` パラメータは、エンティティのスコープ階層に対するクエリをサポートしています。
+NGSI-LD の `scopeQ` パラメータは、エンティティスコープ階層に対するクエリをサポートします。
 
 **サポートされている演算子:**
 
 | 演算子 | 説明 | 例 |
 |----------|-------------|---------|
 | `/path` | 完全一致 | `scopeQ=/Japan/Tokyo` |
-| `/path/+` | 1 レベル下のみ | `scopeQ=/Japan/+` (例: 東京) |
-| `/path/#` | すべての子孫 | `scopeQ=/Japan/#` (例: 東京、東京/渋谷) |
+| `/path/+` | 1 レベル下のみ | `scopeQ=/Japan/+` (例: Tokyo) |
+| `/path/#` | すべての子孫 | `scopeQ=/Japan/#` (例: Tokyo、Tokyo/Shibuya) |
 | `;` | AND 条件 (複数スコープ) | `scopeQ=/Japan/Tokyo;/IoT` |
 
 **例:**
@@ -408,9 +408,9 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo;/IoT'
 
 | ジオクエリ演算子 | NGSIv2 | NGSI-LD | 説明 |
 |--------------------|--------|---------|-------------|
-| `near` | ✅ | ✅ | 指定地点の近く |
+| `near` | ✅ | ✅ | 指定された点の近く |
 | `coveredBy` | ✅ | ✅ | 領域内に完全に含まれる |
-| `within` | ✅ | ✅ | 領域と交差または含まれる |
+| `within` | ✅ | ✅ | 領域と交差するか含まれる |
 | `intersects` | ✅ | ✅ | 領域と交差する |
 | `disjoint` | ✅ | ✅ | 領域と交差しない |
 
@@ -429,7 +429,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 | ヘッダー | NGSIv2 | NGSI-LD | 説明 |
 |--------|--------|---------|-------------|
 | **総数** | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数 |
-| **次へのリンク** | `Link` (rel="next") | `Link` (rel="next") | 次のページへのリンク |
+| **次のリンク** | `Link` (rel="next") | `Link` (rel="next") | 次のページへのリンク |
 
 詳細については、[ページネーション](/ja/api-reference/pagination)を参照してください。
 
@@ -438,7 +438,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 | 通知方法 | NGSIv2 | NGSI-LD | 説明 |
 |--------------------|--------|---------|-------------|
 | **HTTP Webhook** | ✅ | ✅ | REST エンドポイントへの POST |
-| **MQTT** | ✅ | ✅ | MQTT ブローカーへのパブリッシュ (QoS 0/1/2、TLS) |
+| **MQTT** | ✅ | ✅ | MQTT ブローカーへの発行 (QoS 0/1/2、TLS) |
 | **WebSocket** | ✅ | ✅ | リアルタイムイベントストリーム |
 
 ### 5. フェデレーション (コンテキストソース登録)
@@ -447,14 +447,16 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 |---------|--------|---------|-------------|
 | **登録 API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダーの登録 |
 | **並列クエリ** | ✅ | ✅ | 複数プロバイダーへの同時クエリ |
-| **結果のマージ** | ✅ | ✅ | ローカルとリモート結果のマージ |
+| **結果のマージ** | ✅ | ✅ | ローカルとリモートの結果のマージ |
 | **ループ検出** | ✅ | ✅ | `Via` ヘッダーによるループ検出 |
 
 ---
 
 ## NGSI-LD 固有の機能
 
-以下の機能は NGSI-LD API でのみサポートされており、NGSIv2 API では直接利用できません。### 1. Relationship
+以下の機能は NGSI-LD API でのみサポートされており、NGSIv2 API では直接利用できません。
+
+### 1. Relationship
 
 エンティティ間の関連を表します。
 
@@ -473,7 +475,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 
 > **注:** プロトコル分離により、NGSI-LD エンティティ（Relationship 属性を持つものを含む）は NGSIv2 API からアクセスできません。
 
-### 2. LanguageProperty (多言語プロパティ)
+### 2. LanguageProperty（多言語プロパティ）
 
 複数の言語で文字列を保持します。
 
@@ -515,9 +517,9 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
 
 > **注:** プロトコル分離により、NGSI-LD エンティティ（LanguageProperty 属性を持つものを含む）は NGSIv2 API からアクセスできません。
 
-### 3. Scope (スコープ階層)
+### 3. Scope（スコープ階層）
 
-エンティティの論理的な階層を表します。
+エンティティの論理階層を表します。
 
 **NGSI-LD:**
 
@@ -538,18 +540,20 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo'
 
 **NGSIv2 互換性:**
 
-- NGSIv2 は階層的なエンティティ管理のために `Fiware-ServicePath` ヘッダを使用します
-- `servicePath` は `?attrs=servicePath` を介して組み込み属性として利用可能です
+- NGSIv2 は階層的なエンティティ管理に `Fiware-ServicePath` ヘッダーを使用します
+- `servicePath` は `?attrs=servicePath` を通じて組み込み属性として利用できます
 - **servicePath と scope は独立した概念です (#964):** これらは自動的には同期されません
   - NGSIv2 `Fiware-ServicePath` → DB に `servicePath` として保存されます（インフラストラクチャレベルの分離）
   - NGSI-LD `scope` → DB に `scope` として保存されます（ユーザー定義の論理階層）
-  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダを無視します### 4. 属性の射影 (pick / omit パラメーター)
+  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダーを無視します
 
-NGSI-LD では、`pick` と `omit` クエリパラメーターを使用して、レスポンスに含まれる属性を制御できます。
+### 4. Attribute Projection (pick / omit パラメータ)
 
-#### pick パラメーター (属性の選択)
+NGSI-LD では、`pick` と `omit` クエリパラメータを使用して、レスポンスに含まれる属性を制御できます。
 
-レスポンスに指定した属性のみを含めます。
+#### pick パラメータ (属性選択)
+
+指定した属性のみをレスポンスに含めます。
 
 **例:**
 
@@ -576,9 +580,9 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?pick=temper
 }
 ```
 
-#### omit パラメーター (属性の除外)
+#### omit パラメータ (属性除外)
 
-レスポンスから指定した属性を除外します。
+指定した属性をレスポンスから除外します。
 
 **例:**
 
@@ -608,13 +612,13 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?omit=locati
 **注意事項:**
 
 - `pick` と `omit` は同時に使用できません
-- `pick` を使用する場合:`@context`、`id`、`type`、および指定した属性のみが含まれます。`createdAt` と `modifiedAt` は含まれません。
-- `omit` を使用する場合:指定した属性以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様による)
+- `pick` を使用する場合: `@context`、`id`、`type`、および指定した属性のみが含まれます。`createdAt` と `modifiedAt` は含まれません。
+- `omit` を使用する場合: 指定した属性以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様による)
 
 **NGSIv2 互換性:**
 
-- NGSIv2 API では、`attrs` パラメーターが同等の機能を提供します (選択のみ)
-- `omit` に相当する NGSIv2 の機能はありません
+- NGSIv2 API では、`attrs` パラメータが同等の機能を提供します (pick のみ)
+- NGSIv2 には `omit` に相当するものはありません
 
 ```bash
 # Retrieve only temperature and humidity with NGSIv2 (equivalent to pick)
@@ -642,30 +646,30 @@ NGSI-LD では、エンティティに `@context` を含めることで語彙を
 **NGSIv2 互換性:**
 
 - NGSIv2 には `@context` の概念がありません
-- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API から返されません
+- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API では返されません
 
 ---
 
-## エンティティ ID に関する考慮事項
+## エンティティ ID の考慮事項
 
 ### エンティティ ID の一意性 (GeonicDB 拡張)
 
-> **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント (`Fiware-Service`) とServicePath (`Fiware-ServicePath`) のスコープ内で一意です。エンティティ `type` は一意性制約の一部では**ありません**。
+> **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント (`Fiware-Service`) とServicePath (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の**一部ではありません**。
 
-これは、両方の API 間で ID のセマンティクスを統一する意図的な設計決定です:
+これは意図的な設計上の決定であり、両 API 間で ID のセマンティクスを統一します:
 
 - **NGSI-LD** はエンティティ ID を URI として扱い、本質的に一意です
-- **NGSIv2** (標準) は同じ ID で異なる型のエンティティが共存することを許可しますが、GeonicDB はこの動作を**サポートしていません**
+- **NGSIv2** (標準) は同じ ID でも異なる型のエンティティの共存を許可しますが、GeonicDB はこの動作を**サポートしません**
 
 **影響:**
 
-- **直接作成** (`POST /v2/entities`、`POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID を持つエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- **バッチ更新** (`POST /v2/op/update` と `append`/`appendStrict`): `entityId` のみでエンティティを照合します。属性は更新されますが、元の `type` は保持されます
-- **バッチアップサート** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティを照合します。属性は更新されます (型の処理はアップサートのセマンティクスに従います)
-- **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複する ID に対して、エンティティごとのエラー詳細を含む `207` を返します
-- 同じ ID のエンティティ間で型を区別するための NGSIv2 の `?type=` パラメータは適用されなくなりました
+- **直接作成** (`POST /v2/entities`、`POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID を持つエンティティを作成すると (異なる `type` であっても) `409 AlreadyExists` が返されます
+- **バッチ更新** (`POST /v2/op/update` と `append`/`appendStrict`): `entityId` のみでエンティティをマッチングします。属性は更新されますが、元の `type` は保持されます
+- **バッチアップサート** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティをマッチングします。属性は更新されます (型の処理はアップサートのセマンティクスに従います)
+- **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複する ID に対してエンティティごとのエラー詳細を含む `207` を返します
+- 同じ ID のエンティティ間の型による曖昧性解消のための NGSIv2 `?type=` パラメータは適用されなくなりました
 
-この統一により、NGSIv2 の型ベースの区別が NGSI-LD の一意 ID モデルと競合する相互運用性の問題が解消されます。
+この統一により、NGSIv2 の型ベースの曖昧性解消が NGSI-LD の一意 ID モデルと競合する相互運用性の問題が解消されます。
 
 ### NGSI-LD URI 要件
 
@@ -687,31 +691,31 @@ urn:ngsi-ld:WeatherObserved:Tokyo-2026-02-08
 
 **NGSIv2 互換性:**
 
-- NGSIv2 は任意の文字列を ID として使用できます (例: `Room1`、`sensor-abc`)
-- 一貫性と将来の移行のために、どちらの API を使用する場合でも URN 形式の使用を推奨します
+- NGSIv2 では任意の文字列を ID として使用できます (例: `Room1`、`sensor-abc`)
+- 一貫性と将来の移行のため、どちらの API を使用する場合でも URN 形式の使用を推奨します
 
 **ベストプラクティス:**
 
 - NGSIv2 API を使用する場合でも、すべてのエンティティに URN 形式を使用してください
-- NGSIv2 から NGSI-LD へ移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコル分離により API 間のアクセスができません)
+- NGSIv2 から NGSI-LD へ移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコルの分離により API 間のアクセスは防止されます)
 
 ---
 
-## フェデレーション
+## Federation
 
-GeonicDB のフェデレーション機能は、リモートコンテキストプロバイダーのプロトコルを自動的に検出します。
+GeonicDB の federation 機能は、リモートコンテキストプロバイダのプロトコルを自動検出します。
 
 ### 自動プロトコル検出
 
-登録されたリモートプロバイダーに対して、GeonicDB は以下の順序でプロトコルを検出します:
+登録されたリモートプロバイダに対して、GeonicDB は以下の順序でプロトコルを検出します:
 
-1. **明示的な指定** - 登録時に `information.format` が指定されている場合、そのプロトコルが使用されます
+1. **明示的な指定** - 登録時に `information.format` が指定されている場合、そのプロトコルを使用
 2. **自動検出** - URL パスからの自動検出:
    - `/v2/` を含む → NGSIv2
    - `/ngsi-ld/` を含む → NGSI-LD
    - それ以外 → NGSIv2 (デフォルト)
 
-### NGSIv2 からのフェデレーション
+### NGSIv2 からの Federation
 
 **NGSIv2 で登録:**
 
@@ -734,7 +738,7 @@ curl -X POST http://localhost:3000/v2/registrations \
   }'
 ```
 
-**NGSIv2 でクエリすると、自動的に NGSI-LD プロバイダーへ転送されます:**
+**NGSIv2 でクエリすると、NGSI-LD プロバイダへ自動的に転送されます:**
 
 ```bash
 curl http://localhost:3000/v2/entities/urn:ngsi-ld:Vehicle:V999 \
@@ -743,12 +747,11 @@ curl http://localhost:3000/v2/entities/urn:ngsi-ld:Vehicle:V999 \
 
 **動作:**
 
-1. GeonicDB は `urn:ngsi-ld:Vehicle:V999` がローカルに存在しないことを検出します
-2. 登録情報から `http://remote-provider.example.com/ngsi-ld/v1` を特定します
-3. NGSI-LD プロトコルを使用してクエリを転送します: `GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`
-4. レスポンスを NGSI-LD → 内部形式 → NGSIv2 に変換し、クライアントに返します
+1. GeonicDB は `urn:ngsi-ld:Vehicle:V999` がローカルに存在しないことを検出
+2. 登録情報から `http://remote-provider.example.com/ngsi-ld/v1` を特定
+3. NGSI-LD プロトコルを使用してクエリを転送: `GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`4. レスポンスを NGSI-LD → 内部形式 → NGSIv2 に変換してクライアントへ返却
 
-### NGSI-LD からのフェデレーション
+### NGSI-LD からの Federation
 
 **NGSI-LD で登録:**
 
@@ -770,7 +773,7 @@ curl -X POST http://localhost:3000/ngsi-ld/v1/csourceRegistrations \
   }'
 ```
 
-**NGSI-LD でクエリすると、自動的に NGSIv2 プロバイダーへ転送されます:**
+**NGSI-LD でクエリすると、NGSIv2 プロバイダへ自動的に転送されます:**
 
 ```bash
 curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:S888 \
@@ -779,53 +782,52 @@ curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:S888 \
 
 **動作:**
 
-1. GeonicDB は `urn:ngsi-ld:Sensor:S888` がローカルに存在しないことを検出します
-2. 登録情報から `http://legacy-system.example.com/v2` を特定します
-3. NGSIv2 プロトコルを使用してクエリを転送します: `GET /v2/entities/urn:ngsi-ld:Sensor:S888`
-4. レスポンスを NGSIv2 → 内部形式 → NGSI-LD に変換し、クライアントに返します
+1. GeonicDB は `urn:ngsi-ld:Sensor:S888` がローカルに存在しないことを検出
+2. 登録情報から `http://legacy-system.example.com/v2` を特定
+3. NGSIv2 プロトコルを使用してクエリを転送: `GET /v2/entities/urn:ngsi-ld:Sensor:S888`4. レスポンスを NGSIv2 → 内部形式 → NGSI-LD に変換してクライアントへ返却
 
 ---
 
-## ユースケースとベストプラクティス
+## ユースケースとベストプラクティス### どのAPIを使用すべきか？
 
-### どの API を使用すべきか？
+#### NGSIv2を選択すべき場合
 
-#### NGSIv2 を選択するべき場合
+- **既存のFIWARE Orion互換システム** - レガシーシステムとの統合
+- **シンプルなIoTデータ管理** - センサーデータの収集と可視化
+- **学習コストの低さ** - NGSI-LDよりもシンプルな仕様
+- **豊富な既存ドキュメントとツール** - 成熟したNGSIv2エコシステム
 
-- **既存の FIWARE Orion 互換システム** - レガシーシステムとの統合
-- **シンプルな IoT データ管理** - センサーデータの収集と可視化
-- **低い学習コスト** - NGSI-LD よりもシンプルな仕様
-- **豊富な既存ドキュメントとツール** - 成熟した NGSIv2 エコシステム
+**推奨されるユースケース:**
 
-**推奨される使用例:**
-
-- IoT センサーネットワーク
+- IoTセンサーネットワーク
 - 基本的なスマートシティのデータ収集
-- プロトタイピングと PoC
+- プロトタイピングとPoC
 
-#### NGSI-LD を選択するべき場合
+#### NGSI-LDを選択すべき場合
 
-- **セマンティック Web / Linked Data** - JSON-LD と RDF の活用
-- **複雑なエンティティ関係** - Relationship と LanguageProperty の使用
-- **国際標準への準拠** - ETSI 標準に準拠したシステム
-- **将来の拡張性** - NGSI-LD 仕様は継続的に拡張されている
+- **Semantic Web / Linked Data** - JSON-LDとRDFの活用
+- **複雑なエンティティ関係** - RelationshipとLanguagePropertyの使用
+- **国際標準への準拠** - ETSI標準に準拠したシステム
+- **将来の拡張性** - NGSI-LD仕様は拡張が続けられている
 
-**推奨される使用例:**
+**推奨されるユースケース:**
 
 - Smart Data Models を活用したデータカタログ
-- 多言語対応が必要なシステム
+- 多言語サポートが必要なシステム
 - エンティティ間の複雑な関係を表現する必要があるシステム
 - データ統合とオープンデータの公開
 
-#### 両方の API を同時に実行
+#### 両方のAPIの同時実行
 
-GeonicDB は両方の API を同時にサポートしますが、エンティティはプロトコルごとに分離されています。各 API は独自のエンティティセットに対して独立して動作します。
+GeonicDB は両方のAPIを同時にサポートしていますが、エンティティはプロトコル単位で分離されています。各APIは独自のエンティティセットに対して独立して動作します。
 
 **推奨されるアプローチ:**
 
-1. **ユースケースごとに 1 つの API を選択** - 同じデータに対してプロトコルを混在させることは避けてください。要件に基づいて NGSIv2 または NGSI-LD を選択し、それを使い続けてください
-2. **クロスプロトコルのニーズには Federation を使用** - NGSIv2 クライアントが NGSI-LD エンティティにアクセスする必要がある場合(またはその逆)、Federation 経由でコンテキストソースを登録してください
-3. **移行には再作成が必要** - エンティティを NGSIv2 から NGSI-LD に移行するには、NGSIv2 API からエクスポートし、NGSI-LD API 経由で再作成してください。自動的なクロスプロトコル移行はありません### ベストプラクティス
+1. **ユースケースごとに1つのAPIを選択** - 同じデータに対してプロトコルを混在させないでください。要件に基づいてNGSIv2またはNGSI-LDを選択し、それを使い続けてください
+2. **プロトコル間の連携にはFederationを使用** - NGSIv2クライアントがNGSI-LDエンティティにアクセスする必要がある場合（またはその逆）、Federationを介してコンテキストソースを登録してください
+3. **マイグレーションには再作成が必要** - NGSIv2からNGSI-LDへエンティティを移行するには、NGSIv2 APIからエクスポートし、NGSI-LD APIを介して再作成する必要があります。プロトコル間の自動マイグレーションはありません
+
+### ベストプラクティス
 
 #### 1. エンティティ ID には URN 形式を使用する
 
@@ -842,7 +844,7 @@ Room1
 sensor-abc
 ```
 
-理由: NGSI-LD 仕様に準拠し、両方の API 間で互換性を維持できます。
+理由: NGSI-LD 仕様に準拠し、両方の API 間で互換性を維持します。
 
 #### 2. 地理空間データには GeoJSON を使用する
 
@@ -874,7 +876,7 @@ sensor-abc
 }
 ```
 
-理由: ジオクエリは GeoJSON 形式のみをサポートしています。
+理由: Geo クエリは GeoJSON 形式のみをサポートしています。
 
 #### 3. Smart Data Models を活用する
 
@@ -895,17 +897,17 @@ GeonicDB は Smart Data Models の `@context` を自動補完します。
 
 理由: `type` が Smart Data Models のモデル名と一致する場合、適切な `@context` が自動的に補完されます。
 
-#### 4. 目的に応じてサブスクリプションを選択する
+#### 4. 目的に応じたサブスクリプションを選択する
 
 | 目的 | 推奨チャネル | 理由 |
 |---------|---------------------|--------|
-| Web アプリ (リアルタイム更新) | WebSocket | 低レイテンシ、サーバ不要 |
-| サーバ間連携 | HTTP Webhook | 信頼性、リトライ機能 |
+| Web アプリ (リアルタイム更新) | WebSocket | 低遅延、サーバー不要 |
+| サーバー間統合 | HTTP Webhook | 信頼性、リトライ機能 |
 | IoT デバイス | MQTT | 軽量、QoS 保証 |
 
 #### 5. テナント分離を活用する
 
-`Fiware-Service` ヘッダを使用してテナントを分離します。
+`Fiware-Service` ヘッダーを使用してテナントを分離します。
 
 ```bash
 # Create entity in tenant "demo"
@@ -927,18 +929,18 @@ curl -X POST http://localhost:3000/v2/entities \
 
 | 項目 | NGSIv2 | NGSI-LD | GeonicDB の動作 |
 |------|--------|---------|-------------------|
-| **プロトコル** | REST/JSON | REST/JSON-LD | 両方をサポート。エンティティは `protocol` フィールドで分離 |
+| **プロトコル** | REST/JSON | REST/JSON-LD | 両方サポート; エンティティは `protocol` フィールドで分離 |
 | **エンティティ分離** | `protocol: 'ngsiv2'` | `protocol: 'ngsild'` | 各 API は自身のエンティティのみを参照 |
 | **エンティティ ID** | 任意の文字列 | URI (URN 推奨) | URN 推奨。**ID はテナント + servicePath ごとに一意** (型による区別は削除) |
-| **属性タイプ** | シンプル (Number、Text など) | セマンティック (Property、Relationship など) | タイプマッピングルールで対応関係を定義 (上記の表を参照) |
-| **システム属性** | `dateCreated`、`dateModified` | `createdAt`、`modifiedAt` | 内部的に統一、API ごとに変換 |
-| **ジオクエリ** | ✅ | ✅ | 共有機能 |
+| **属性タイプ** | シンプル (Number、Text など) | セマンティック (Property、Relationship など) | タイプマッピングルールで対応を定義 (上記の表を参照) |
+| **システム属性** | `dateCreated`、`dateModified` | `createdAt`、`modifiedAt` | 内部で統一、API ごとに変換 |
+| **Geo クエリ** | ✅ | ✅ | 共有機能 |
 | **サブスクリプション** | ✅ (HTTP、MQTT、WebSocket) | ✅ (HTTP、MQTT、WebSocket) | 共有機能 |
-| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出。プロトコル間アクセスを可能にする |
-| **プロトコル間アクセス** | 直接サポートなし | 直接サポートなし | プロトコル間のニーズにはフェデレーションを使用 |
+| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出; プロトコル間アクセスを実現 |
+| **プロトコル間アクセス** | 直接サポートなし | 直接サポートなし | プロトコル間アクセスにはフェデレーションを使用 |
 | **ユースケース** | IoT、レガシーシステム | セマンティック Web、オープンデータ | ユースケースごとに 1 つの API を選択 |
 
-GeonicDB は厳密なプロトコル分離により NGSIv2 と NGSI-LD の両方の API を提供します。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
+GeonicDB は NGSIv2 と NGSI-LD の両方の API を提供し、厳格なプロトコル分離を実現しています。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
 
 ---
 

--- a/docs/ja/features/smart-data-models.md
+++ b/docs/ja/features/smart-data-models.md
@@ -37,7 +37,9 @@ GeonicDB は、次のドメインから主要な Smart Data Models をサポー�
 - スキーマ URL
 - サンプル プロパティ
 
-## MCP ツール: `data_models`Smart Data Models カタログを参照するための MCP ツールが利用可能です。
+## MCP ツール: `data_models`
+
+Smart Data Models カタログを参照するための MCP ツールが利用可能です。
 
 ### アクション
 

--- a/docs/ja/features/smart-data-models.md
+++ b/docs/ja/features/smart-data-models.md
@@ -35,7 +35,9 @@ GeonicDB は、次のドメインから主要な Smart Data Models をサポー�
 - JSON-LD @context URL
 - 説明
 - スキーマ URL
-- サンプル プロパティ## MCP ツール: `data_models`Smart Data Models カタログを参照するための MCP ツールが利用可能です。
+- サンプル プロパティ
+
+## MCP ツール: `data_models`Smart Data Models カタログを参照するための MCP ツールが利用可能です。
 
 ### アクション
 

--- a/docs/ja/features/subscriptions.md
+++ b/docs/ja/features/subscriptions.md
@@ -49,12 +49,7 @@ EventBridge ─┬─> SubscriptionMatcher -> SQS -> HTTP/MQTT  [existing]
 
 ### 有効化
 
-SAM テンプレートで `EventStreamingEnabled` パラメータを `true` に設定してデプロイします。
-
-```bash
-sam deploy -t infrastructure/template.yaml \
-  --parameter-overrides EventStreamingEnabled=true
-```
+GeonicDB SaaS ではイベントストリーミングは既定で有効です。追加の設定は不要です。
 
 ### 環境変数
 

--- a/docs/ja/migration/compatibility-matrix.md
+++ b/docs/ja/migration/compatibility-matrix.md
@@ -226,7 +226,9 @@ outline: deep
 | **通知配信** | | | |
 | 順序保証 | ✅ (SQS FIFO) | ⚠️ 限定的 | |
 | リトライ機能 | ✅ | ✅ | |
-| Dead Letter Queue | ✅ | ❌ | |## 登録 / コンテキストプロバイダー
+| Dead Letter Queue | ✅ | ❌ | |
+
+## 登録 / コンテキストプロバイダー
 
 | 機能 | GeonicDB | FIWARE Orion | 備考 |
 |---------|:------------------:|:------------:|-------|
@@ -308,7 +310,9 @@ outline: deep
 | MCP 認証 (JWT) | ✅ | ❌ | テナント分離サポート |
 | **llms.txt** | ✅ | ❌ | AI/LLM 向け API ドキュメント (`GET /llms.txt`) |
 | **tools.json** | ✅ | ❌ | AI エージェント向けツール定義 (`GET /tools.json`) |
-| **OpenAPI 3.0** | ✅ | ✅ | `GET /openapi.json` |## 運用と監視
+| **OpenAPI 3.0** | ✅ | ✅ | `GET /openapi.json` |
+
+## 運用と監視
 
 | 機能 | GeonicDB | FIWARE Orion | 備考 |
 |---------|:------------------:|:------------:|-------|
@@ -394,7 +398,9 @@ outline: deep
 - オンプレミス環境で運用する必要がある
 - 他の FIWARE エコシステムコンポーネント (Keyrock、Wilma など) と統合する
 - Docker/Kubernetes で運用する予定
-- AWS 以外のクラウドまたはマルチクラウド環境で運用する## 参考資料
+- AWS 以外のクラウドまたはマルチクラウド環境で運用する
+
+## 参考資料
 
 - [GeonicDB Repository](https://github.com/geolonia/geonicdb) (プライベートリポジトリ)
 - [FIWARE Orion Documentation](https://fiware-orion.readthedocs.io/)

--- a/docs/ja/reference/cli.md
+++ b/docs/ja/reference/cli.md
@@ -9,8 +9,7 @@ outline: deep
 
 - **リポジトリ**: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)
 - **ランタイム**: Node.js >= 20
-- **パッケージ**: `@geolonia/geonicdb-cli`
-## 目次
+- **パッケージ**: `@geolonia/geonicdb-cli`## 目次
 
 - [インストール](#インストール)
 - [クイックスタート](#クイックスタート)
@@ -135,8 +134,7 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 }
 ```
 
-**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`
-#
+**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`#
 
 ### `geonic config set <key> <value>`設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
 
@@ -334,8 +332,7 @@ CLI は 24 時間ごとに新しいバージョンをチェックし、アップ
 
 ## コマンドリファレンス
 
-### `entities`
-NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
+### `entities`NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
 
 #
 
@@ -473,8 +470,7 @@ cat entities.json | geonic batch upsert
 | `geonic sub update <id> [json]` | サブスクリプションの更新 |
 | `geonic sub delete <id>` | サブスクリプションの削除 |
 
-**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
-```bash
+**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count````bash
 geonic sub create '{
   "type": "Subscription",
   "entities": [{"type": "Room"}],
@@ -499,8 +495,7 @@ geonic sub create '{
 | `geonic reg update <id> [json]` | 登録の更新 |
 | `geonic reg delete <id>` | 登録の削除 |
 
-**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
----
+**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`---
 
 ### `types`利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
 
@@ -545,8 +540,7 @@ geonic temporal entities get urn:ngsi-ld:Room:001 \
 
 ### `geonic temporal entities get <id>`エンティティの時系列表現を取得します。
 
-**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`
-#
+**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`#
 
 ### `geonic temporal entities create [json]`時系列エンティティを作成します。
 
@@ -582,8 +576,7 @@ geonic temporal entityOperations query @query.json \
 | `geonic snapshots delete <id>` | スナップショットを削除 |
 | `geonic snapshots clone <id>` | スナップショットをクローン |
 
-**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`
----
+**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`---
 
 ### `rules`ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
 
@@ -734,15 +727,13 @@ geonic admin api-keys update gdb_abc123 '{"name": "renamed-key", "isActive": fal
 
 ---
 
-### `health`
-```bash
+### `health````bash
 geonic health
 ```
 
 サーバーのヘルス状態を確認します (`GET /health`)。
 
-### `version`
-```bash
+### `version````bash
 geonic version
 ```
 
@@ -797,8 +788,7 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 | `geonic me api-keys create [json]` | 新しい API キーを作成 |
 | `geonic me api-keys delete <key-id>` | API キーを削除 |
 
-**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count`
-```bash
+**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count````bash
 # Create a personal API key
 geonic me api-keys create '{
   "name": "my-dev-key",

--- a/docs/ja/reference/cli.md
+++ b/docs/ja/reference/cli.md
@@ -9,7 +9,9 @@ outline: deep
 
 - **リポジトリ**: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)
 - **ランタイム**: Node.js >= 20
-- **パッケージ**: `@geolonia/geonicdb-cli`## 目次
+- **パッケージ**: `@geolonia/geonicdb-cli`
+
+## 目次
 
 - [インストール](#インストール)
 - [クイックスタート](#クイックスタート)
@@ -134,21 +136,31 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 }
 ```
 
-**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`#
-
-### `geonic config set <key> <value>`設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
+**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`
 
 #
 
-### `geonic config get <key>`設定値を取得します。
+### `geonic config set <key> <value>`
+
+設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
 
 #
 
-### `geonic config list`現在のプロファイルのすべての設定値を表示します。
+### `geonic config get <key>`
+
+設定値を取得します。
 
 #
 
-### `geonic config delete <key>`設定値を削除します。
+### `geonic config list`
+
+現在のプロファイルのすべての設定値を表示します。
+
+#
+
+### `geonic config delete <key>`
+
+設定値を削除します。
 
 ### プロファイル管理
 
@@ -156,23 +168,33 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 
 #
 
-### `geonic profile list`すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
+### `geonic profile list`
+
+すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
 
 #
 
-### `geonic profile use <name>`アクティブなプロファイルを切り替えます。
+### `geonic profile use <name>`
+
+アクティブなプロファイルを切り替えます。
 
 #
 
-### `geonic profile create <name>`新しい空のプロファイルを作成します。
+### `geonic profile create <name>`
+
+新しい空のプロファイルを作成します。
 
 #
 
-### `geonic profile delete <name>`プロファイルを削除します。`default` プロファイルは削除できません。
+### `geonic profile delete <name>`
+
+プロファイルを削除します。`default` プロファイルは削除できません。
 
 #
 
-### `geonic profile show [name]`プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
+### `geonic profile show [name]`
+
+プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
 
 ### 環境変数
 
@@ -332,11 +354,15 @@ CLI は 24 時間ごとに新しいバージョンをチェックし、アップ
 
 ## コマンドリファレンス
 
-### `entities`NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
+### `entities`
+
+NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
 
 #
 
-### `geonic entities list`オプションのフィルタを使用してエンティティをリストします。
+### `geonic entities list`
+
+オプションのフィルタを使用してエンティティをリストします。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -371,7 +397,9 @@ geonic entities list --type Sensor --count-only
 
 #
 
-### `geonic entities get <id>`ID で単一のエンティティを取得します。
+### `geonic entities get <id>`
+
+ID で単一のエンティティを取得します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -379,7 +407,9 @@ geonic entities list --type Sensor --count-only
 
 #
 
-### `geonic entities create [json]`新しいエンティティを作成します。
+### `geonic entities create [json]`
+
+新しいエンティティを作成します。
 
 ```bash
 geonic entities create '{
@@ -395,7 +425,9 @@ geonic entities create '{
 
 #
 
-### `geonic entities update <id> [json]`エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
+### `geonic entities update <id> [json]`
+
+エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
 
 ```bash
 geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property", "value": 25.0}}'
@@ -403,19 +435,27 @@ geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property"
 
 #
 
-### `geonic entities replace <id> [json]`すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
+### `geonic entities replace <id> [json]`
+
+すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
 
 #
 
-### `geonic entities upsert [json]`エンティティを作成または更新します (`POST /entityOperations/upsert`)。
+### `geonic entities upsert [json]`
+
+エンティティを作成または更新します (`POST /entityOperations/upsert`)。
 
 #
 
-### `geonic entities delete <id>`エンティティを削除します。
+### `geonic entities delete <id>`
+
+エンティティを削除します。
 
 ---
 
-### `entities attrs`エンティティの個別の属性を管理します。
+### `entities attrs`
+
+エンティティの個別の属性を管理します。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -435,7 +475,9 @@ geonic entities attrs update urn:ngsi-ld:Room:001 temperature '{"type": "Propert
 
 ---
 
-### `entityOperations` (バッチ)
+### `entityOperations`
+
+ (バッチ)
 
 エンティティのバッチ操作 (`/ngsi-ld/v1/entityOperations`)。エイリアス: `batch`。
 
@@ -458,7 +500,9 @@ cat entities.json | geonic batch upsert
 
 ---
 
-### `subscriptions` (sub)
+### `subscriptions`
+
+ (sub)
 
 コンテキストサブスクリプション (`/ngsi-ld/v1/subscriptions`) を管理します。エイリアス: `sub`。
 
@@ -485,7 +529,9 @@ geonic sub create '{
 
 ---
 
-### `registrations` (reg)
+### `registrations`
+
+ (reg)
 
 コンテキストソース登録 (`/ngsi-ld/v1/csourceRegistrations`) を管理します。エイリアス: `reg`。
 
@@ -497,9 +543,13 @@ geonic sub create '{
 | `geonic reg update <id> [json]` | 登録の更新 |
 | `geonic reg delete <id>` | 登録の削除 |
 
-**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`---
+**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
 
-### `types`利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
+---
+
+### `types`
+
+利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -508,11 +558,15 @@ geonic sub create '{
 
 ---
 
-### `temporal`時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
+### `temporal`
+
+時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
 
 #
 
-### `geonic temporal entities list`時系列エンティティの一覧を取得します。
+### `geonic temporal entities list`
+
+時系列エンティティの一覧を取得します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -540,19 +594,29 @@ geonic temporal entities get urn:ngsi-ld:Room:001 \
 
 #
 
-### `geonic temporal entities get <id>`エンティティの時系列表現を取得します。
+### `geonic temporal entities get <id>`
 
-**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`#
+エンティティの時系列表現を取得します。
 
-### `geonic temporal entities create [json]`時系列エンティティを作成します。
-
-#
-
-### `geonic temporal entities delete <id>`時系列エンティティを削除します。
+**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`
 
 #
 
-### `geonic temporal entityOperations query [json]`集約サポート付きで POST による時系列エンティティのクエリを実行します。
+### `geonic temporal entities create [json]`
+
+時系列エンティティを作成します。
+
+#
+
+### `geonic temporal entities delete <id>`
+
+時系列エンティティを削除します。
+
+#
+
+### `geonic temporal entityOperations query [json]`
+
+集約サポート付きで POST による時系列エンティティのクエリを実行します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -568,7 +632,9 @@ geonic temporal entityOperations query @query.json \
 
 ---
 
-### `snapshots`エンティティスナップショットを管理します。
+### `snapshots`
+
+エンティティスナップショットを管理します。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -578,9 +644,13 @@ geonic temporal entityOperations query @query.json \
 | `geonic snapshots delete <id>` | スナップショットを削除 |
 | `geonic snapshots clone <id>` | スナップショットをクローン |
 
-**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`---
+**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`
 
-### `rules`ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
+---
+
+### `rules`
+
+ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -621,11 +691,15 @@ DCAT-AP データカタログを参照します。
 
 ---
 
-### `admin`管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
+### `admin`
+
+管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
 
 #
 
-### `admin tenants`| コマンド | 説明 |
+### `admin tenants`
+
+| コマンド | 説明 |
 |---------|-------------|
 | `geonic admin tenants list` | テナント一覧を取得 |
 | `geonic admin tenants get <id>` | テナントを取得 |
@@ -637,7 +711,9 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin users`| コマンド | 説明 |
+### `admin users`
+
+| コマンド | 説明 |
 |---------|-------------|
 | `geonic admin users list` | ユーザー一覧を取得 |
 | `geonic admin users get <id>` | ユーザーを取得 |
@@ -650,7 +726,9 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin policies`XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
+### `admin policies`
+
+XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -664,7 +742,9 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin oauth-clients`OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
+### `admin oauth-clients`
+
+OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -676,7 +756,9 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin api-keys`API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
+### `admin api-keys`
+
+API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -719,7 +801,9 @@ geonic admin api-keys update gdb_abc123 '{"name": "renamed-key", "isActive": fal
 
 #
 
-### `admin cadde`CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
+### `admin cadde`
+
+CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -745,7 +829,9 @@ geonic version
 
 CLI のバージョンとサーバーのバージョンを表示します (`GET /version`)。
 
-### `me`現在認証されているユーザーを表示し、ユーザーリソースを管理します。
+### `me`
+
+現在認証されているユーザーを表示し、ユーザーリソースを管理します。
 
 ```bash
 geonic me
@@ -755,7 +841,9 @@ geonic me
 
 #
 
-### `me oauth-clients`自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
+### `me oauth-clients`
+
+自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -786,7 +874,9 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 
 #
 
-### `me api-keys`自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
+### `me api-keys`
+
+自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -813,7 +903,9 @@ geonic me api-keys delete gdb_abc123
 
 > **注意**: 平文の API キーは、作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
 
-### `help`WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
+### `help`
+
+WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
 
 ```bash
 geonic help                    # All commands overview

--- a/docs/ja/reference/cli.md
+++ b/docs/ja/reference/cli.md
@@ -470,7 +470,9 @@ cat entities.json | geonic batch upsert
 | `geonic sub update <id> [json]` | サブスクリプションの更新 |
 | `geonic sub delete <id>` | サブスクリプションの削除 |
 
-**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count````bash
+**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
+
+```bash
 geonic sub create '{
   "type": "Subscription",
   "entities": [{"type": "Room"}],
@@ -727,13 +729,17 @@ geonic admin api-keys update gdb_abc123 '{"name": "renamed-key", "isActive": fal
 
 ---
 
-### `health````bash
+### `health`
+
+```bash
 geonic health
 ```
 
 サーバーのヘルス状態を確認します (`GET /health`)。
 
-### `version````bash
+### `version`
+
+```bash
 geonic version
 ```
 
@@ -788,7 +794,9 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 | `geonic me api-keys create [json]` | 新しい API キーを作成 |
 | `geonic me api-keys delete <key-id>` | API キーを削除 |
 
-**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count````bash
+**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count`
+
+```bash
 # Create a personal API key
 geonic me api-keys create '{
   "name": "my-dev-key",


### PR DESCRIPTION
## Automated Sync & Translation

**Trigger**: workflow_dispatch
**GeonicDB SHA**: N/A (manual dispatch)

### Changed files
docs/en/api-reference/ngsiv2.md
docs/en/core-concepts/ngsiv2-vs-ngsild.md

### Process
1. Synced English source docs from geolonia/geonicdb → docs/en/
2. Translated English docs to Japanese via yuuhitsu → docs/ja/
3. Build verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation（ドキュメント）**
  * SaaS向け設定の明確化：IP制限はテナント設定API経由で設定、詳細はサポートへ案内
  * 認証関連環境変数はSaaSコンソールで管理（直接設定不要）を追記
  * イベントストリーミングはSaaSでデフォルト有効化と明記
  * API仕様・プロトコル分離・レスポンス記載を整理・強化し可読性向上
  * 日本語ドキュメントの見出し・改行・例示の体裁を多数修正
<!-- end of auto-generated comment: release notes by coderabbit.ai -->