### PR TITLE
chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.15 — SF1 P-A4 newline sentinel (cmd_385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [feat] Phase 1 — saas-docs-rewrite.ts + YAML rule config (R-DEV-MD + R-SAM-BATCH) 実装（cmd_371）(Closes #152)
 
 ### Changed
+- chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.15 — SF1 P-A4 newline sentinel (Closes #175)
 - [glossary] Context Broker hybrid 形式化 — 「ブローカー」を except_after で復活、MQTT/Message/Event broker 文脈を許容（cmd_361）(Closes #137)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.13 → 0.1.14 (SF6 context_exception hybrid schema) (Closes #136)
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.14",
+    "@geolonia/yuuhitsu": "^0.1.15",
     "@playwright/test": "^1.58.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.14
-        version: 0.1.14(ws@8.19.0)(zod@4.4.2)
+        specifier: ^0.1.15
+        version: 0.1.15(ws@8.19.0)(zod@4.4.2)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -460,8 +460,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.14':
-    resolution: {integrity: sha512-FHRCQIEEv+ZzWMCvkjDQuaveaSQke4zsqaHo3pJPfT54mVaCsXsBTnf5O/mqQeoylnb5zYUmAg3N9kinkUuvNA==}
+  '@geolonia/yuuhitsu@0.1.15':
+    resolution: {integrity: sha512-abqyy39Znejc37Pw23axMn5mBpnDHr7lto6U3s1+sM43dr2XfPhxU/zmxfPdOQLBuQSv8LodcLt/Mwfx0oJ2IA==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -1879,7 +1879,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.14(ws@8.19.0)(zod@4.4.2)':
+  '@geolonia/yuuhitsu@0.1.15(ws@8.19.0)(zod@4.4.2)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary
- `@geolonia/yuuhitsu` 0.1.14 → 0.1.15 bump
- SF1 P-A4 newline sentinel (%%BB%%) 導入による翻訳パイプライン newline 喪失根治

## Phase 2 monitoring 開始
マージ後 1 週間 monitoring。list/heading/hr/fence 連結問題が再発しないことを確認。
問題なければ Phase 3 (cmd_386) で fix-doc-quality.ts 4 関数一括削除予定。

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * `@geolonia/yuuhitsu` の依存関係を 0.1.14 から 0.1.15 にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->