### PR TITLE
feat: fixListMerge debug logging — DEBUG_FIXLISTMERGE=1 制御 (cmd_382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- [feat] cmd_382 — fixListMerge に DEBUG_FIXLISTMERGE=1 制御の debug logging 追加（skip 理由・行番号記録）(Closes #172)
 - [feat] cmd_378 — fix-doc-quality.ts SF4 拡張: fixEmbeddedFences 4/5-backtick edge case (B軸) + fixHeadingMerge heading+inline-code+body 分離 (C軸)。unit tests 9 件追加 (Closes #164)
 - [feat] cmd_375 SF4 — fix-doc-quality.ts に fixListMerge / fixHeadingMerge / fixHorizontalRuleMerge / fixAnchorI18n 4 関数追加 + unit tests 29 件。list/heading/hr 連結検出・自動分割、ja docs アンカー Hybrid auto-fix 実装 (Closes #159)
 - [feat] Phase 2 — saas-rewrite-rules.yaml に R-SAM-DEPLOY + R-ENV-ADMIN + R-ENV-TABLE 3 rules 追加 + unit tests 9 件（cmd_372）(Closes #154)

--- a/scripts/fix-doc-quality.ts
+++ b/scripts/fix-doc-quality.ts
@@ -360,12 +360,15 @@ function slugify(text: string): string {
  * Skips code blocks and table rows. Numbered lists are out of scope (Phase 2).
  */
 export function fixListMerge(content: string): string {
+  const DEBUG = process.env.DEBUG_FIXLISTMERGE === '1'
   const lines = content.split('\n')
   const result: string[] = []
   let inFencedBlock = false
 
-  for (const line of lines) {
+  for (let lineNum = 0; lineNum < lines.length; lineNum++) {
+    const line = lines[lineNum]
     const trimmed = line.trimStart()
+    const lineNo = lineNum + 1
 
     if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
       inFencedBlock = !inFencedBlock
@@ -374,12 +377,19 @@ export function fixListMerge(content: string): string {
     }
 
     if (inFencedBlock || trimmed.startsWith('|')) {
+      if (DEBUG) {
+        const reason = inFencedBlock ? 'fence' : 'table'
+        console.error(`[fixListMerge] L${lineNo} skip(${reason}): ${line.slice(0, 80)}`)
+      }
       result.push(line)
       continue
     }
 
     // Only split unordered list items (- or *)
     if (!trimmed.startsWith('- ') && !trimmed.startsWith('* ')) {
+      if (DEBUG) {
+        console.error(`[fixListMerge] L${lineNo} skip(non-list): ${line.slice(0, 80)}`)
+      }
       result.push(line)
       continue
     }
@@ -395,15 +405,29 @@ export function fixListMerge(content: string): string {
     while ((match = splitRegex.exec(line)) !== null) {
       const splitAt = match.index + 1 // split right after the closing char
       const backtickCount = (line.slice(0, splitAt).match(/`/g) ?? []).length
-      if (backtickCount % 2 !== 0) continue // inside inline code — skip
+      if (backtickCount % 2 !== 0) {
+        if (DEBUG) {
+          console.error(`[fixListMerge] L${lineNo} skip(inline-code) col${splitAt}: backticks=${backtickCount}, context="${line.slice(Math.max(0, splitAt - 10), splitAt + 10)}"`)
+        }
+        continue // inside inline code — skip
+      }
+      if (DEBUG) {
+        console.error(`[fixListMerge] L${lineNo} split col${splitAt}: context="${line.slice(Math.max(0, splitAt - 10), splitAt + 10)}"`)
+      }
       parts.push(line.slice(lastSplit, splitAt))
       lastSplit = splitAt
     }
 
     if (parts.length > 0) {
       parts.push(line.slice(lastSplit))
+      if (DEBUG) {
+        console.error(`[fixListMerge] L${lineNo} process(split ${parts.length} parts): ${line.slice(0, 80)}`)
+      }
       result.push(...parts)
     } else {
+      if (DEBUG) {
+        console.error(`[fixListMerge] L${lineNo} skip(no-match): ${line.slice(0, 80)}`)
+      }
       result.push(line)
     }
   }


### PR DESCRIPTION
## Summary
- `scripts/fix-doc-quality.ts` の `fixListMerge` に `DEBUG_FIXLISTMERGE=1` 制御の debug logging を追加
- skip 理由（fence 内 / table 内 / pattern 不一致 等）を行番号とともに記録
- production 動作に影響なし（env var 非設定時はサイレント）

## 背景
cmd_380 軍師分析: B 軸 fixListMerge paradox — local では pass するが workflow output に残差。
Phase 1 として actual 挙動を観察し、Phase 2 regex 強化の根拠確立。

Closes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * デバッグ機能を追加しました。`DEBUG_FIXLISTMERGE=1` 環境変数を設定することで、詳細なログ出力が可能になります。スキップされた行の理由や行番号がより詳しく記録されるようになり、問題の診断がしやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->