### PR TITLE
fix: saas-rewrite 冪等化 — R-ENV-ADMIN/TABLE negative lookbehind/lookahead (cmd_381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - chore(deps): bump @geolonia/yuuhitsu 0.1.13 → 0.1.14 (SF6 context_exception hybrid schema) (Closes #136)
 
 ### Fixed
+- [fix] cmd_381 — saas-rewrite 冪等化: R-ENV-ADMIN/R-ENV-TABLE に negative lookbehind/lookahead 追加、skip_in_code: false に変更して全文一括マッチングを有効化。unit tests 6 件追加 (Closes #171)
 - [fix] cmd_379 — PR#166 残課題 hotfix: saas-rewrite 重複注記削除（en+ja admin.md）、fixListMerge 範囲外 list 5箇所・OS パス 1箇所分離、changelog.md 見出し連結修正、ngsiv2-vs-ngsild.md TOC アンカー + heading 連結修正、subscriptions.md 誤記修正 + DPoP アンカー追加、endpoints.md bare fence 2件修正 (Closes #167)
 - [fix] cmd_376 — PR#161 残課題 3 種 hotfix: bare fence 55 件修正 (11 merged lines in 7 files)、geonicdb 小文字 prose 露出解消（Glossary Check 修正と共通原因）、smart-data-models.md heading 連結分離 (Closes #162)
 - [fix] cmd_373 — PR#155 ja list/heading 連結 + アンカー hotfix（ngsild.md 11箇所 list 分離 + ngsiv2-vs-ngsild.md heading/hr 分離 + #federation → #フェデレーション）(Closes #157)

--- a/scripts/config/saas-rewrite-rules.yaml
+++ b/scripts/config/saas-rewrite-rules.yaml
@@ -88,19 +88,19 @@ rules:
   - id: R-ENV-ADMIN
     description: "ADMIN_ALLOWED_IPS env var section → prepend SaaS note (en/ja, admin+endpoints)"
     enabled: true
-    skip_in_code: true
+    skip_in_code: false  # full-content matching required for cross-line negative lookbehind
     skip_in_changelog: true
     matchers:
-      - pattern: 'Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable\.'
+      - pattern: '(?<!Contact Geolonia support for details\.\n\n)Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable\.'
         replacement: "**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.\n\nRestrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable."
         scope: ['docs/en/api-reference/admin.md']
-      - pattern: 'By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API \(`/admin/\*`\) to specific IP addresses:'
+      - pattern: '(?<!Contact Geolonia support for details\.\n\n)By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API \(`/admin/\*`\) to specific IP addresses:'
         replacement: "**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.\n\nBy setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:"
         scope: ['docs/en/api-reference/endpoints.md']
-      - pattern: '`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
+      - pattern: '(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
         replacement: "**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。\n\n`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。"
         scope: ['docs/ja/api-reference/admin.md']
-      - pattern: '`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API \(`/admin/\*`\) へのアクセスを特定の IP アドレスに制限できます:'
+      - pattern: '(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API \(`/admin/\*`\) へのアクセスを特定の IP アドレスに制限できます:'
         replacement: "**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。\n\n`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:"
         scope: ['docs/ja/api-reference/endpoints.md']
 
@@ -108,12 +108,12 @@ rules:
   - id: R-ENV-TABLE
     description: "endpoints.md env var table → append SaaS note after ADMIN_ALLOWED_IPS row (en/ja)"
     enabled: true
-    skip_in_code: true
+    skip_in_code: false  # full-content matching required for negative lookahead across lines
     skip_in_changelog: true
     matchers:
-      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| IPs/CIDRs allowed to access the Admin API \(comma-separated\) \|'
+      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| IPs/CIDRs allowed to access the Admin API \(comma-separated\) \|(?!\n\n> \*\*SaaS users\*\*)'
         replacement: "| `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |\n\n> **SaaS users**: These environment variables are managed via the GeonicDB SaaS console. Direct configuration is not required."
         scope: ['docs/en/api-reference/endpoints.md']
-      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| 管理 API へのアクセスを許可する IP/CIDR\(カンマ区切り\) \|'
+      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| 管理 API へのアクセスを許可する IP/CIDR\(カンマ区切り\) \|(?!\n\n> \*\*SaaS 利用者の方へ\*\*)'
         replacement: "| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |\n\n> **SaaS 利用者の方へ**: これらの環境変数は GeonicDB SaaS コンソールで管理されます。直接設定は不要です。"
         scope: ['docs/ja/api-reference/endpoints.md']

--- a/scripts/config/saas-rewrite-rules.yaml
+++ b/scripts/config/saas-rewrite-rules.yaml
@@ -91,16 +91,16 @@ rules:
     skip_in_code: false  # full-content matching required for cross-line negative lookbehind
     skip_in_changelog: true
     matchers:
-      - pattern: '(?<!Contact Geolonia support for details\.\n\n)Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable\.'
+      - pattern: '(?<!Contact Geolonia support for details\.\n\n)(?<!Contact Geolonia support for details\.\r\n\r\n)Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable\.'
         replacement: "**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.\n\nRestrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable."
         scope: ['docs/en/api-reference/admin.md']
-      - pattern: '(?<!Contact Geolonia support for details\.\n\n)By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API \(`/admin/\*`\) to specific IP addresses:'
+      - pattern: '(?<!Contact Geolonia support for details\.\n\n)(?<!Contact Geolonia support for details\.\r\n\r\n)By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API \(`/admin/\*`\) to specific IP addresses:'
         replacement: "**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.\n\nBy setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:"
         scope: ['docs/en/api-reference/endpoints.md']
-      - pattern: '(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
+      - pattern: '(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)(?<!詳細は Geolonia サポートにお問い合わせください。\r\n\r\n)`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
         replacement: "**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。\n\n`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。"
         scope: ['docs/ja/api-reference/admin.md']
-      - pattern: '(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API \(`/admin/\*`\) へのアクセスを特定の IP アドレスに制限できます:'
+      - pattern: '(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)(?<!詳細は Geolonia サポートにお問い合わせください。\r\n\r\n)`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API \(`/admin/\*`\) へのアクセスを特定の IP アドレスに制限できます:'
         replacement: "**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。\n\n`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:"
         scope: ['docs/ja/api-reference/endpoints.md']
 
@@ -111,9 +111,9 @@ rules:
     skip_in_code: false  # full-content matching required for negative lookahead across lines
     skip_in_changelog: true
     matchers:
-      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| IPs/CIDRs allowed to access the Admin API \(comma-separated\) \|(?!\n\n> \*\*SaaS users\*\*)'
+      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| IPs/CIDRs allowed to access the Admin API \(comma-separated\) \|(?!\r?\n\r?\n> \*\*SaaS users\*\*)'
         replacement: "| `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |\n\n> **SaaS users**: These environment variables are managed via the GeonicDB SaaS console. Direct configuration is not required."
         scope: ['docs/en/api-reference/endpoints.md']
-      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| 管理 API へのアクセスを許可する IP/CIDR\(カンマ区切り\) \|(?!\n\n> \*\*SaaS 利用者の方へ\*\*)'
+      - pattern: '\| `ADMIN_ALLOWED_IPS` \| - \| 管理 API へのアクセスを許可する IP/CIDR\(カンマ区切り\) \|(?!\r?\n\r?\n> \*\*SaaS 利用者の方へ\*\*)'
         replacement: "| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |\n\n> **SaaS 利用者の方へ**: これらの環境変数は GeonicDB SaaS コンソールで管理されます。直接設定は不要です。"
         scope: ['docs/ja/api-reference/endpoints.md']

--- a/tests/unit/saas-docs-rewrite.test.ts
+++ b/tests/unit/saas-docs-rewrite.test.ts
@@ -504,6 +504,108 @@ describe('processFile — R-ENV-TABLE (JA)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 15. Idempotency — R-ENV-ADMIN (applying twice yields the same result)
+// ---------------------------------------------------------------------------
+describe('idempotency — R-ENV-ADMIN (EN admin.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-ADMIN')!
+  const path = 'docs/en/api-reference/admin.md'
+
+  it('applying R-ENV-ADMIN twice yields identical result (en admin.md)', () => {
+    const input =
+      'Restrict admin API access to specific IP addresses or CIDR ranges using the `ADMIN_ALLOWED_IPS` environment variable.'
+    const { content: once, changes: c1 } = processFile(input, rule, path)
+    const { content: twice, changes: c2 } = processFile(once, rule, path)
+    expect(c1).toBe(1)
+    expect(c2).toBe(0)
+    expect(twice).toBe(once)
+  })
+})
+
+describe('idempotency — R-ENV-ADMIN (EN endpoints.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-ADMIN')!
+  const path = 'docs/en/api-reference/endpoints.md'
+
+  it('applying R-ENV-ADMIN twice yields identical result (en endpoints.md)', () => {
+    const input =
+      'By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:'
+    const { content: once, changes: c1 } = processFile(input, rule, path)
+    const { content: twice, changes: c2 } = processFile(once, rule, path)
+    expect(c1).toBe(1)
+    expect(c2).toBe(0)
+    expect(twice).toBe(once)
+  })
+})
+
+describe('idempotency — R-ENV-ADMIN (JA admin.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-ADMIN')!
+  const path = 'docs/ja/api-reference/admin.md'
+
+  it('applying R-ENV-ADMIN twice yields identical result (ja admin.md)', () => {
+    const input =
+      '`ADMIN_ALLOWED_IPS` 環境変数を使用して、管理 API へのアクセスを特定の IP アドレスまたは CIDR 範囲に制限できます。'
+    const { content: once, changes: c1 } = processFile(input, rule, path)
+    const { content: twice, changes: c2 } = processFile(once, rule, path)
+    expect(c1).toBe(1)
+    expect(c2).toBe(0)
+    expect(twice).toBe(once)
+  })
+})
+
+describe('idempotency — R-ENV-ADMIN (JA endpoints.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-ADMIN')!
+  const path = 'docs/ja/api-reference/endpoints.md'
+
+  it('applying R-ENV-ADMIN twice yields identical result (ja endpoints.md)', () => {
+    const input =
+      '`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:'
+    const { content: once, changes: c1 } = processFile(input, rule, path)
+    const { content: twice, changes: c2 } = processFile(once, rule, path)
+    expect(c1).toBe(1)
+    expect(c2).toBe(0)
+    expect(twice).toBe(once)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 16. Idempotency — R-ENV-TABLE (applying twice yields the same result)
+// ---------------------------------------------------------------------------
+describe('idempotency — R-ENV-TABLE (EN endpoints.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-TABLE')!
+  const path = 'docs/en/api-reference/endpoints.md'
+
+  it('applying R-ENV-TABLE twice yields identical result (en endpoints.md)', () => {
+    const input =
+      '| `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |'
+    const { content: once, changes: c1 } = processFile(input, rule, path)
+    const { content: twice, changes: c2 } = processFile(once, rule, path)
+    expect(c1).toBe(1)
+    expect(c2).toBe(0)
+    expect(twice).toBe(once)
+  })
+})
+
+describe('idempotency — R-ENV-TABLE (JA endpoints.md)', () => {
+  const config = loadConfig(join(process.cwd(), 'scripts/config/saas-rewrite-rules.yaml'))
+  const rule = config.rules.find(r => r.id === 'R-ENV-TABLE')!
+  const path = 'docs/ja/api-reference/endpoints.md'
+
+  it('applying R-ENV-TABLE twice yields identical result (ja endpoints.md)', () => {
+    const input =
+      '| `ADMIN_ALLOWED_IPS` | - | 管理 API へのアクセスを許可する IP/CIDR(カンマ区切り) |'
+    const { content: once, changes: c1 } = processFile(input, rule, path)
+    const { content: twice, changes: c2 } = processFile(once, rule, path)
+    expect(c1).toBe(1)
+    expect(c2).toBe(0)
+    expect(twice).toBe(once)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // matchesScope
 // ---------------------------------------------------------------------------
 describe('matchesScope', () => {


### PR DESCRIPTION
## Summary
- `scripts/config/saas-rewrite-rules.yaml` の R-ENV-ADMIN (4 matchers) に **negative lookbehind** を追加
- R-ENV-TABLE (2 matchers) に **negative lookahead** を追加  
- `skip_in_code: true → false` に変更（クロスライン lookbehind/lookahead には full-content 一括処理が必要なため）
- 冪等性 unit tests 6 件追加（en/ja × R-ENV-ADMIN 4 + R-ENV-TABLE 2）

## 背景
cmd_380 軍師分析: R-ENV-ADMIN/R-ENV-TABLE の matcher が置換後テキストにもマッチするため、
毎 sync run で SaaS 注記が +1 重複追加される冪等性破壊が発生していた。

## 変更詳細
- **R-ENV-ADMIN EN**: `(?<!Contact Geolonia support for details.\n\n)` で SaaS 注記適用済を検出
- **R-ENV-ADMIN JA**: `(?<!詳細は Geolonia サポートにお問い合わせください。\n\n)` で検出
- **R-ENV-TABLE EN**: `(?!\n\n> \*\*SaaS users\*\*)` で後続の SaaS 注記存在を確認
- **R-ENV-TABLE JA**: `(?!\n\n> \*\*SaaS 利用者の方へ\*\*)` で確認

## テスト
- 全 197 件 PASS・SKIP=0 確認済み
- 新規冪等性テスト: 1回目 `changes=1`、2回目 `changes=0`・内容不変を検証

Closes #171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * SaaS ドキュメント書き換えで SaaS ユーザ向けメモの重複追加を防止しました
  * 管理者向け説明と API リファレンステーブルの書き換え処理を改善し、既に注記が存在する場合は再付与しないようにしました

* **テスト**
  * 書き換えルールの冪等性を検証する6件のユニットテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->