### PR TITLE
feat(docs): add Live Demo links to demo-app.md — demo.geonicdb.com CTA (cmd_386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- [feat] cmd_386 — demo-app.md に Live Demo リンク追加 (demo.geonicdb.com) (Closes #177)
 - [feat] cmd_382 — fixListMerge に DEBUG_FIXLISTMERGE=1 制御の debug logging 追加（skip 理由・行番号記録）(Closes #172)
 - [feat] cmd_378 — fix-doc-quality.ts SF4 拡張: fixEmbeddedFences 4/5-backtick edge case (B軸) + fixHeadingMerge heading+inline-code+body 分離 (C軸)。unit tests 9 件追加 (Closes #164)
 - [feat] cmd_375 SF4 — fix-doc-quality.ts に fixListMerge / fixHeadingMerge / fixHorizontalRuleMerge / fixAnchorI18n 4 関数追加 + unit tests 29 件。list/heading/hr 連結検出・自動分割、ja docs アンカー Hybrid auto-fix 実装 (Closes #159)

--- a/docs/en/saas/demo-app.md
+++ b/docs/en/saas/demo-app.md
@@ -6,6 +6,8 @@ outline: deep
 
 # Demo App
 
+Try the live demo at **[demo.geonicdb.com](https://demo.geonicdb.com)** — no setup required.
+
 The GeonicDB Demo App is a collection of interactive applications that showcase GeonicDB capabilities. Built with React, Vite, and MapLibre GL JS, the demos cover real-world use cases from executive dashboards to geo-spatial city maps.
 
 ## Demo Applications
@@ -22,6 +24,8 @@ An executive summary view that aggregates data from GeonicDB entities into actio
 - **Entity Table** — Sortable overview of all entities with key attributes
 - **Mini Map** — Location-aware entities plotted on a map
 
+[Try it →](https://demo.geonicdb.com/dashboard)
+
 ### API Tutorial
 
 **Audience**: Developers and evaluators
@@ -36,6 +40,8 @@ A guided, 5-step interactive walkthrough that teaches you the GeonicDB API hands
 
 Each step provides multi-language code samples (curl, JavaScript, Python) and lets you execute API calls directly in the browser.
 
+[Try it →](https://demo.geonicdb.com/tutorial)
+
 ### Smart Building
 
 **Audience**: Facility managers and building operators
@@ -49,6 +55,8 @@ A building management interface demonstrating IoT sensor data visualization:
 - **Live Simulation** — Run simulations with adjustable speed to see real-time data changes
 - **Inline Editing** — Modify entity attributes directly from the UI
 
+[Try it →](https://demo.geonicdb.com/smart-building)
+
 ### City Map
 
 **Audience**: GIS engineers and smart city planners
@@ -60,6 +68,8 @@ A full-screen geographic interface for spatial data exploration:
 - **Query Result Overlay** — See matching entities with the generated curl command
 - **Entity Panel** — Browse and filter entities by type
 - **AI Chat** — Natural language queries powered by MCP, with tool call visualization
+
+[Try it →](https://demo.geonicdb.com/city-map)
 
 ## Tech Stack
 
@@ -140,6 +150,7 @@ geonicdb-demo-app/
 
 ## Links
 
+- **Live Demo**: [demo.geonicdb.com](https://demo.geonicdb.com)
 - **Geolonia Maps**: [geolonia.com](https://geolonia.com/)
 
 ## Next Steps

--- a/docs/ja/saas/demo-app.md
+++ b/docs/ja/saas/demo-app.md
@@ -6,7 +6,7 @@ outline: deep
 
 # デモアプリ
 
-**[demo.geonicdb.com](https://demo.geonicdb.com)** でライブデモをお試しいただけます — セットアップ不要です。
+**[GeonicDB デモ](https://demo.geonicdb.com)** でライブデモをお試しいただけます — セットアップ不要です。
 
 GeonicDB Demo App は、GeonicDB の機能を体験できるインタラクティブなアプリケーション集です。React、Vite、MapLibre GL JS で構築され、エグゼクティブダッシュボードから地理空間シティマップまで、実際のユースケースをカバーしています。
 
@@ -150,7 +150,7 @@ geonicdb-demo-app/
 
 ## リンク
 
-- **ライブデモ**: [demo.geonicdb.com](https://demo.geonicdb.com)
+- **ライブデモ**: [GeonicDB デモ](https://demo.geonicdb.com)
 - **Geolonia Maps**: [geolonia.com](https://geolonia.com/)
 
 ## 次のステップ

--- a/docs/ja/saas/demo-app.md
+++ b/docs/ja/saas/demo-app.md
@@ -6,6 +6,8 @@ outline: deep
 
 # デモアプリ
 
+**[demo.geonicdb.com](https://demo.geonicdb.com)** でライブデモをお試しいただけます — セットアップ不要です。
+
 GeonicDB Demo App は、GeonicDB の機能を体験できるインタラクティブなアプリケーション集です。React、Vite、MapLibre GL JS で構築され、エグゼクティブダッシュボードから地理空間シティマップまで、実際のユースケースをカバーしています。
 
 ## デモアプリケーション
@@ -22,6 +24,8 @@ GeonicDB エンティティのデータをアクション可能なメトリク�
 - **エンティティテーブル** — 主要属性付きの全エンティティのソート可能な一覧
 - **ミニマップ** — 位置情報を持つエンティティの地図表示
 
+[試す →](https://demo.geonicdb.com/dashboard)
+
 ### API Tutorial（API チュートリアル）
 
 **対象**: 開発者、評価者
@@ -36,6 +40,8 @@ GeonicDB API をハンズオンで学ぶ、ガイド付き5ステップのイン
 
 各ステップでマルチ言語のコードサンプル（curl、JavaScript、Python）を提供し、ブラウザ内で直接 API コールを実行できます。
 
+[試す →](https://demo.geonicdb.com/tutorial)
+
 ### Smart Building（スマートビルディング）
 
 **対象**: 施設管理者、ビルオペレーター
@@ -49,6 +55,8 @@ IoT センサーデータの可視化を示すビル管理インターフェー�
 - **ライブシミュレーション** — 速度調整可能なシミュレーションでリアルタイムデータ変化を確認
 - **インライン編集** — UI から直接エンティティ属性を変更
 
+[試す →](https://demo.geonicdb.com/smart-building)
+
 ### City Map（シティマップ）
 
 **対象**: GIS エンジニア、スマートシティプランナー
@@ -60,6 +68,8 @@ IoT センサーデータの可視化を示すビル管理インターフェー�
 - **クエリ結果オーバーレイ** — マッチしたエンティティと生成された curl コマンドの表示
 - **エンティティパネル** — タイプ別フィルタリング付きのエンティティ一覧
 - **AI チャット** — MCP によるツールコール可視化付きの自然言語クエリ
+
+[試す →](https://demo.geonicdb.com/city-map)
 
 ## 技術スタック
 
@@ -140,6 +150,7 @@ geonicdb-demo-app/
 
 ## リンク
 
+- **ライブデモ**: [demo.geonicdb.com](https://demo.geonicdb.com)
 - **Geolonia Maps**: [geolonia.com](https://geolonia.com/)
 
 ## 次のステップ


### PR DESCRIPTION
## Summary
- `docs/{en,ja}/saas/demo-app.md` 冒頭に Live Demo CTA 追加（demo.geonicdb.com）
- 各デモセクション（Dashboard / API Tutorial / Smart Building / City Map）に Try it リンク追加
- 「リンク」セクションに Live Demo を追加

Closes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * ダッシュボード、APIチュートリアル、スマートビルディング、シティマップ各セクションに「試す →」のライブデモリンクを追加しました。
  * ページ上部およびリンク一覧に「ライブデモ」への導線を追加し、セットアップ不要ですぐにデモを試せるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->