### PR TITLE
feat: cmd_378 — fix-doc-quality.ts SF4 拡張 fixEmbeddedFences (B軸) + fixHeadingMerge (C軸)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- [feat] cmd_378 — fix-doc-quality.ts SF4 拡張: fixEmbeddedFences 4/5-backtick edge case (B軸) + fixHeadingMerge heading+inline-code+body 分離 (C軸)。unit tests 9 件追加 (Closes #164)
 - [feat] cmd_375 SF4 — fix-doc-quality.ts に fixListMerge / fixHeadingMerge / fixHorizontalRuleMerge / fixAnchorI18n 4 関数追加 + unit tests 29 件。list/heading/hr 連結検出・自動分割、ja docs アンカー Hybrid auto-fix 実装 (Closes #159)
 - [feat] Phase 2 — saas-rewrite-rules.yaml に R-SAM-DEPLOY + R-ENV-ADMIN + R-ENV-TABLE 3 rules 追加 + unit tests 9 件（cmd_372）(Closes #154)
 - [feat] Phase 1 — saas-docs-rewrite.ts + YAML rule config (R-DEV-MD + R-SAM-BATCH) 実装（cmd_371）(Closes #152)

--- a/scripts/fix-doc-quality.ts
+++ b/scripts/fix-doc-quality.ts
@@ -163,8 +163,8 @@ export function fixEmbeddedFences(content: string): string {
   for (const line of lines) {
     const trimmed = line.trimStart()
 
-    // Track fenced block boundaries — toggle on any ``` line
-    if (trimmed.startsWith('```')) {
+    // Track fenced block boundaries — toggle on any ``` or ~~~ line
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
       inFencedBlock = !inFencedBlock
       result.push(line)
       continue
@@ -176,20 +176,20 @@ export function fixEmbeddedFences(content: string): string {
       continue
     }
 
-    // Find last occurrence of ``` in the line (potential embedded fence)
-    const fenceIdx = line.lastIndexOf('```')
-    if (fenceIdx > 0) {
-      const afterFence = line.slice(fenceIdx + 3)
-      // Must be followed by a language identifier (a–z)
-      if (/^[a-z]/.test(afterFence)) {
-        const prose = line.slice(0, fenceIdx)
-        const indent = line.match(/^\s*/)?.[0] ?? ''
-        const fencePart = indent + line.slice(fenceIdx)
-        result.push(prose)
-        result.push('')
-        result.push(fencePart)
-        continue
-      }
+    // Detect mid-line fence: prose + (N≥3 consecutive backticks) + lang identifier, at EOL.
+    // When N>3, the extra (N-3) leading backticks are inline-code close chars and stay with prose.
+    // Handles both standard 3-backtick (N=3) and 4/5-backtick edge cases from yuuhitsu newline loss.
+    const fenceMatch = line.match(/^(.*?)(`{3,})([a-z][a-z0-9_+-]*)\s*$/i)
+    if (fenceMatch && fenceMatch[1].length > 0) {
+      const proseEnd = fenceMatch[1]
+      const inlineCloseCount = fenceMatch[2].length - 3
+      const lang = fenceMatch[3]
+      const finalProse = inlineCloseCount > 0 ? proseEnd + '`'.repeat(inlineCloseCount) : proseEnd
+      const indent = line.match(/^\s*/)?.[0] ?? ''
+      result.push(finalProse)
+      result.push('')
+      result.push(indent + '```' + lang)
+      continue
     }
 
     result.push(line)
@@ -441,6 +441,20 @@ export function fixHeadingMerge(content: string): string {
     if (inFencedBlock) {
       result.push(line)
       continue
+    }
+
+    // Detect heading + inline-code + body: ## heading `code`body → split.
+    // Greedy `.+` finds the LAST inline-code span; body must start with non-space char.
+    // Must run BEFORE the heading skip-check below to catch this pattern.
+    if (/^#{1,6} /.test(trimmed)) {
+      const headingBodyMatch = trimmed.match(/^(#{1,6} .+`[^`]+`)([^\s`].*)$/)
+      if (headingBodyMatch) {
+        const indent = line.match(/^\s*/)?.[0] ?? ''
+        result.push(indent + headingBodyMatch[1])
+        result.push('')
+        result.push(headingBodyMatch[2])
+        continue
+      }
     }
 
     // Skip lines that already start with a heading or are standalone hr/empty

--- a/tests/unit/fix-doc-quality.test.ts
+++ b/tests/unit/fix-doc-quality.test.ts
@@ -151,6 +151,46 @@ describe('fixEmbeddedFences', () => {
     expect(lines[1]).toBe('')
     expect(lines[2]).toBe('  ```json')
   })
+
+  // B-axis: 4-backtick edge case (PR#161 ai-integration L253 pattern)
+  it('splits 4-backtick embedded fence: inline-close + fence-open (B-axis regression)', () => {
+    // Pattern: text`````json → text` + blank + ```json  (4 backticks = 1 inline-close + 3 fence)
+    const broken = 'text````json'
+    const result = fixEmbeddedFences(broken)
+    const lines = result.split('\n')
+    expect(lines[0]).toBe('text`')
+    expect(lines[1]).toBe('')
+    expect(lines[2]).toBe('```json')
+  })
+
+  it('splits 5-backtick embedded fence: 2 inline-close + fence-open (B-axis regression)', () => {
+    // Pattern: text`````bash → text`` + blank + ```bash  (5 backticks = 2 inline-close + 3 fence)
+    const broken = 'text`````bash'
+    const result = fixEmbeddedFences(broken)
+    const lines = result.split('\n')
+    expect(lines[0]).toBe('text``')
+    expect(lines[1]).toBe('')
+    expect(lines[2]).toBe('```bash')
+  })
+
+  it('splits list item with 4-backtick fence (PR#161 ai-integration macOS/Windows path pattern)', () => {
+    // Simulates the yuuhitsu newline-loss pattern from ai-integration L253
+    const broken = '- **macOS**: `~/config.json`- **Windows**: `%APPDATA%\\config.json````json'
+    const result = fixEmbeddedFences(broken)
+    const lines = result.split('\n')
+    expect(lines[0]).toBe('- **macOS**: `~/config.json`- **Windows**: `%APPDATA%\\config.json`')
+    expect(lines[1]).toBe('')
+    expect(lines[2]).toBe('```json')
+  })
+
+  it('splits standard 3-backtick fence (regression: existing behaviour unchanged)', () => {
+    const broken = 'text```json'
+    const result = fixEmbeddedFences(broken)
+    const lines = result.split('\n')
+    expect(lines[0]).toBe('text')
+    expect(lines[1]).toBe('')
+    expect(lines[2]).toBe('```json')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -548,6 +588,39 @@ describe('fixHeadingMerge', () => {
 
   it('does not modify standalone hr lines', () => {
     expect(fixHeadingMerge('---')).toBe('---')
+  })
+
+  // C-axis: heading + inline-code + body (PR#161 smart-data-models.md L40 pattern)
+  it('splits heading + inline-code + body when no space between close-backtick and body (C-axis)', () => {
+    const input = '## MCP ツール: `data_models`Smart Data Models カタログを参照するための MCP ツールが利用可能です。'
+    const result = fixHeadingMerge(input)
+    const lines = result.split('\n')
+    expect(lines[0]).toBe('## MCP ツール: `data_models`')
+    expect(lines[1]).toBe('')
+    expect(lines[2]).toBe('Smart Data Models カタログを参照するための MCP ツールが利用可能です。')
+  })
+
+  it('does not split heading + inline-code when no body follows (C-axis: no change)', () => {
+    const input = '## H `code`'
+    expect(fixHeadingMerge(input)).toBe(input)
+  })
+
+  it('does not split heading + inline-code when body is separated by a space (C-axis: space → no change)', () => {
+    const input = '## H `code` body text'
+    expect(fixHeadingMerge(input)).toBe(input)
+  })
+
+  it('splits heading + multiple inline-codes + body at last inline-close (C-axis)', () => {
+    const input = '## H `a` `b`body'
+    const result = fixHeadingMerge(input)
+    const lines = result.split('\n')
+    expect(lines[0]).toBe('## H `a` `b`')
+    expect(lines[1]).toBe('')
+    expect(lines[2]).toBe('body')
+  })
+
+  it('does not split plain heading without inline-code (C-axis: no change)', () => {
+    expect(fixHeadingMerge('## Normal Heading Text')).toBe('## Normal Heading Text')
   })
 })
 


### PR DESCRIPTION
## Summary

- **B軸 fixEmbeddedFences**: `lastIndexOf`/`/^[a-z]/` 検査を regex ``(`{3,})([a-z][a-z0-9_+-]*)`` に置換。4-backtick (inline-close + fence-open) edge case を正確に split し、余剰 backtick を prose 側に保持。`~~~` fence 追跡も追加
- **C軸 fixHeadingMerge**: skip-check 前に heading+inline-code+body 分離 branch を追加。`## H \`code\`body` → `## H \`code\`` + 空行 + `body` に分離。greedy `.+` で複数 inline-code 時は最後の close-backtick 後を body と判定
- **unit tests 9 件追加** (B軸 4 件 + C軸 5 件、PR#161 発覚パターン回帰テスト含む)

## Background

PR#161 sync run 25275443594 で発覚した 2 残存パターンの根本修正:
- B軸: yuuhitsu 翻訳で inline-close backtick + fence-open が結合 (4 backtick: `` ````json``) → fixEmbeddedFences が `/^[a-z]/` test で split 不発 → 55 bare fence violations + 3 geonicdb lowercase violations
- C軸: `## H \`code\`body` 形式の heading+body 連結 → fixHeadingMerge が heading-start を skip → CodeRabbit Minor 指摘未対応

## Test plan

- [x] `pnpm test` — 全 191 tests PASS, SKIP 0
- [x] `/code-review-expert --auto` — P0/P1 ゼロ
- [ ] CI PASS 確認
- [ ] CodeRabbit Actionable ゼロ確認

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ドキュメント品質修正機能が拡張されました：埋め込まれたコードフェンスの処理が改善され、バックティックとチルダ記号の両方に対応します。

* **バグ修正**
  * 見出し、行内コード、本文が混在するケースにおける分離処理が改善されました。

* **テスト**
  * 4バックティック、5バックティックなどのエッジケースを含む9個のユニットテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->