### PR TITLE
docs: sync and translate from geonicdb/docs

### DIFF
--- a/docs/ja/ai-integration/examples.md
+++ b/docs/ja/ai-integration/examples.md
@@ -5,11 +5,11 @@ outline: deep
 ---
 # AI 統合
 
-GeonicDB は AI エージェント（Claude、GPT-4、Gemini など）が API を簡単に利用できるよう、複数の AI 指向インターフェースを提供しています。
+GeonicDB は複数の AI 指向インターフェースを提供しており、AI エージェント（Claude、GPT-4、Gemini など）が API を簡単に利用できるようになっています。
 
 ## エンドポイント一覧
 
-| エンドポイント | 形式 | 説明 |
+| エンドポイント | フォーマット | 説明 |
 |---------------|------|------|
 | `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
 | `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
@@ -22,34 +22,31 @@ GeonicDB は AI エージェント（Claude、GPT-4、Gemini など）が API �
 
 Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
 
-### 利用可能なツール (5 ツール)
+### 利用可能なツール（5 つのツール）
 
-各ツールは `action` および `resource` パラメータを介して操作を選択します。
+各ツールは `action` と `resource` パラメータを通じて操作を選択します。
 
 | ツール名 | リソース | アクション | 説明 |
 |---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、型、属性の管理 |
+| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、および属性の管理 |
 | `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作（最大 1,000 件） |
 | `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
 | `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理（super_admin、get/update/delete） |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理（認証が必要） |
+| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、およびポリシー管理（認証が必要） |
 
 ### 自動 NGSI-LD 属性タイプ検出
 
-MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動的に推論します：
 
 | 値のパターン | 検出されるタイプ | 例 |
 |------------|-----------|-----|
 | `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| GeoJSON オブジェクト（Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString） | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
 | `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
-タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+タイプを明示的に指定することもできます：
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -83,7 +80,7 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 ## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
 )
 
-API 検出情報を提供します。
+API ディスカバリー情報を提供します。
 
 ```json
 {
@@ -146,22 +143,20 @@ response = client.chat.completions.create(
 )
 ```
 
-## MCP (Model Context Protocol) サポート
+## MCP（Model Context Protocol）サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント（Claude Desktop など）は、コンテキストブローカーに直接接続できます。
+GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント（Claude Desktop など）はコンテキストブローカーに直接接続できます。
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`- **トランスポート**: ストリーム可能な HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
 - **動作モード**: ステートレス (Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
+- **認証**: `AUTH_ENABLED=true` の場合、アクセス制御とテナント分離が JWT Bearer トークンを介して実施されます
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発環境（認証なし）
+#### ローカル開発環境（認証なし）
 
 ```json
 {
@@ -180,11 +175,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` は必須です。これは GeonicDB が Streamable HTTP (POST) のみをサポートしており、SSE が利用できないためです。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要です）。
+> **注意**: GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できないため、`--transport http-only` が必要です。`http://` URL には `--allow-http` が必要です（本番環境の `https://` では不要です）。
 
-
-
-### 本番環境（JWT 認証あり）
+#### 本番環境（JWT 認証を使用）
 
 ```json
 {
@@ -204,13 +197,11 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンは有効期限があり、定期的な更新が必要です。
+JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンは有効期限があるため、定期的な更新が必要です。
 
+#### 本番環境（API キー認証を使用）
 
-
-### 本番環境（API キー認証あり）
-
-API キーは有効期限がなく、Claude Desktop などの長期的な統合に推奨されます。
+API キーは有効期限がなく、Claude Desktop などの長期稼働する統合には推奨されます。
 
 **ステップ 1: GeonicDB CLI のインストール**
 
@@ -239,9 +230,9 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー（`gdb_` で始まる文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のためにキーを CLI 設定に保存します。
+> **重要**: API キー（`gdb_` プレフィックス付きの文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
 
-API キーで利用可能なスコープ:
+API キーの利用可能なスコープ:
 
 | スコープ | 説明 |
 |---|---|
@@ -254,10 +245,9 @@ API キーで利用可能なスコープ:
 
 **ステップ 4: Claude Desktop の設定**
 
-Claude Desktop 設定ファイルを編集します:
+Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -281,15 +271,13 @@ Claude Desktop 設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列から分離できます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保持できます。
 
 **ステップ 5: Claude Desktop の再起動**
 
 設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -304,18 +292,16 @@ geonic me api-keys delete <key-id>
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
 - **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効の場合**: 省略すると、ログインしているユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
+- **認証が有効の場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分自身のテナントにのみアクセスできます。
 
-### ServicePath仕様
+### Service Path の指定
 
-`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+`entities`、`types`、`attributes`、`batch`、`temporal` ツールには、階層的なスコープ内でエンティティを管理するための `servicePath` パラメータがあります。
 
+#### 基本形式
 
-
-### 基本フォーマット
-
-- **フォーマット**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
-- **デフォルト**: 省略された場合、ルートパス `/` が使用されます
+- **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
+- **デフォルト**: 省略した場合、ルートパス `/` が使用されます
 - **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
@@ -326,9 +312,7 @@ entities tool:
   servicePath: "/hello"
 ```
 
-
-
-### 階層検索 (`/#`
+#### 階層検索 (`/#`
 )
 
 `/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
@@ -341,9 +325,7 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
-
-
-### 複数パス指定 (カンマ区切り)
+#### 複数パスの指定 (カンマ区切り)
 
 カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
 
@@ -359,21 +341,21 @@ entities tool:
 
 ### NGSI-LD クエリパラメータ
 
-`entities` ツールは、NGSI-LD クエリパラメータの完全なセットをサポートしています:
+`entities` ツールは、NGSI-LD クエリパラメータの全セットをサポートしています:
 
 | パラメータ | 説明 | 例 |
 |---|---|---|
-| `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
-| `idPattern` | エンティティ ID に一致する正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` をプレフィックスとして付与 | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
+| `idList` | 一括取得用のカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
+| `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
+| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を接頭辞として付ける | `"createdAt"`、`"!modifiedAt"` |
+| `orderDirection` | ソート方向 (`!` 接頭辞の代替) | `"asc"`、`"desc"` |
 | `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
 | `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
 | `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
 | `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
 | `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
 | `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY フォーマットの空間 ID | `"18/232814/103224"` |
+| `spatialId` | ZFXY 形式の空間 ID | `"18/232814/103224"` |
 | `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
 
 ```yaml
@@ -426,19 +408,19 @@ curl -X POST http://localhost:3000/mcp \
 
 - **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
-- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
+- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。JWT RBAC トークンにはスコープ制限は適用されません。
 - **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
 
-## JSON スキーマとカスタムデータモデル
+## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは、作成時に JSON スキーマ (Draft 2020-12) が自動的に生成されます。この JSON スキーマは、AI ツールで以下の目的に活用できます。
+カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は AI ツールで次の目的に活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加の属性を許可します)。厳密な検証を強制するには `false` に設定します。この場合、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持てるかどうかを制御します。デフォルトは `true` (追加の属性を許可し、NGSI-LD のセマンティクスに従います) です。`false` に設定すると厳格な検証が適用され、定義された属性のみが受け入れられます。AI エージェントはエンティティ作成時にこのフィールドをチェックして、追加の属性が許可されているかを判断する必要があります。
 
 ### AI ツールでの使用例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -457,9 +439,9 @@ entities tool:
     unit: "Celsius"    # enum: ["Celsius", "Fahrenheit", "Kelvin"]
 ```
 
-**検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON スキーマを参照してエラーの原因を特定し、有効な値に修正できます。
+**検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON Schema を参照してエラーの原因を特定し、有効な値に修正できます。
 
-### エンティティテンプレートの生成
+### エンティティテンプレート生成
 
 `config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
 
@@ -492,15 +474,16 @@ config tool:
 }
 ```
 
-テンプレートは、以下の優先順位で値を決定します:
-1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` の値
+テンプレートは次の優先順位で値を決定します:
+1. `defaultValue` が定義されている場合はそれを使用
+2. `example` 値が定義されている場合はそれを使用
 3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
+AI エージェントはこのテンプレートをベースとして、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON スキーマを `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
+`/openapi.json` エンドポイントは、認証されたユーザーのテナントに紐づくカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できます。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -508,7 +491,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON スキーマは、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
 
 ```json
 {
@@ -530,7 +513,7 @@ curl https://api.example.com/openapi.json \
 
 ### 語彙マッピングのためのプロパティ @context
 
-`propertyDetails` の各プロパティには、オプションで HTTP(S) URL を持つ `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
+`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性定義時に [schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` 値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -553,7 +536,7 @@ config tool:
       # No @context → auto-generated URL
 ```
 
-生成される JSON-LD `@context` は以下のようになります:
+生成される JSON-LD `@context` は次のようになります:
 
 ```json
 {
@@ -565,15 +548,15 @@ config tool:
 }
 ```
 
-プロパティ URI はエンティティタイプに依存しません。同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
+プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
 ### @context 解決の拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使った JavaScript SDK
+## AI コーディングアシスタントと JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加設定なしで完全なパブリック API を自動的に検出できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加の設定なしで完全なパブリック API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
@@ -585,33 +568,33 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向け�
 | クエリパラメータ | `GetEntitiesParams` 型 |
 | サブスクリプションオプション | `SubscribeOptions` 型 |
 | イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言に記載 |
+| すべての 10 イベントタイプ | 型宣言にドキュメント化 |
 
 ### 仕組み
 
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完がすぐに利用できます。詳細は SDK ドキュメントを参照してください。
+個別のドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE オートコンプリートが利用できます。詳細については、SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
 
 ### エンドポイント
 
 | エンドポイント | メソッド | 説明 |
 |----------|--------|-------------|
-| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証を記述 |
-| `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
+| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証方法を記述 |
+| `/a2a` | POST | A2A 操作のための JSON-RPC 2.0 エンドポイント |
 
 ### サポートされているメソッド (フェーズ 1)
 
 | JSON-RPC メソッド | 説明 |
 |-----------------|-------------|
-| `message/send` | メッセージを送信し同期レスポンスを受信 |
+| `message/send` | メッセージを送信し、同期的なレスポンスを受信 |
 | `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションを使用してタスクを一覧表示 |
+| `tasks/list` | フィルタリングとページネーションを使用してタスクをリスト表示 |
 | `tasks/cancel` | タスクのキャンセルをリクエスト |
 
 ### スキル
@@ -631,8 +614,8 @@ A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピング�
 A2A は REST API と同じ認証方法を使用します:
 - **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
 - **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` によるクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` 証明ヘッダー (有効化時)
+- **OAuth 2.0**: `POST /oauth/token` 経由のクライアント認証情報フロー
+- **DPoP**: `Authorization: DPoP <token>` + `DPoP` 証明ヘッダー (有効な場合)
 
 `Fiware-Service` ヘッダーによるテナント指定を推奨します (未指定時はデフォルトテナントにフォールバック)。
 
@@ -663,7 +646,7 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 
 ### MCP との関係
 
-A2A と MCP は補完的です:
+A2A と MCP は相互補完的です:
 - **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
 - **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 

--- a/docs/ja/ai-integration/overview.md
+++ b/docs/ja/ai-integration/overview.md
@@ -3,15 +3,15 @@ title: "AI Integration Overview"
 description: "Overview of GeonicDB AI-native features"
 outline: deep
 ---
-# AI 統合
+# AI インテグレーション
 
-GeonicDB は、AI エージェント(Claude、GPT-4、Gemini など)が API を簡単に利用できるように、複数の AI 向けインターフェースを提供しています。
+GeonicDB は複数の AI 指向インターフェースを提供しているため、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できます。
 
 ## エンドポイント一覧
 
-| エンドポイント | 形式 | 説明 |
+| エンドポイント | フォーマット | 説明 |
 |---------------|------|------|
-| `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
+| `GET /llms.txt` | Markdown (llms.txt) | LLM 用の API ドキュメント |
 | `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
 | `GET /.well-known/ai-plugin.json` | JSON | AI プラグインマニフェスト |
 | `GET /openapi.json` | JSON | OpenAPI 3.0 仕様 |
@@ -20,36 +20,33 @@ GeonicDB は、AI エージェント(Claude、GPT-4、Gemini など)が API を�
 ## Tool Use スキーマ (`/tools.json`
 )
 
-Claude Tool Use と OpenAI Function Calling に互換性のあるツール定義を提供します。
+Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
 
-### 利用可能なツール (5 ツール)
+### 利用可能なツール (5 つのツール)
 
-各ツールは `action` と `resource` パラメータで操作を選択します。
+各ツールは `action` および `resource` パラメータを介して操作を選択します。
 
 | ツール名 | リソース | アクション | 説明 |
 |---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作(最大 1,000 件) |
-| `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
-| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理(super_admin、get/update/delete) |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理(認証が必要) |
+| `entities` | entities (デフォルト), types, attributes | list, get, create, update, delete, replace, search_by_location, search_by_attribute, get_info, get_all, append, patch_all, patch | IoT エンティティ、タイプ、および属性管理 |
+| `batch` | - | create, upsert, update, merge, delete, query, purge | 一括エンティティ操作 (最大 1,000 項目) |
+| `temporal` | - | get, query, create, delete, add_attributes, delete_attribute, merge, modify_instance, delete_instance, batch_create, batch_upsert, batch_delete, batch_query | 時系列データ管理 |
+| `config` | rules, jsonld_contexts, data_models, cadde_config | list, get, create, update, delete, activate, deactivate, list_domains, list_models, get_model, generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理 (super_admin, get/update/delete) |
+| `admin` | users, tenants, policies | list, get, create, update, delete, activate, deactivate, change_password | ユーザー、テナント、およびポリシー管理 (認証が必要) |
 
-### NGSI-LD 属性タイプの自動検出
+### 自動 NGSI-LD 属性タイプ検出
 
 MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 
 | 値のパターン | 検出されるタイプ | 例 |
 |------------|-----------|-----|
 | `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| GeoJSON オブジェクト (Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
 | `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -83,7 +80,7 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 ## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
 )
 
-API 検出情報を提供します。
+API ディスカバリー情報を提供します。
 
 ```json
 {
@@ -148,20 +145,18 @@ response = client.chat.completions.create(
 
 ## MCP (Model Context Protocol) サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント(Claude Desktop など)はコンテキストブローカーに直接接続できます。
+GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント (Claude Desktop など) はコンテキストブローカーに直接接続できます。
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`- **トランスポート**: ストリーム可能な HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
-- **動作モード**: ステートレス(Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
+- **動作モード**: ステートレス (Lambda 互換)
+- **認証**: `AUTH_ENABLED=true` の場合、アクセス制御とテナント分離が JWT Bearer トークンを介して実施されます
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発環境 (認証なし)
+#### ローカル開発環境（認証なし）
 
 ```json
 {
@@ -180,11 +175,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` は、GeonicDB が Streamable HTTP (POST) のみをサポートしているため必須です（SSE は利用できません）。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要）。
+> **注意**: GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できないため、`--transport http-only` が必要です。`http://` URL には `--allow-http` が必要です（本番環境の `https://` では不要）。
 
-
-
-### 本番環境 (JWT 認証を使用)
+#### 本番環境（JWT 認証あり）
 
 ```json
 {
@@ -206,19 +199,17 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
 
+#### 本番環境（API キー認証あり）
 
+API キーには有効期限がなく、Claude Desktop のような長期間使用する統合には推奨されます。
 
-### 本番環境 (API キー認証を使用)
-
-API キーには有効期限がなく、Claude Desktop などの長期間の統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**手順 1: GeonicDB CLI をインストール**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: CLI へのログインと設定**
+**手順 2: ログインして CLI を設定**
 
 ```bash
 # Set the server URL
@@ -228,7 +219,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**手順 3: API キーを作成**
 
 ```bash
 geonic me api-keys create \
@@ -239,9 +230,9 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー (`gdb_` プレフィックスの文字列) は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグを使用すると、自動使用のために CLI 設定にキーが保存されます。
+> **重要**: API キー（`gdb_` で始まる文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
 
-API キーの利用可能なスコープ:
+API キーで利用可能なスコープ:
 
 | スコープ | 説明 |
 |---|---|
@@ -252,13 +243,11 @@ API キーの利用可能なスコープ:
 | `read:registrations` | コンテキストソース登録の読み取り |
 | `write:registrations` | 登録の作成、更新、削除 |
 
-**ステップ 4: Claude Desktop の設定**
+**手順 4: Claude Desktop を設定**
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -282,15 +271,13 @@ Claude Desktop の設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保つことができます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列から分離できます。
 
-**ステップ 5: Claude Desktop の再起動**
+**手順 5: Claude Desktop を再起動**
 
-設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されます。
+設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -302,22 +289,20 @@ geonic me api-keys delete <key-id>
 
 ### テナントの指定
 
-各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
+各ツールには操作対象のテナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効な場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効な場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントのみにアクセスできます。
+- **認証が無効な場合**: 省略すると `default` テナントが使用されます。
+- **認証が有効な場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントのみアクセス可能です。
 
 ### ServicePathの指定
 
-`entities`、`types`、`attributes`、`batch`、および `temporal` ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
 
+#### 基本形式
 
-
-### 基本フォーマット
-
-- **フォーマット**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
+- **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
 - **デフォルト**: 省略した場合、ルートパス `/` が使用されます
-- **ユースケース**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+- **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用します
 
 ```yaml
 # Get entities under the /hello path
@@ -327,12 +312,10 @@ entities tool:
   servicePath: "/hello"
 ```
 
-
-
-### 階層検索 (`/#`
+#### 階層検索 (`/#`
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
+`/#` サフィックスを使用すると、指定したパスとそのすべての子パスを検索できます。
 
 ```yaml
 # Search /Madrid/Gardens and its child paths (e.g., /Madrid/Gardens/ParqueNorte)
@@ -342,9 +325,7 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
-
-
-### 複数パスの指定 (カンマ区切り)
+#### 複数パス指定 (カンマ区切り)
 
 カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
 
@@ -360,13 +341,13 @@ entities tool:
 
 ### NGSI-LD クエリパラメータ
 
-`entities` ツールは、NGSI-LD クエリパラメータの完全なセットをサポートします:
+`entities` ツールは、NGSI-LD クエリパラメータの全セットをサポートしています:
 
 | パラメータ | 説明 | 例 |
 |---|---|---|
 | `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
 | `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を前に付ける | `"createdAt"`、`"!modifiedAt"` |
+| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を前置 | `"createdAt"`、`"!modifiedAt"` |
 | `orderDirection` | ソート方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
 | `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
 | `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
@@ -374,8 +355,8 @@ entities tool:
 | `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
 | `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
 | `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY フォーマットの空間 ID | `"18/232814/103224"` |
-| `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
+| `spatialId` | ZFXY 形式の空間 ID | `"18/232814/103224"` |
+| `spatialIdDepth` | 空間 ID 階層検索の深度 | `2` |
 
 ```yaml
 # List entities sorted by creation time (newest first) with system attributes
@@ -399,7 +380,7 @@ entities tool:
   q: "temperature>20"
 ```
 
-`batch` ツールの `query` アクションも `orderBy`、`orderDirection`、および `sysAttrs` をサポートします。
+`batch` ツールの `query` アクションも、`orderBy`、`orderDirection`、`sysAttrs` をサポートしています。
 
 ### 検証
 
@@ -426,20 +407,20 @@ curl -X POST http://localhost:3000/mcp \
 ### 制限事項
 
 - **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
-- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) および `DELETE /mcp` (セッション終了) は 405 を返します。
-- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
+- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
+- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
+- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。JWT RBAC トークンにはスコープ制限は適用されません。
+- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
 
 ## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは作成時に、JSON Schema (Draft 2020-12) が自動的に生成されます。この JSON Schema は、以下の目的で AI ツールに活用できます。
+カスタムデータモデルは作成時に JSON Schema (Draft 2020-12) が自動的に生成されます。この JSON Schema は AI ツールで以下の目的に活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持てるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加属性を許可します)。`false` に設定すると厳密な検証が強制され、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加属性が許可されているかどうかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持てるかどうかを制御します。デフォルトは `true` (任意の追加属性を許可、NGSI-LD のセマンティクスに従う)。`false` に設定すると厳密な検証が強制され、定義された属性のみが受け入れられます。AI エージェントは、エンティティ作成時にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
 
-### AI ツールでのユースケース例
+### AI ツールでの使用例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -462,7 +443,7 @@ entities tool:
 
 ### エンティティテンプレート生成
 
-`config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+`config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動的に生成できます。
 
 ```yaml
 # Generate a template
@@ -494,14 +475,15 @@ config tool:
 ```
 
 テンプレートは以下の優先順位で値を決定します:
-1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` 値
+1. `defaultValue` が定義されている場合はその値
+2. `example` 値が定義されている場合はその値
 3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
+`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールは、テナント固有のデータモデルを自動的に認識できます。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -509,7 +491,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema はレスポンスの `components.schemas` に追加されます:
 
 ```json
 {
@@ -529,9 +511,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### ボキャブラリマッピングのための Property @context
+### 語彙マッピングのためのプロパティ @context
 
-`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致するボキャブラリを確認し、それを `@context` 値として設定してください。
+`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、`@context` 値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -554,7 +536,7 @@ config tool:
       # No @context → auto-generated URL
 ```
 
-生成される JSON-LD `@context` は次のようになります:
+生成される JSON-LD `@context` は以下のようになります:
 
 ```json
 {
@@ -566,15 +548,15 @@ config tool:
 }
 ```
 
-プロパティ URI はエンティティタイプに依存しません。同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
+プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名 (例: `email`) は同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
-### @context 解決の拡張
+### @context 解決拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API 経由でエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使用した JavaScript SDK
+## AI コーディングアシスタントでの JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加の設定なしで完全なパブリック API を自動的に発見できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加の設定なしで完全なパブリック API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
@@ -586,33 +568,33 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向け�
 | クエリパラメータ | `GetEntitiesParams` 型 |
 | サブスクリプションオプション | `SubscribeOptions` 型 |
 | イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言にドキュメント化 |
+| 全 10 種類のイベントタイプ | 型宣言内でドキュメント化 |
 
 ### 仕組み
 
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがそのまま利用できます。詳細は SDK ドキュメントを参照してください。
+別途ドキュメントの URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完をすぐに利用できます。詳細は SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
 
 ### エンドポイント
 
 | エンドポイント | メソッド | 説明 |
 |----------|--------|-------------|
-| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証方法を記述 |
+| `/.well-known/agent-card.json` | GET | Agent Card — 機能、スキル、認証方法を記述 |
 | `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
 
 ### サポートされているメソッド (フェーズ 1)
 
 | JSON-RPC メソッド | 説明 |
 |-----------------|-------------|
-| `message/send` | メッセージを送信し、同期的なレスポンスを受信 |
+| `message/send` | メッセージを送信し、同期レスポンスを受信 |
 | `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションによるタスクの一覧表示 |
+| `tasks/list` | フィルタリングとページネーションを使用してタスクを一覧表示 |
 | `tasks/cancel` | タスクのキャンセルをリクエスト |
 
 ### スキル
@@ -629,13 +611,13 @@ A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピング�
 
 ### 認証
 
-A2A は REST API と同じ認証方法を使用します:
+A2A は REST API と同じ認証方式を使用します:
 - **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
-- **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` によるクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効な場合)
+- **API Key**: `X-Api-Key: <key>` ヘッダー
+- **OAuth 2.0**: `POST /oauth/token` 経由のクライアントクレデンシャルフロー
+- **DPoP**: `Authorization: DPoP <token>` + `DPoP` proof ヘッダー (有効時)
 
-`Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
+`Fiware-Service` ヘッダーによるテナント指定を推奨します (未指定時はデフォルトテナントにフォールバック)。
 
 ### 例: メッセージの送信
 
@@ -666,9 +648,9 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 
 A2A と MCP は補完的な関係にあります:
 - **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして連携
+- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-両方とも同じ基盤となるサービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートしています。
+両者は同じ基盤サービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
 ## 参考文献
 

--- a/docs/ja/ai-integration/tools-json.md
+++ b/docs/ja/ai-integration/tools-json.md
@@ -3,13 +3,13 @@ title: "tools.json"
 description: "AI tool definitions (tools.json)"
 outline: deep
 ---
-# AI インテグレーション
+# AI 統合
 
-GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 向けインターフェースを提供しています。
+GeonicDB は AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 指向インターフェースを提供しています。
 
 ## エンドポイント一覧
 
-| エンドポイント | フォーマット | 説明 |
+| エンドポイント | 形式 | 説明 |
 |---------------|------|------|
 | `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
 | `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
@@ -20,23 +20,23 @@ GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API �
 ## Tool Use スキーマ (`/tools.json`
 )
 
-Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
+Claude Tool Use と OpenAI Function Calling に対応したツール定義を提供します。
 
 ### 利用可能なツール (5 つのツール)
 
-各ツールは `action` および `resource` パラメータで操作を選択します。
+各ツールは `action` と `resource` パラメータを介して操作を選択します。
 
 | ツール名 | リソース | アクション | 説明 |
 |---------|---------|-----------|------|
 | `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作 (最大 1,000 アイテム) |
+| `batch` | - | create、upsert、update、merge、delete、query、purge | バルクエンティティ操作 (最大 1,000 アイテム) |
 | `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
 | `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理 (super_admin、get/update/delete) |
 | `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理 (認証が必要) |
 
-### NGSI-LD 属性タイプの自動検出
+### 自動 NGSI-LD 属性タイプ検出
 
-MCP ツールは、属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 
 | 値のパターン | 検出されるタイプ | 例 |
 |------------|-----------|-----|
@@ -46,10 +46,7 @@ MCP ツールは、属性値から NGSI-LD タイプを自動的に推論しま�
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -83,7 +80,7 @@ MCP ツールは、属性値から NGSI-LD タイプを自動的に推論しま�
 ## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
 )
 
-API 検出情報を提供します。
+API ディスカバリー情報を提供します。
 
 ```json
 {
@@ -148,20 +145,18 @@ response = client.chat.completions.create(
 
 ## MCP (Model Context Protocol) サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント (Claude Desktop など) は、コンテキストブローカーに直接接続できます。
+GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント (Claude Desktop など) はコンテキストブローカーに直接接続できます。
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`- **トランスポート**: ストリーミング可能な HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
 - **動作モード**: ステートレス (Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
+- **認証**: `AUTH_ENABLED=true` の場合、アクセス制御とテナント分離は JWT Bearer トークンによって実施されます
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発 (認証なし)
+#### ローカル開発（認証なし）
 
 ```json
 {
@@ -180,11 +175,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` が必要です。GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できません。`--allow-http` は `http://` URL に必要です (本番環境の `https://` では不要です)。
+> **注意**: GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できないため、`--transport http-only` が必要です。`http://` URL には `--allow-http` が必要です（本番環境の `https://` では不要）。
 
-
-
-### 本番環境 (JWT 認証を使用)
+#### 本番環境（JWT 認証を使用）
 
 ```json
 {
@@ -204,13 +197,11 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
+JWT トークンは `/auth/login` エンドポイントから取得できます。なお、JWT トークンには有効期限があり、定期的な更新が必要です。
 
+#### 本番環境（API キー認証を使用）
 
-
-### 本番環境 (API キー認証を使用)
-
-API キーには有効期限がなく、Claude Desktop などの長期間使用する統合に推奨されます。
+API キーには有効期限がなく、Claude Desktop のような長期間の統合に推奨されます。
 
 **ステップ 1: GeonicDB CLI のインストール**
 
@@ -239,13 +230,13 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー (`gdb_` プレフィックスの文字列) は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
+> **重要**: API キー（`gdb_` プレフィックスの文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、CLI の設定に鍵を保存して自動使用を可能にします。
 
 API キーで利用可能なスコープ:
 
 | スコープ | 説明 |
 |---|---|
-| `read:entities` | エンティティ、タイプ、属性の読み取り |
+| `read:entities` | エンティティ、型、属性の読み取り |
 | `write:entities` | エンティティの作成、更新、削除 |
 | `read:subscriptions` | サブスクリプションの読み取り |
 | `write:subscriptions` | サブスクリプションの作成、更新、削除 |
@@ -256,8 +247,7 @@ API キーで利用可能なスコープ:
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -281,15 +271,13 @@ Claude Desktop の設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保持できます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列から分離できます。
 
 **ステップ 5: Claude Desktop の再起動**
 
-設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
+設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールとして表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -304,19 +292,17 @@ geonic me api-keys delete <key-id>
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
 - **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効の場合**: 省略すると、ログイン中のユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
+- **認証が有効の場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分自身のテナントにのみアクセスできます。
 
 ### ServicePathの指定
 
-`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+`entities`、`types`、`attributes`、`batch`、`temporal` ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
 
-
-
-### 基本形式
+#### 基本形式
 
 - **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
 - **デフォルト**: 省略した場合、ルートパス `/` が使用されます
-- **ユースケース**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+- **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -326,9 +312,7 @@ entities tool:
   servicePath: "/hello"
 ```
 
-
-
-### 階層検索 (`/#`
+#### 階層検索 (`/#`
 )
 
 `/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
@@ -341,11 +325,9 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
+#### 複数パス指定 (カンマ区切り)
 
-
-### 複数パスの指定 (カンマ区切り)
-
-カンマで区切ることで、複数のパス (最大 10 パス) を同時に検索できます。
+カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
 
 ```yaml
 # Search both /park1 and /park2
@@ -367,7 +349,7 @@ entities tool:
 | `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
 | `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を接頭辞として付ける | `"createdAt"`、`"!modifiedAt"` |
 | `orderDirection` | ソート方向 (`!` 接頭辞の代替) | `"asc"`、`"desc"` |
-| `sysAttrs` | システム属性 (`createdAt`、`modifiedAt`) を結果に含める | `true` |
+| `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
 | `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
 | `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
 | `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
@@ -427,18 +409,18 @@ curl -X POST http://localhost:3000/mcp \
 - **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
 - **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。JWT RBAC トークンにはスコープ制限は適用されません。
 - **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
 
 ## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は AI ツールで以下の目的に利用できます。
+カスタムデータモデルは作成時に JSON Schema (Draft 2020-12) が自動生成されます。この JSON Schema は AI ツールで以下の目的に活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加属性を許可) です。`false` に設定すると厳密な検証が適用され、定義された属性のみが受け入れられます。AI エージェントはエンティティ作成時にこのフィールドを確認して、追加属性が許可されているかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかを制御します。デフォルトは `true` です (NGSI-LD のセマンティクスに従い、任意の追加属性を許可)。厳密な検証を強制するには `false` に設定します — 定義された属性のみが受け入れられます。AI エージェントはエンティティを作成する際にこのフィールドをチェックして、追加属性が許可されているかどうかを判断する必要があります。
 
 ### AI ツールでの使用例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照することで、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -459,9 +441,9 @@ entities tool:
 
 **検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON Schema を参照してエラーの原因を特定し、有効な値に修正できます。
 
-### エンティティテンプレート生成
+### エンティティテンプレートの生成
 
-`config` ツールの `generate_template` アクションを使用することで、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+`config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
 
 ```yaml
 # Generate a template
@@ -471,7 +453,7 @@ config tool:
   type: "TemperatureSensor"
 ```
 
-**レスポンス例:**
+**応答例:**
 
 ```json
 {
@@ -494,14 +476,14 @@ config tool:
 
 テンプレートは以下の優先順位で値を決定します:
 1. `defaultValue` が定義されている場合はその値
-2. `example` の値が定義されている場合はその値
+2. `example` 値が定義されている場合はその値
 3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントはこのテンプレートをベースとして、ユーザーの指示に従って値を変更し、エンティティを作成できます。
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールは、テナント固有のデータモデルを自動的に認識できるようになります。
+`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -509,7 +491,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema は、応答の `components.schemas` に追加されます:
 
 ```json
 {
@@ -529,9 +511,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### 語彙マッピングのための Property @context
+### 語彙マッピングのためのプロパティ @context
 
-`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
+`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` 値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -568,13 +550,13 @@ config tool:
 
 プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
-### @context 解決の拡張
+### @context 解決拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API 経由でエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストが応答の `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
 ## AI コーディングアシスタントを使用した JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は追加設定なしで完全なパブリック API を自動的に認識できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は追加の設定なしで完全な公開 API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
@@ -588,16 +570,16 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに�
 | イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
 | 全 10 種類のイベントタイプ | 型宣言内に文書化 |
 
-### 動作の仕組み
+### 仕組み
 
-1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取り
+1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI が文書化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細は SDK ドキュメントを参照してください。
+別途のドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細については SDK ドキュメントを参照してください。
 
-## A2A (Agent-to-Agent プロトコル) サポート
+## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
 
 ### エンドポイント
 
@@ -610,14 +592,14 @@ GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A
 
 | JSON-RPC メソッド | 説明 |
 |-----------------|-------------|
-| `message/send` | メッセージを送信し、同期レスポンスを受信 |
+| `message/send` | メッセージを送信し、同期的な応答を受信 |
 | `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションによるタスク一覧取得 |
+| `tasks/list` | フィルタリングとページネーションを使用してタスクをリスト表示 |
 | `tasks/cancel` | タスクのキャンセルをリクエスト |
 
 ### スキル
 
-A2A は MCP で利用可能な同じ 5 つのツールにマッピングされます:
+A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピングされます:
 
 | スキル ID | 説明 |
 |----------|-------------|
@@ -631,11 +613,11 @@ A2A は MCP で利用可能な同じ 5 つのツールにマッピングされ�
 
 A2A は REST API と同じ認証方法を使用します:
 - **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
-- **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` を介したクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効時)
+- **API Key**: `X-Api-Key: <key>` ヘッダー
+- **OAuth 2.0**: `POST /oauth/token` 経由のクライアントクレデンシャルフロー
+- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効化時)
 
-`Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
+`Fiware-Service` ヘッダーによるテナント指定を推奨します (未指定時はデフォルトテナントにフォールバック)。
 
 ### 例: メッセージの送信
 
@@ -664,11 +646,11 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 
 ### MCP との関係
 
-A2A と MCP は補完的な関係にあります:
+A2A と MCP は相補的です:
 - **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
+- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして連携
 
-両者は同じ基盤サービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
+両方とも同じ基盤となるサービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
 ## 参考資料
 

--- a/docs/ja/api-reference/endpoints.md
+++ b/docs/ja/api-reference/endpoints.md
@@ -9,7 +9,7 @@ outline: deep
 
 ## 目次
 
-- [概要](#概要)
+- [概要](#overview)
 - [認証とマルチテナンシー](#認証とマルチテナンシー)
 - [ページネーション](#ページネーション)
 - [認証 API](#認証-api)
@@ -17,16 +17,16 @@ outline: deep
 - [NGSIv2 API](#ngsiv2-api) (→ [API_NGSIV2.md](./ngsiv2.md))
 - [NGSI-LD API](#ngsi-ld-api) (→ [API_NGSILD.md](./ngsild.md))
 - [クエリ言語](#クエリ言語)
-- [ジオクエリ](#ジオクエリ)
+- [ジオクエリ](#geo-queries)
 - [空間 ID 検索](#空間-id-検索)
 - [GeoJSON 出力](#geojson-出力)
-- [ベクタータイル](#ベクタータイル)
+- [ベクトルタイル](#vector-tiles)
 - [座標参照系 (CRS)](#座標参照系-crs)
 - [データカタログ API](#データカタログ-api)
 - [CADDE 統合](#cadde-統合)
 - [イベントストリーミング](#イベントストリーミング)
 - [エラーレスポンス](#エラーレスポンス)
-- [実装状況](#実装状況)
+- [実装ステータス](#implementation-status)
 
 ---
 
@@ -35,7 +35,7 @@ outline: deep
 この Context Broker は、FIWARE NGSI (Next Generation Service Interface) 仕様に準拠した RESTful API を提供します。
 
 **関連ドキュメント:**
-- [NGSIv2 / NGSI-LD 互換性ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の互換性、型マッピング、ベストプラクティス
+- [NGSIv2 / NGSI-LD 相互運用ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の相互運用性、型マッピング、ベストプラクティス
 - [WebSocket イベントストリーミング](../features/subscriptions.md) - リアルタイムイベントサブスクリプション、実装例、ベストプラクティス
 
 ### ベース URL
@@ -53,11 +53,11 @@ https://{api-gateway-url}/{stage}
 
 ### OPTIONS メソッド
 
-`OPTIONS` メソッドはすべてのエンドポイントでサポートされています。CORS プリフライトリクエストに対して、許可されたメソッドとヘッダーに関する情報を返します。
+すべてのエンドポイントで `OPTIONS` メソッドがサポートされています。これは CORS プリフライトリクエストに応答して、許可されたメソッドとヘッダーに関する情報を返します。
 
 #### レスポンス形式
 
-OPTIONS リクエストは `204 No Content` を返し、以下のヘッダーが含まれます:
+OPTIONS リクエストは `204 No Content` を返し、以下のヘッダーを含みます。
 
 ```http
 OPTIONS /v2/entities/urn:ngsi-ld:Room:Room1
@@ -70,7 +70,7 @@ Access-Control-Allow-Headers: Content-Type, Fiware-Service, Fiware-ServicePath, 
 Access-Control-Max-Age: 86400
 ```
 
-NGSI-LD エンドポイントの場合、追加の `Accept-Patch` ヘッダーも返されます:
+NGSI-LD エンドポイントの場合、追加で `Accept-Patch` ヘッダーも返されます。
 
 ```http
 OPTIONS /ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1
@@ -84,21 +84,21 @@ Access-Control-Allow-Headers: Content-Type, NGSILD-Tenant, Fiware-Service, Link,
 Access-Control-Max-Age: 86400
 ```
 
-> **注意**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証や SDK の条件付きリクエストがプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
+> **注意**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証および SDK 条件付きリクエストがプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
 
 ### エンティティ ID の一意性 (GeonicDB 拡張)
 
 > **GeonicDB 拡張**: この動作は、同じ ID で異なる型を持つエンティティの共存を許可する標準 NGSIv2 仕様とは異なります。
 
-GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の一部では **ありません**。
+GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティ `type` は一意性制約の一部では**ありません**。
 
 **主な動作:**
 
-- 既存のエンティティと同じ ID でエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- バッチ upsert 操作は `entityId` のみでエンティティをマッチングします (型は上書き可能)
-- 同一 ID のエンティティ間で型を区別するための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
+- 既存のエンティティと同じ ID を持つエンティティを作成する場合 (異なる `type` であっても)、`409 AlreadyExists` が返されます
+- バッチアップサート操作は `entityId` のみでエンティティを照合します (型は上書きされる可能性があります)
+- 同じ ID のエンティティ間の型の曖昧性解消のための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
 
-この設計は NGSI-LD 仕様に準拠しており、エンティティ ID は URI であり、本質的に一意です。エンティティ ID は、テナント、servicePath、プロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
+この設計は、エンティティ ID が URI であり本質的に一意である NGSI-LD 仕様と整合しています。エンティティ ID はテナント、servicePath、プロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
 
 ---
 
@@ -106,12 +106,12 @@ GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) 
 
 ### 必須ヘッダー
 
-すべてのリクエストには、以下のヘッダーを含めることを推奨します:
+すべてのリクエストには、以下のヘッダーを含めることが推奨されます:
 
 | ヘッダー | 必須 | 説明 | デフォルト |
-|--------|------|------|---------|
-| `Fiware-Service` / `NGSILD-Tenant` | 推奨 | テナント名 (英数字とアンダースコアのみ) | `default` |
-| `Fiware-ServicePath` | NGSIv2 のみ | テナント内の階層パス (`/` で開始)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/` (クエリ時は `/#` と同等) |
+|--------|----------|-------------|---------|
+| `Fiware-Service` / `NGSILD-Tenant` | 推奨 | テナント名(英数字とアンダースコアのみ) | `default` |
+| `Fiware-ServicePath` | NGSIv2 のみ | テナント内の階層パス(`/` で始まる)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/` (クエリでは `/#` と同等) |
 | `Fiware-Correlator` | オプション | リクエストトレーシング用の相関 ID | 自動生成 |
 
 ### 使用例
@@ -122,21 +122,21 @@ curl -X GET "https://api.example.com/v2/entities" \
   -H "Fiware-ServicePath: /buildings/floor1"
 ```
 
-### テナントの分離
+### テナント分離
 
 - 異なる `Fiware-Service` 値のデータは完全に分離されます
 - 同じテナント内では、`Fiware-ServicePath` を使用してデータを階層的に整理できます
 - テナント名は自動的に小文字に変換されます
 
-### ServicePathの仕様
+### ServicePath仕様
 
-[FIWARE Orion 仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html) に準拠しています。
+[FIWARE Orion 仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html)に準拠しています。
 
-#### 基本形式
+#### 基本フォーマット
 
-- `/` で始まる絶対パスのみ許可されます
-- 英数字とアンダースコアのみ許可されます
-- 最大 10 階層、各レベル最大 50 文字
+- `/` で始まる絶対パスのみが許可されます
+- 英数字とアンダースコアのみが許可されます
+- 最大 10 レベル、1 レベルあたり最大 50 文字
 
 ```bash
 # Retrieve entities at a specific path
@@ -148,7 +148,7 @@ curl "http://localhost:3000/v2/entities" \
 #### 階層検索 (`/#`
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます (**クエリ操作のみ**)。
+`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます(**クエリ操作のみ**)。
 
 ```bash
 # Search /Madrid/Gardens and all its child paths
@@ -157,9 +157,9 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /Madrid/Gardens/#"
 ```
 
-#### 複数パス (カンマ区切り)
+#### 複数パス(カンマ区切り)
 
-カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス、**クエリ操作のみ**)。
+カンマで区切ることで、複数のパスを同時に検索できます(最大 10 パス、**クエリ操作のみ**)。
 
 ```bash
 # Search both /park1 and /park2
@@ -171,8 +171,8 @@ curl "http://localhost:3000/v2/entities" \
 #### デフォルト動作
 
 | 操作 | ヘッダー省略時 | 説明 |
-|------|--------------|------|
-| クエリ (GET) | `/` | ルートパスのみ検索 |
+|-----------|------------------------|-------------|
+| クエリ (GET) | `/` | ルートパスのみを検索 |
 | 書き込み (POST/PUT/PATCH/DELETE) | `/` | ルートパスで作成/更新 |
 
 **注意**: 書き込み操作では、単一の非階層パスのみ使用できます。`/#` や複数パスを指定するとエラーになります。
@@ -192,7 +192,7 @@ curl "http://localhost:3000/v2/entities" \
 
 ### レスポンスヘッダー
 
-各 API タイプごとに、合計数を示すヘッダーが返されます:
+各 API タイプごとに、合計件数を示すヘッダーが返されます:
 
 | API | ヘッダー名 | 条件 |
 |-----|-------------|-----------|
@@ -209,7 +209,7 @@ curl "http://localhost:3000/v2/entities" \
 Link: <https://api.example.com/v2/entities?limit=10&offset=20>; rel="next", <https://api.example.com/v2/entities?limit=10&offset=0>; rel="prev"
 ```
 
-### 検証
+### バリデーション
 
 無効なページネーションパラメータは `400 Bad Request` を返します:
 
@@ -233,55 +233,55 @@ curl "http://localhost:3000/v2/entities?limit=10&options=count" \
   -H "Fiware-Service: smartcity"
 ```
 
-### 注意事項
+### 注記
 
-- `offset` が合計数を超える場合、空の配列が返されます (エラーではありません)
-- FIWARE Orion の仕様に準拠しています
+- `offset` が合計件数を超える場合、空の配列が返されます (エラーではありません)
+- FIWARE Orion 仕様に準拠しています
 
 ---
 
-## HTTP キャッシュコントロール (ETag / 条件付きリクエスト)
+## HTTP キャッシュ制御 (ETag / 条件付きリクエスト)
 
-GET エンドポイントはエンドポイントクラスに基づいてキャッシュ関連ヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップでき、[RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠しています。
+GET エンドポイントは、エンドポイントのクラスに基づいてキャッシュ関連のヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップできます。これは [RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠しています。
 
-### エンドポイントクラス
+### エンドポイントのクラス
 
-| クラス | エンドポイント | バリデータ (ETag/Last-Modified) | 条件付きリクエスト | Cache-Control |
+| クラス | エンドポイント | バリデーター (ETag/Last-Modified) | 条件付きリクエスト | Cache-Control |
 |-------|-----------|-------------------------------|----------------------|---------------|
-| **Data** | `/v2/entities` (リスト、単一、attrs、attrs/{name}、attrs/{name}/value)、`/v2/subscriptions`、`/v2/registrations`、`/ngsi-ld/v1/entities` (リスト、単一、attrs、attrs/{name})、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions` | ✓ | ✓ (`If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache` |
-| **Temporal** | `/ngsi-ld/v1/temporal/entities` (リストと単一、集約を含む) | ✗ (ETag なし — 時系列集約には安価な単調バリデータがない) | ✗ | `private, no-cache` |
-| **Meta** | `/v2/types`、`/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes` (リストと単一) | ✗ (ETag なし、Last-Modified なし) | ✗ (`304` サポートなし) | `max-age=60, stale-while-revalidate=120` |
+| **データ** | `/v2/entities` (リスト、単一、attrs、attrs/{name}、attrs/{name}/value)、`/v2/subscriptions`、`/v2/registrations`、`/ngsi-ld/v1/entities` (リスト、単一、attrs、attrs/{name})、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions` | ✓ | ✓ (`If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache` |
+| **時系列** | `/ngsi-ld/v1/temporal/entities` (リスト、単一、集約を含む) | ✗ (ETag なし — 時系列集約には安価な単調バリデーターが不足) | ✗ | `private, no-cache` |
+| **メタ** | `/v2/types`、`/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes` (リストと単一) | ✗ (ETag なし、Last-Modified なし) | ✗ (`304` サポートなし) | `max-age=60, stale-while-revalidate=120` |
 
-すべてのキャッシュ制御されたレスポンスは同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーション分離、CloudFront のような共有キャッシュに必要)。
+すべてのキャッシュ制御されたレスポンスは、同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーションの分離、CloudFront などの共有キャッシュに必要)。
 
-### レスポンスヘッダー (Data エンドポイント)
-
-| ヘッダー | 説明 |
-|--------|-------------|
-| `ETag` | 弱いエンティティタグ (`W/"..."`、RFC 7232 §2.3.2 弱いバリデータ)。生成は常に **リソーススコープ** (`path + Accept + tenant + Fiware-ServicePath`) をシードに混ぜ込むため、異なるエンドポイント、Accept フォーマット、**テナント**、または **ServicePath** は、基礎となる状態が同一であっても異なる ETag を生成します。`tenant` スロットは最初に `NGSILD-Tenant` を読み取り、`Fiware-Service` にフォールバックし、`extractTenantContext` の優先順位と一致します。テナント / ServicePathシードは、中間キャッシュが `Vary` を誤って処理した場合でも、テナント間の ETag 衝突を防ぎます。<br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェスト、合計カウントとリソーススコープと組み合わせ。<br>• **単一リソース**: `modifiedAt` のハッシュとリソーススコープの組み合わせ。|
-| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP 日付。|
-| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) への保存を禁止します。`no-cache` はプライベートキャッシュからの再利用前に再検証を強制します。|
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`。|
-
-### レスポンスヘッダー (Meta エンドポイント)
+### レスポンスヘッダー (データエンドポイント)
 
 | ヘッダー | 説明 |
 |--------|-------------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証による短期キャッシング。|
-| `Vary` | Data エンドポイントと同じ。|
+| `ETag` | 弱いエンティティタグ (`W/"..."`、RFC 7232 §2.3.2 弱いバリデーター)。生成時には常に **リソーススコープ** (`path + Accept + tenant + Fiware-ServicePath`) をシードに混ぜ込むため、異なるエンドポイント、Accept フォーマット、**テナント**、または **ServicePath** は、基礎となる状態が同一であっても異なる ETag を生成します。`tenant` スロットは最初に `NGSILD-Tenant` を読み取り、`Fiware-Service` にフォールバックし、`extractTenantContext` の優先順位と一致します。テナント / servicePath のシードは、中間キャッシュによって `Vary` が誤って処理された場合でも、テナント間の ETag 衝突を防ぎます。<br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェストと、合計カウントおよびリソーススコープを組み合わせます。<br>• **単一リソース**: `modifiedAt` のハッシュとリソーススコープを組み合わせます。 |
+| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP-date。 |
+| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) への保存を禁止します。`no-cache` はプライベートキャッシュからの再利用前に再検証を強制します。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`。 |
 
-Meta エンドポイントは意図的に `ETag` / `Last-Modified` を省略します。これは、そのコンテンツが安価な単調バリデータを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストではなく `max-age` に依存する必要があります。
+### レスポンスヘッダー (メタエンドポイント)
 
-### 条件付きリクエスト (Data エンドポイントのみ)
+| ヘッダー | 説明 |
+|--------|-------------|
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証による短期キャッシング。 |
+| `Vary` | データエンドポイントと同じ。 |
+
+メタエンドポイントは意図的に `ETag` / `Last-Modified` を省略します。これは、それらのコンテンツが安価な単調バリデーターを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストの代わりに `max-age` に依存する必要があります。
+
+### 条件付きリクエスト (データエンドポイントのみ)
 
 クライアントは条件付きリクエストヘッダーを送信して、結果が変更されていない場合に `304 Not Modified` (空のボディ) を受け取ることができます:
 
 | リクエストヘッダー | 動作 |
 |----------------|----------|
-| `If-None-Match: <ETag>` | サーバーは現在の `ETag` と比較します。一致する場合、`304` を返します。ワイルドカード `*` は常に一致します。|
-| `If-Modified-Since: <HTTP-date>` | サーバーは現在の `Last-Modified` と比較します。変更されていない場合、`304` を返します。|
+| `If-None-Match: <ETag>` | サーバーは現在の `ETag` と比較します。一致した場合、`304` を返します。ワイルドカード `*` は常に一致します。 |
+| `If-Modified-Since: <HTTP-date>` | サーバーは現在の `Last-Modified` と比較します。変更されていない場合、`304` を返します。 |
 
-両方のヘッダーが存在する場合、RFC 7232 §6 に従い `If-None-Match` が優先されます。
+両方のヘッダーが存在する場合、RFC 7232 §6 により `If-None-Match` が優先されます。
 
 ### 例
 
@@ -304,22 +304,22 @@ curl -i "http://localhost:3000/v2/entities" \
 
 ### 注記
 
-- ETag は弱い (`W/`) です — これらはバイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータを持つが属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
-- ETag 生成はリソースパスと `Accept` ヘッダーをシードに含めます。異なるエンドポイントと異なるコンテンツネゴシエーションは、基礎となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
+- ETag は弱い (`W/`) — バイト単位の同一性ではなく、セマンティックな等価性を伝えます。同じデータで属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
+- ETag 生成には、リソースパスと `Accept` ヘッダーがシードに含まれます。異なるエンドポイントや異なるコンテンツネゴシエーションは、基礎となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
 - `304` レスポンスは `ETag`、`Last-Modified`、`Cache-Control`、`Vary`、および CORS ヘッダーを保持します。
-- 条件評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
-- キャッシュコントロールは以下に適用されます:
-  - **NGSIv2**: `/v2/entities` (リスト / 単一 / attrs / attrs+name / attrs+name+value)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`  - **NGSI-LD Data**: `/ngsi-ld/v1/entities` (リスト / 単一 / attrs / attrs+name)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`  - **NGSI-LD Meta**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`  - **NGSI-LD Temporal**: `/ngsi-ld/v1/temporal/entities` (リストと単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
+- 条件付き評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
+- キャッシュ制御は以下に適用されます:
+  - **NGSIv2**: `/v2/entities` (リスト / 単一 / attrs / attrs+name / attrs+name+value)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`  - **NGSI-LD データ**: `/ngsi-ld/v1/entities` (リスト / 単一 / attrs / attrs+name)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`  - **NGSI-LD メタ**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`  - **NGSI-LD 時系列**: `/ngsi-ld/v1/temporal/entities` (リストと単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
 
-### クライアント主導のキャッシュコントロール
+### クライアント駆動のキャッシュ制御
 
 クライアントは `Cache-Control` リクエストヘッダーを送信して、キャッシング動作に影響を与えることができます:
 
 | リクエストヘッダー | サーバーの動作 |
 |----------------|-----------------|
-| `Cache-Control: no-store` | サーバーはレスポンス `Cache-Control` を `no-store` にオーバーライドします (CDN / 中間キャッシュ抑制ヒント)。|
-| `Cache-Control: no-cache` | サーバーは特別なオーバーライドを行いません; エンドポイントのデフォルトポリシーが引き続き適用されます (data → 再検証; meta → `max-age=60` など)。|
-| `Cache-Control: max-age=N` | エッジキャッシュレイヤー用に予約済み (Phase 3 / CloudFront)。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。|
+| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします (CDN/中間キャッシュ抑制ヒント)。 |
+| `Cache-Control: no-cache` | サーバーは特別なオーバーライドを行いません。エンドポイントのデフォルトポリシーが引き続き適用されます (データ → 再検証、メタ → `max-age=60` など)。 |
+| `Cache-Control: max-age=N` | エッジキャッシュレイヤー (フェーズ 3 / CloudFront) 用に予約されています。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。 |
 
 ---
 
@@ -338,11 +338,11 @@ curl -i "http://localhost:3000/v2/entities" \
 | 環境変数 | デフォルト | 説明 |
 |---------|-----------|------|
 | `AUTH_ENABLED` | `false` | 認証を有効化 |
-| `JWT_SECRET` | - | JWT トークン署名用のシークレット (32 文字以上推奨) |
+| `JWT_SECRET` | - | JWT トークン署名用のシークレット (32 文字以上を推奨) |
 | `JWT_EXPIRES_IN` | `1h` | アクセストークンの有効期限 |
 | `JWT_REFRESH_EXPIRES_IN` | `7d` | リフレッシュトークンの有効期限 |
-| `SUPER_ADMIN_EMAIL` | - | 環境変数で設定されるスーパー管理者のメールアドレス |
-| `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定されるスーパー管理者のパスワード |
+| `SUPER_ADMIN_EMAIL` | - | 環境変数で設定するスーパー管理者のメールアドレス |
+| `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定するスーパー管理者のパスワード |
 | `ADMIN_ALLOWED_IPS` | - | Admin API へのアクセスを許可する IP/CIDR (カンマ区切り) |
 
 ### ロールと権限
@@ -350,8 +350,8 @@ curl -i "http://localhost:3000/v2/entities" \
 | ロール | 説明 | 権限 |
 |-------|------|------|
 | `super_admin` | スーパー管理者 | `/admin/*`、`/auth/*`、`/me/*`、監視エンドポイントのみ。データ API (`/v2/*`、`/ngsi-ld/*`、`/catalog*`、`/rules*`) にはアクセス**できません** — 403 を返します |
-| `tenant_admin` | テナント管理者 | 自分のテナント内のユーザーを管理 |
-| `user` | 一般ユーザー | 自分のプロフィール表示とパスワード変更のみ |
+| `tenant_admin` | テナント管理者 | 自身のテナント内のユーザーを管理 |
+| `user` | 一般ユーザー | 自身のプロフィール表示とパスワード変更のみ |
 
 ### ログイン
 
@@ -375,13 +375,13 @@ Content-Type: application/json
 ```
 
 | パラメータ | 型 | 必須 | 説明 |
-|-----------|------|------|------|
+|----------|-----|------|------|
 | `email` | string | はい | メールアドレス |
 | `password` | string | はい | パスワード |
-| `tenantId` | string | いいえ | 指定された場合、そのテナントにスコープされた JWT を発行します。省略時はプライマリテナントがデフォルト |
-| `resourceScopes` | ResourceScope[] | いいえ | エンティティレベルのアクセス制御スコープ。省略時は完全アクセス。詳細は AUTH.md を参照 |
+| `tenantId` | string | いいえ | 指定した場合、そのテナントにスコープされた JWT を発行します。省略時はプライマリテナントがデフォルトです |
+| `resourceScopes` | ResourceScope[] | いいえ | エンティティレベルのアクセス制御スコープ。省略時はフルアクセス。詳細は AUTH.md を参照してください |
 
-**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダー経由でテナントを指定できます (テナント名で解決)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダー値は `^[a-z0-9_]+$` と一致する必要があります。
+**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダーでテナントを指定できます (テナント名で解決されます)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダー値は `^[a-z0-9_]+$` と一致する必要があります。
 
 **レスポンス例**
 
@@ -400,7 +400,7 @@ Content-Type: application/json
 }
 ```
 
-### トークンリフレッシュ
+### トークンのリフレッシュ
 
 ```http
 POST /auth/refresh
@@ -417,7 +417,7 @@ Content-Type: application/json
 
 **レスポンス**: ログインと同じ形式
 
-### 現在のユーザー情報取得
+### 現在のユーザー情報を取得
 
 ```http
 GET /me
@@ -453,7 +453,7 @@ Content-Type: application/json
 }
 ```
 
-**レスポンス**: `204 No Content`**注意**: パスワード変更後、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
+**レスポンス**: `204 No Content`**注意**: パスワードを変更すると、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するには、再度ログインしてください。
 
 ### ログアウト
 
@@ -462,10 +462,9 @@ POST /auth/logout
 Authorization: Bearer <accessToken>
 ```
 
-すべてのセッションを無効化します。このユーザーに対して発行されたすべてのアクセストークンとリフレッシュトークンが即座に無効化されます。
+すべてのセッションを無効化します。このユーザーに発行されたすべてのアクセストークンとリフレッシュトークンは即座に無効化されます。
 
-**レスポンス**: `204 No Content`
-### API キー トークン交換
+**レスポンス**: `204 No Content`### API キートークン交換
 
 #### Nonce の取得
 
@@ -477,9 +476,7 @@ Origin: https://example.com
 {"api_key": "gdb_your_api_key_here"}
 ```
 
-**レスポンス**: `200 OK`
-
-```json
+**レスポンス**: `200 OK````json
 {
   "nonce": "base64url_timestamp.hmac_signature",
   "challenge": "sha256_challenge_string",
@@ -502,9 +499,7 @@ Origin: https://example.com
 }
 ```
 
-**レスポンス**: `200 OK`
-
-```json
+**レスポンス**: `200 OK````json
 {
   "access_token": "<session_jwt>",
   "token_type": "Bearer",
@@ -513,13 +508,13 @@ Origin: https://example.com
 }
 ```
 
-**DPoP トークン バインディング**(オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明キーにバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を必要とします — 最初のリクエストは `DPoP-Nonce` ヘッダーと共に `400 use_dpop_nonce` を返します。証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
+**DPoP トークンバインディング** (オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明キーにバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を必要とします — 最初のリクエストは `DPoP-Nonce` ヘッダーとともに `400 use_dpop_nonce` を返します。証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
 
 ### 管理 API
 
-管理 API は `super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセス可能です。
+管理 API は `super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセスできます。
 
-#### ユーザー一覧
+#### ユーザー一覧取得
 
 ```http
 GET /admin/users
@@ -530,9 +525,9 @@ Authorization: Bearer <accessToken>
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `tenantId` | テナント ID でフィルター (super_admin のみ) |
-| `role` | ロールでフィルター |
-| `limit` | 取得する結果の数 |
+| `tenantId` | テナント ID でフィルタリング (super_admin のみ) |
+| `role` | ロールでフィルタリング |
+| `limit` | 取得する結果の件数 |
 | `offset` | オフセット |
 
 #### ユーザー作成
@@ -585,7 +580,7 @@ DELETE /admin/users/{userId}
 Authorization: Bearer <accessToken>
 ```
 
-#### ユーザーの有効化/無効化
+#### ユーザーのアクティブ化/非アクティブ化
 
 ```http
 POST /admin/users/{userId}/activate
@@ -593,9 +588,9 @@ POST /admin/users/{userId}/deactivate
 Authorization: Bearer <accessToken>
 ```
 
-#### ログインのロック解除
+#### ログインロック解除
 
-ブルートフォース保護によってロックされたアカウントのロックを解除します。
+ブルートフォース保護によってロックされたアカウントをロック解除します。
 
 ```http
 POST /admin/users/{userId}/unlock
@@ -643,7 +638,7 @@ Content-Type: application/json
 }
 ```
 
-> **注意**: テナント名には小文字の英数字とアンダースコアのみを含める必要があります (`^[a-z0-9_]+$`)。
+> **注記**: テナント名には小文字の英数字とアンダースコア (`^[a-z0-9_]+$`) のみを含める必要があります。
 
 #### テナント取得
 
@@ -667,9 +662,9 @@ DELETE /admin/tenants/{tenantId}
 Authorization: Bearer <accessToken>
 ```
 
-**カスケード削除**: テナントが削除されると、関連するすべてのデータ (エンティティ、サブスクリプション、登録、ルール、ポリシー、ユーザー、メンバーシップ、および全 16 コレクション) が自動的にカスケード削除されます。削除が開始される前に、テナントは自動的に無効化され、新しい API リクエストがブロックされます。
+**カスケード削除**: テナントが削除されると、関連するすべてのデータ (エンティティ、サブスクリプション、レジストレーション、ルール、ポリシー、ユーザ、メンバーシップ、およびすべての 16 個のコレクション) が自動的にカスケード削除されます。削除が開始される前に、テナントは自動的に無効化され、新しい API リクエストがブロックされます。
 
-#### テナントの有効化/無効化
+#### テナントの有効化 / 無効化
 
 ```http
 POST /admin/tenants/{tenantId}/activate
@@ -679,11 +674,11 @@ Authorization: Bearer <accessToken>
 
 ### カスタムデータモデル管理
 
-> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
+> **注記**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
 
 ### IP 制限
 
-`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます。
+`ADMIN_ALLOWED_IPS` 環境変数を設定することで、管理 API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:
 
 ```bash
 # Single IP
@@ -696,11 +691,11 @@ ADMIN_ALLOWED_IPS=192.168.1.100,10.0.0.50
 ADMIN_ALLOWED_IPS=192.168.1.0/24,10.0.0.0/8
 ```
 
-許可されていない IP からのアクセスは `403 Forbidden` エラーとなります。
+許可されていない IP からのアクセスは `403 Forbidden` エラーになります。
 
-#### テナント毎の IP 制限
+#### テナントごとの IP 制限
 
-テナント毎に個別の IP 制限を設定できます。テナントレベルの設定が存在する場合は、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
+テナントごとに個別の IP 制限を設定できます。テナントレベルの設定が存在する場合、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
 
 ```http
 GET /admin/tenants/{tenantId}/ip-restrictions
@@ -709,13 +704,13 @@ DELETE /admin/tenants/{tenantId}/ip-restrictions
 Authorization: Bearer <accessToken>
 ```
 
-スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかを指定できます。詳細は AUTH.md を参照してください。
+スコープは `admin` (管理 API のみ) または `all` (すべての API) のいずれかを指定できます。詳細については AUTH.md を参照してください。
 
-### ルールエンジン管理（tenant_admin）
+### ルールエンジン管理 (tenant_admin)
 
 エンティティの変更を自動的に処理するルールを管理します。`tenant_admin` ロールが必要です。`AUTH_ENABLED=true` の場合、`super_admin` は `/rules*` エンドポイントにアクセスできません。
 
-- **REACTIVCORE_RULES.md** - ユーザーガイド(使用例、管理 API など)
+- **REACTIVCORE_RULES.md** - ユーザーガイド (使用例、Admin API など)
 
 #### ルール一覧の取得
 
@@ -728,10 +723,10 @@ Authorization: Bearer <accessToken>
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `limit` | 結果の件数(デフォルト: 20、最大: 100) |
-| `offset` | オフセット(デフォルト: 0) |
-| `servicePath` | ServicePathでフィルタ |
-| `isActive` | アクティブ/非アクティブでフィルタ(`true` / `false`) |
+| `limit` | 結果の件数 (デフォルト: 20、最大: 100) |
+| `offset` | オフセット (デフォルト: 0) |
+| `servicePath` | ServicePathでフィルタリング |
+| `isActive` | アクティブ/非アクティブでフィルタリング (`true` / `false`) |
 
 #### ルールの作成
 
@@ -804,13 +799,13 @@ Authorization: Bearer <accessToken>
 
 #### クロスプロトコルアクション
 
-ルールアクション(`createEntity`、`updateAttribute`、`deleteAttribute`)は、プロトコル境界を越えて動作するためのオプションフィールド `protocol` をサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
+ルールアクション (`createEntity`、`updateAttribute`、`deleteAttribute`) は、プロトコル境界を越えて動作するためのオプションの `protocol` フィールドをサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
 
 | フィールド | アクション | 型 | 説明 |
 |---|---|---|---|
-| `protocol` | createEntity、updateAttribute、deleteAttribute | `'ngsiv2' \| 'ngsild'` | ターゲットプロトコル(デフォルト: トリガーから継承) |
+| `protocol` | createEntity, updateAttribute, deleteAttribute | `'ngsiv2' \| 'ngsild'` | ターゲットプロトコル (デフォルト: トリガーから継承) |
 | `servicePath` | createEntity | `string` | NGSIv2 のターゲット servicePath (テンプレート変数をサポート) |
-| `scope` | createEntity | `string[]` | NGSI-LD のターゲットスコープ(テンプレート変数をサポート) |
+| `scope` | createEntity | `string[]` | NGSI-LD のターゲット scope (テンプレート変数をサポート) |
 
 プロトコルを越える場合、servicePath ↔ scope は自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` は、トリガーエンティティのコンテキストを参照します。
 
@@ -832,7 +827,7 @@ OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (
 - `DELETE /me/oauth-clients/{clientId}` - 自分のクライアント削除 (セルフサービス)
 - `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自分のシークレット再生成 (セルフサービス)
 
-**有効化:** `AUTH_ENABLED=true` の場合、OAuth 2.0 は常に有効になります。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
+**有効化:** OAuth 2.0 は `AUTH_ENABLED=true` の場合、常に有効になります。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
 
 **利用可能なスコープ:**
 
@@ -853,12 +848,12 @@ OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (
 | `admin:oauth-clients` | OAuth クライアント管理 API | ❌ | ✅ | ✅ |
 | `admin:metrics` | メトリクス API | ❌ | ✅ | ✅ |
 | `admin:tenants` | テナント管理 API | ❌ | ❌ | ✅ |
-| `permanent` | トークンが期限切れにならない | — | — | — |
+| `permanent` | トークンの有効期限なし | — | — | — |
 | `jwt` | JWT 形式のトークン | — | — | — |
 
-> ロール列は、セルフサービス (`/me/oauth-clients`) 経由でリクエスト可能なスコープを示します。管理者が作成したクライアント (`/admin/oauth-clients`) には、これらの制限は適用されません。
+> ロール列は、セルフサービス (`/me/oauth-clients`) で要求できるスコープを示しています。管理者が作成したクライアント (`/admin/oauth-clients`) はこれらの制限を受けません。
 
-**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ (JSON 文字列) を指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細は AUTH.md を参照してください。
+**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ (JSON 文字列) を指定すると、エンティティレベルのアクセス制御が適用されたトークンが発行されます。詳細は AUTH.md を参照してください。
 
 **詳細:** AUTH.md の OAuth 2.0 セクションを参照してください。
 
@@ -866,7 +861,7 @@ OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (
 
 ## API キートークン交換 (ブラウザ SDK)
 
-ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短時間有効なセッション JWT に交換できます。
+ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短期間有効なセッション JWT に交換できます。
 
 **主要なエンドポイント:**
 - `POST /auth/nonce` - Nonce + PoW チャレンジのリクエスト (API キー + Origin ヘッダーが必要)
@@ -874,15 +869,15 @@ OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (
 
 **JavaScript SDK:** `npm install @geolonia/geonicdb-sdk` — トークン交換、DPoP、WebSocket、再接続を自動的に処理します。
 
-**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60 秒 TTL) → Proof of Work → 短時間有効な JWT (1 時間)
+**セキュリティ層:** Origin 検証 → HMAC Nonce (60秒 TTL) → Proof of Work → 短期間有効な JWT (1時間)
 
-**詳細:** AUTH.md の API Key Token Exchange セクションおよび SDK ドキュメントで完全な API リファレンスを参照してください。
+**詳細:** AUTH.md の API キートークン交換セクションおよび完全な API リファレンスについては SDK ドキュメントを参照してください。
 
 ---
 
 ## メタエンドポイント
 
-メタエンドポイントは認証を必要とせず、システムステータスと API 情報を提供します。
+メタエンドポイントは認証不要で、システムステータスと API 情報を提供します。
 
 ### API ドキュメント (llms.txt 形式)
 
@@ -899,7 +894,7 @@ AI フレンドリーな [llms.txt](https://llmstxt.org/) 形式で API ドキ�
 GET /api.json
 ```
 
-JSON 形式で API エンドポイントの一覧を返します。
+API エンドポイントのリストを JSON 形式で返します。
 
 **レスポンス例**
 
@@ -918,6 +913,7 @@ JSON 形式で API エンドポイントの一覧を返します。
   }
 }
 ```
+
 ### OpenAPI 仕様
 
 ```http
@@ -979,9 +975,9 @@ NGSI-LD API サポート情報を返します。
 
 ### ヘルスチェック
 
-すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返した場合にセカンダリへ切り替えます。
+すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返した場合にセカンダリに切り替えます。
 
-#### 基本ヘルス
+#### 基本ヘルスチェック
 
 ```http
 GET /health
@@ -1000,13 +996,13 @@ GET /health
 }
 ```
 
-#### Liveness プローブ
+#### Liveness Probe
 
 ```http
 GET /health/live
 ```
 
-Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中かどうかをチェックします。
+Kubernetes / Route 53 の Liveness Probe 用。サービスが実行中かどうかをチェックします。
 
 **レスポンス例**
 
@@ -1019,23 +1015,26 @@ Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中か
 }
 ```
 
-#### Readiness プローブ
+#### Readiness Probe
 
 ```http
 GET /health/ready
 ```
 
-Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチェックし、オプションで DynamoDB と EventBridge の詳細ヘルスチェックを実行します。
+Kubernetes / Route 53 の Readiness Probe 用。MongoDB 接続性をチェックし、オプションで DynamoDB と EventBridge のディープヘルスチェックを実行します。
 
-**環境変数による詳細ヘルスチェックの有効化**
+**環境変数によるディープヘルスチェックの有効化**
 
 | 環境変数 | 説明 |
 |---------|------|
-| `HEALTH_CHECK_DYNAMODB=true` | DynamoDB DescribeTable 接続チェックを追加 |
-| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続チェックを追加 |
+| `HEALTH_CHECK_DYNAMODB=true` | DynamoDB DescribeTable 接続性チェックを追加 |
+| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続性チェックを追加 |
 
 **レスポンス**
-- 成功: `200 OK` と `status: "healthy"`- 失敗: `503 Service Unavailable` と `status: "unhealthy"`**レスポンス例(詳細ヘルスチェック有効時)**
+- 成功: `200 OK` と `status: "healthy"` を返す
+- 失敗: `503 Service Unavailable` と `status: "unhealthy"` を返す
+
+**レスポンス例 (ディープヘルスチェック有効時)**
 
 ```json
 {
@@ -1051,9 +1050,10 @@ Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチ
   "totalLatencyMs": 35
 }
 ```
+
 ### 統計とメトリクス
 
-FIWARE Orion 互換の統計エンドポイントと、Prometheus 形式のメトリクスエンドポイントを提供します。
+FIWARE Orion互換の統計エンドポイントとPrometheus形式のメトリクスエンドポイントを提供します。
 
 #### 統計
 
@@ -1062,7 +1062,7 @@ GET /statistics
 Authorization: Bearer <token>
 ```
 
-サーバーの運用統計を FIWARE Orion 互換形式で返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+FIWARE Orion互換形式でサーバーの運用統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1102,7 +1102,7 @@ GET /cache/statistics
 Authorization: Bearer <token>
 ```
 
-サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1132,7 +1132,7 @@ GET /metrics
 Authorization: Bearer <token>
 ```
 
-Prometheus エクスポジション形式でメトリクスを返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
+Prometheus エクスポジション形式でメトリクスを返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
 
 **レスポンス**
 - Content-Type: `text/plain; version=0.0.4`**レスポンス例**
@@ -1176,7 +1176,7 @@ geonicdb_notifications_failed_total 10
 GET /tools.json
 ```
 
-Claude Tool Use / OpenAI Function Calling と互換性のある JSON 形式でツール定義を返します。これは AI エージェントが API をツールとして使用するためのスキーマです。
+Claude Tool Use / OpenAI Function Calling に互換性のある JSON 形式でツール定義を返します。これは AI エージェントが API をツールとして使用するためのスキーマです。
 
 **提供されるツール**: `list_entities`、`get_entity`、`search_by_location`、`search_by_attribute`、`create_entity`、`update_entity`、`delete_entity`、`list_entity_types`、`get_temporal_data`、`subscribe`##### AI プラグインマニフェスト
 
@@ -1184,7 +1184,7 @@ Claude Tool Use / OpenAI Function Calling と互換性のある JSON 形式で�
 GET /.well-known/ai-plugin.json
 ```
 
-AI プラグインマニフェストを返します。API の概要、ツール定義 URL、OpenAPI 仕様 URL などが含まれます。
+AI プラグインマニフェストを返します。API の概要、ツール定義 URL、OpenAPI 仕様 URL などを含みます。
 
 ##### MCP (Model Context Protocol)
 
@@ -1194,7 +1194,7 @@ Content-Type: application/json
 Accept: application/json, text/event-stream
 ```
 
-MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、MCP tools/call 経由で 5 つのツールすべてが利用可能です。
+MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、全 5 つのツールが MCP tools/call 経由で利用可能です。
 
 `AUTH_ENABLED=true` の場合、Bearer トークン(JWT)による認証が必要です。テナントアクセス制御も適用されます。
 
@@ -1225,7 +1225,7 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
 GET /.well-known/agent-card.json
 ```
 
-A2A Agent Card。このエージェントの機能、スキル、認証について説明します。認証は不要です。
+A2A エージェントカード。このエージェントの機能、スキル、認証方法を記述します。認証は不要です。
 
 ```http
 POST /a2a
@@ -1235,23 +1235,23 @@ Fiware-Service: <tenant>  (optional, falls back to default tenant)
 ```
 
 エージェント間通信のための A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合、認証が必要です。サポートされるメソッド:
-- `message/send` — メッセージを送信し、同期レスポンスを受信
-- `tasks/get` — タスクの現在の状態を取得
-- `tasks/list` — フィルタリングとページネーション付きでタスクを一覧表示
-- `tasks/cancel` — タスクのキャンセルをリクエスト
+- `message/send` — メッセージを送信し、同期レスポンスを受け取る
+- `tasks/get` — タスクの現在の状態を取得する
+- `tasks/list` — フィルタリングとページネーションでタスクをリストする
+- `tasks/cancel` — タスクのキャンセルをリクエストする
 
 5 つのスキルが利用可能: entities、batch、temporal、config、admin (MCP ツールと同じ)。
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+詳細については、[AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
 
-#### テナント別メトリクス (管理 API)
+#### テナントごとのメトリクス (Admin API)
 
 ```http
 GET /admin/metrics
 Authorization: Bearer <accessToken>
 ```
 
-テナントとServicePath別のメトリクスを返します。`super_admin` ロールが必要です。
+テナントとServicePathごとのメトリクスを返します。`super_admin` ロールが必要です。
 
 **レスポンス例**
 
@@ -1275,6 +1275,7 @@ Authorization: Bearer <accessToken>
   }
 }
 ```
+
 ---
 
 ## NGSIv2 API
@@ -1291,7 +1292,7 @@ NGSI-LD API の詳細については、[API_NGSILD.md](./ngsild.md) を参照し
 
 ## クエリ言語
 
-属性値によるフィルタリングは `q` パラメータを使用して可能です。
+属性値によるフィルタリングは、`q` パラメータを使用して可能です。
 
 ### 基本構文
 
@@ -1308,13 +1309,13 @@ NGSI-LD API の詳細については、[API_NGSILD.md](./ngsild.md) を参照し
 
 ### 複数条件
 
-AND 条件はセミコロン (`;`) で結合します:
+セミコロン (`;`) で AND 条件を結合します:
 
 ```text
 q=temperature>20;pressure<800
 ```
 
-OR 条件はパイプ (`|`) で結合します (`;` は `|` より優先順位が高くなります):
+パイプ (`|`) で OR 条件を結合します (`;` は `|` より優先されます):
 
 ```text
 q=temperature==23|temperature==35
@@ -1323,7 +1324,7 @@ q=temperature>25;humidity<40|status==active
 
 ### 範囲クエリ
 
-`==` 演算子と `..` を組み合わせて範囲フィルタリングを行います (境界値を含む):
+`==` 演算子を `..` と組み合わせて範囲フィルタリングを行います (境界を含む):
 
 ```text
 q=temperature==20..30    # 20 or above and 30 or below
@@ -1338,25 +1339,25 @@ q=name==Room1     # Exact match
 
 ---
 
-## ジオクエリ
+## Geo-Queries
 
-位置情報を持つエンティティは空間的にクエリできます。
+位置情報を持つエンティティは、空間的にクエリできます。
 
 ### パラメータ
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `georel` | 空間関係 (coveredBy、within、intersects、disjoint、equals) |
-| `geometry` | ジオメトリタイプ (point、polygon、line、box) |
-| `coords` | 座標 (NGSIv2: 緯度,経度 形式; NGSI-LD: 経度,緯度 形式; 複数のポイントはセミコロンで区切る) |
+| `georel` | 空間関係 (coveredBy, within, intersects, disjoint, equals) |
+| `geometry` | ジオメトリタイプ (point, polygon, line, box) |
+| `coords` | 座標 (NGSIv2: 緯度,経度 形式; NGSI-LD: 経度,緯度 形式; 複数の点はセミコロンで区切る) |
 
-> **注意**: `georel`、`geometry`、`coords` (または NGSI-LD では `coordinates`) はすべて一緒に指定する必要があります。一部のみを指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 4.10)。
+> **注意**: `georel`、`geometry`、および `coords` (NGSI-LD では `coordinates`) は、すべて一緒に指定する必要があります。一部のみを指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 4.10)。
 
 ### 座標形式
 
-NGSIv2 では、座標は **緯度,経度** の順序で指定します (NGSIv2 仕様に準拠)。NGSI-LD では、座標は **経度,緯度** の順序です (GeoJSON 標準に準拠)。
+NGSIv2 では、座標は **緯度,経度** の順序で指定されます (NGSIv2 仕様に準拠)。NGSI-LD では、座標は **経度,緯度** の順序です (GeoJSON 標準に準拠)。
 
-> **重要**: NGSIv2 における緯度,経度の順序は GeoJSON 標準 (経度,緯度) からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用しています。API を使用する際は、使用している API バージョンに合わせて正しい順序で座標を指定してください。
+> **重要**: NGSIv2 における緯度,経度の順序は、GeoJSON 標準 (経度,緯度) からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用します。API を使用する際は、使用している API バージョンに対して正しい順序で座標を指定してください。
 
 ```text
 # NGSIv2 (latitude,longitude)
@@ -1369,7 +1370,7 @@ coordinates=[139.7671,35.6812]       # Single point
 
 ### エリア検索 (coveredBy / within)
 
-ポリゴン内のエンティティを検索します:
+ポリゴン内のエンティティを検索:
 
 ```http
 GET /v2/entities?georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138
@@ -1377,7 +1378,7 @@ GET /v2/entities?georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;3
 
 ### 交差検索 (intersects)
 
-ジオメトリと交差するエンティティを検索します:
+ジオメトリと交差するエンティティを検索:
 
 ```http
 GET /v2/entities?georel=intersects&geometry=box&coords=35.67,139.76;35.69,139.78
@@ -1385,22 +1386,23 @@ GET /v2/entities?georel=intersects&geometry=box&coords=35.67,139.76;35.69,139.78
 
 ### 非交差検索 (disjoint)
 
-ジオメトリと交差しないエンティティを検索します:
+ジオメトリと交差しないエンティティを検索:
 
 ```http
 GET /v2/entities?georel=disjoint&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138
 ```
+
 ### 近接検索 (near)
 
-指定された座標から一定の距離内にあるエンティティを検索します。
+指定した座標から一定の距離内にあるエンティティを検索します。
 
 #### パラメータ
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `maxDistance` | 最大距離(メートル) |
-| `minDistance` | 最小距離(メートル) |
-| `orderByDistance` | `true` に設定すると、結果を距離順にソートし、各エンティティに距離情報(`@distance`)を付加します |
+| `maxDistance` | 最大距離 (メートル) |
+| `minDistance` | 最小距離 (メートル) |
+| `orderByDistance` | `true` に設定すると、結果を距離でソートし、各エンティティに距離情報 (`@distance`) を付加します |
 
 #### 基本的な使い方 (NGSIv2)
 
@@ -1430,7 +1432,7 @@ GET /ngsi-ld/v1/entities?georel=near;minDistance==100000&geometry=Point&coordina
 GET /ngsi-ld/v1/entities?georel=near;minDistance==500;maxDistance==10000&geometry=Point&coordinates=[139.7671,35.6812]
 ```
 
-#### georel の構文比較
+#### georel 構文の比較
 
 georel パラメータの修飾子構文は NGSIv2 と NGSI-LD で異なります:
 
@@ -1440,14 +1442,14 @@ georel パラメータの修飾子構文は NGSIv2 と NGSI-LD で異なりま�
 | 最小距離 | `georel=near;minDistance:1000` | `georel=near;minDistance==1000` | `:` と `==` の違い |
 | 距離範囲 | `georel=near;minDistance:500;maxDistance:10000` | `georel=near;minDistance==500;maxDistance==10000` | `:` と `==` の違い |
 
-> **構文が異なる理由**: NGSIv2 では `:` を使用してパラメータ値を指定しますが、NGSI-LD では ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用する API バージョンに対応した構文を使用してください。
+> **構文の違いの理由**: NGSIv2 はパラメータ値の指定に `:` を使用しますが、NGSI-LD は ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用している API バージョンに対応した構文を使用してください。
 
-#### 距離のソートと距離情報
+#### 距離ソートと距離情報
 
 `orderByDistance=true` パラメータを指定すると、以下の機能が有効になります:
 
-1. **距離のソート**: 結果が指定された座標からの距離の昇順でソートされます
-2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定された座標からの距離(メートル単位)が返されます
+1. **距離ソート**: 結果は指定した座標からの距離の昇順でソートされます
+2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定した座標からの距離 (メートル単位) が返されます
 
 この機能は MongoDB の `$geoNear` 集約パイプラインを使用して実装されています。
 
@@ -1494,7 +1496,7 @@ GET /ngsi-ld/v1/entities?georel=near;maxDistance==5000&geometry=Point&coordinate
 
 ##### 降順ソート
 
-`orderDirection=desc` と組み合わせて使用すると、距離の降順(遠い順)でソートされます:
+`orderDirection=desc` を併用すると、距離の降順 (最も遠いものから) でソートできます:
 
 ```http
 GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.7671&orderByDistance=true&orderDirection=desc
@@ -1502,40 +1504,40 @@ GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.
 
 #### 制限事項
 
-- **Point ジオメトリのみ**: `geometry=point` (NGSIv2) または `geometry=Point` (NGSI-LD) のみがサポートされています
+- **ポイントジオメトリのみ**: `geometry=point` (NGSIv2) または `geometry=Point` (NGSI-LD) のみがサポートされています
 
 ### エラー処理
 
 geo-query パラメータが無効な場合、`400 Bad Request` が返されます。
 
-| エラー条件 | エラーメッセージ例 |
+| エラー条件 | エラーメッセージの例 |
 |----------------|-----------------------|
-| 無効な `georel` 値 | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
-| 無効な `geometry` 値 | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box` |
-| 不十分な座標 (Point) | `Point geometry requires at least 2 coordinates, but got 1` |
-| 不十分な座標 (Polygon) | `Polygon geometry requires at least 4 coordinate pairs (8 values), but got 6 values` |
-| 不十分な座標 (LineString) | `LineString geometry requires at least 2 coordinate pairs (4 values), but got 2 values` |
-| 不十分な座標 (Box) | `Box geometry requires 2 coordinate pairs (4 values), but got 2 values` |
+| 無効な `georel` の値 | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
+| 無効な `geometry` の値 | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box` |
+| 座標の不足 (Point) | `Point geometry requires at least 2 coordinates, but got 1` |
+| 座標の不足 (Polygon) | `Polygon geometry requires at least 4 coordinate pairs (8 values), but got 6 values` |
+| 座標の不足 (LineString) | `LineString geometry requires at least 2 coordinate pairs (4 values), but got 2 values` |
+| 座標の不足 (Box) | `Box geometry requires 2 coordinate pairs (4 values), but got 2 values` |
 | 無効な座標値 | `Invalid coordinate value: xxx` |
 | 緯度が範囲外 | `Latitude out of range: 91. Must be between -90 and 90.` |
 | 経度が範囲外 | `Longitude out of range: 181. Must be between -180 and 180.` |
 | 距離なしの `near` | `The 'near' georel requires maxDistance and/or minDistance modifier` |
-| Point 以外のジオメトリでの `near` | `The 'near' georel requires Point geometry, but 'polygon' was provided` |
+| Point 以外のジオメトリを持つ `near` | `The 'near' georel requires Point geometry, but 'polygon' was provided` |
 
 ---
 
 ## 空間 ID 検索
 
-日本のデジタル庁 / IPA が定めた 3 次元空間識別規格 (ZFXY 形式) に基づく空間検索をサポートします。
+日本のデジタル庁 / IPA が定める 3 次元空間識別標準 (ZFXY 形式) に基づく空間検索をサポートしています。
 
 ### ZFXY 形式
 
 | 要素 | 説明 | 範囲 |
-|---------|-------------|-------|
+|------|------|------|
 | Z | ズームレベル | 0-28 |
 | F | 垂直方向 (高度レベル) | 整数 |
-| X | 東西方向 (経度タイル) | 0 to 2^z-1 |
-| Y | 南北方向 (緯度タイル) | 0 to 2^z-1 |
+| X | 東西方向 (経度タイル) | 0 から 2^z-1 |
+| Y | 南北方向 (緯度タイル) | 0 から 2^z-1 |
 
 形式: `{z}/{f}/{x}/{y}` (例: `20/0/929593/410773`)
 
@@ -1553,7 +1555,7 @@ GET /ngsi-ld/v1/entities?spatialId=20/0/929593/410773
 
 ### 階層展開 (spatialIdDepth)
 
-`spatialIdDepth` パラメータを指定すると、指定した空間 ID を中心とした周囲のタイルに検索を拡張します。
+`spatialIdDepth` パラメータを指定すると、指定された空間 ID を中心とした周辺タイルに検索を拡張します。
 
 ```http
 # depth=1: Expands to a 3x3 tile grid (9 tiles)
@@ -1564,8 +1566,8 @@ GET /v2/entities?spatialId=20/0/929593/410773&spatialIdDepth=2
 ```
 
 | spatialIdDepth | 展開範囲 | タイル数 |
-|----------------|-----------------|------------|
-| 0 (デフォルト) | 指定したタイルのみ | 1 |
+|----------------|----------|----------|
+| 0 (デフォルト) | 指定されたタイルのみ | 1 |
 | 1 | 3x3 | 9 |
 | 2 | 5x5 | 25 |
 | 3 | 7x7 | 49 |
@@ -1587,7 +1589,7 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&spatialIdDe
 
 ## GeoJSON 出力
 
-RFC 7946 準拠の GeoJSON FeatureCollection 形式でエンティティを出力できます。
+エンティティは RFC 7946 準拠の GeoJSON FeatureCollection 形式で出力できます。
 
 ### NGSIv2 での使用方法
 
@@ -1653,7 +1655,7 @@ Accept: application/geo+json
 
 ### NGSI-LD における @context
 
-NGSI-LD で GeoJSON を出力する場合、`@context` が FeatureCollection レベルに含まれます:
+NGSI-LD で GeoJSON を出力する際、`@context` は FeatureCollection レベルに含まれます:
 
 ```json
 {
@@ -1700,9 +1702,9 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&options=geo
 
 ---
 
-## ベクタータイル
+## Vector Tiles
 
-エンティティは XYZ タイル方式に基づいて GeoJSON ベクタータイルとして出力できます。大量のエンティティを地図上に効率的に表示するために最適化されています。
+エンティティは XYZ タイルスキームに基づいた GeoJSON ベクタータイルとして出力できます。大量のエンティティを地図上に効率的に表示するために最適化されています。
 
 ### エンドポイント
 
@@ -1751,8 +1753,8 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson" \
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `type` | エンティティタイプでフィルタリング |
-| `attrs` | 出力する属性をカンマ区切りリストで指定 |
+| `type` | エンティティタイプでフィルタ |
+| `attrs` | カンマ区切りリストで出力する属性を指定 |
 
 **使用例**
 
@@ -1797,7 +1799,7 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 ### クラスタリング
 
-タイル内のエンティティ数が閾値(デフォルト: 1000)を超えた場合、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスター Feature が返されます。
+タイル内のエンティティ数が閾値 (デフォルト: 1000) を超えると、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスター Feature が返されます。
 
 **クラスタリング時のレスポンス例**
 
@@ -1836,20 +1838,20 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 | ヘッダー | 説明 |
 |--------|-------------|
-| `X-Tile-Mode` | `individual` (個別のエンティティ) または `clustered` (クラスタリング) |
+| `X-Tile-Mode` | `individual` (個別エンティティ) または `clustered` (クラスタリング) |
 | `X-Total-Count` | タイル内のエンティティの総数 |
 
 ### 設定
 
 | 環境変数 | デフォルト | 説明 |
 |----------------------|---------|-------------|
-| `MAX_ENTITIES_PER_REQUEST` | `1000` | クラスタリングの閾値(この値以上でクラスタリングが発生) |
+| `MAX_ENTITIES_PER_REQUEST` | `1000` | クラスタリングの閾値 (この値以上でクラスタリングが発生) |
 
-### 参考文献
+### 参考資料
 
 - [TileJSON 3.0 仕様](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
 - [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
-- [XYZ タイル方式](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+- [XYZ タイルスキーム](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
 
 ---
 
@@ -1861,9 +1863,9 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 | CRS | EPSG | 説明 | 使用例 |
 |-----|------|-------------|----------|
-| WGS84 | EPSG:4326 | 世界測地系 1984 (デフォルト) | GPS、国際標準 |
-| JGD2011 | EPSG:6668 | 日本測地系 2011 | 日本国内の高精度測量 |
-| Web Mercator | EPSG:3857 | Web メルカトル図法 | Google Maps、OpenStreetMap など |
+| WGS84 | EPSG:4326 | World Geodetic System 1984 (デフォルト) | GPS、国際標準 |
+| JGD2011 | EPSG:6668 | Japanese Geodetic Datum 2011 | 日本における高精度測量 |
+| Web Mercator | EPSG:3857 | Web Mercator 投影法 | Google Maps、OpenStreetMap など |
 
 ### CRS の指定方法
 
@@ -1893,7 +1895,7 @@ GET /ngsi-ld/v1/entities?type=Store&crs=urn:ogc:def:crs:EPSG::6668
 
 ### レスポンスヘッダー
 
-CRS を指定したリクエストに対するレスポンスには、`Content-Crs` ヘッダーが含まれます:
+CRS を指定したリクエストへのレスポンスには `Content-Crs` ヘッダーが含まれます:
 
 ```text
 Content-Crs: EPSG:6668
@@ -1907,9 +1909,9 @@ Content-Crs: urn:ogc:def:crs:EPSG::6668
 
 ### 座標の入出力
 
-#### クエリ時(入力)
+#### クエリ時 (入力)
 
-ジオクエリの座標は、指定された CRS で解釈されます:
+Geo-query の座標は指定された CRS で解釈されます:
 
 ```http
 # Proximity search with JGD2011 coordinates
@@ -1938,7 +1940,7 @@ curl -X POST "http://localhost:3000/v2/entities?crs=EPSG:3857" \
   }'
 ```
 
-#### 取得時(出力)
+#### 取得時 (出力)
 
 取得時に `crs` パラメータを指定すると、指定された CRS に変換された座標が返されます:
 
@@ -1953,7 +1955,7 @@ curl "http://localhost:3000/v2/entities/Store1?crs=EPSG:6668" \
 | 変換 | 精度 |
 |------------|----------|
 | WGS84 ↔ JGD2011 | 数 cm から数十 cm |
-| WGS84 ↔ Web メルカトル | 計算精度に依存(緯度 ±85 度以内) |
+| WGS84 ↔ Web Mercator | 計算精度に依存 (緯度 ±85 度以内) |
 
 ### 使用例
 
@@ -2014,11 +2016,11 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Landmark&crs=EPSG:6668" \
 |-------|-----------|-------------|
 | Unsupported CRS | 400 | 指定された CRS コードはサポートされていません |
 | Invalid CRS format | 400 | 無効な CRS 形式が指定されました |
-| Coordinates out of range | 400 | Web メルカトルで緯度 ±85 度を超える座標 |
+| Coordinates out of range | 400 | Web Mercator で緯度 ±85 度を超える座標 |
 
 ### 制限事項
 
-- Web メルカトル (EPSG:3857) は緯度 ±85 度を超える範囲をサポートしていません
+- Web Mercator (EPSG:3857) は緯度 ±85 度を超える領域をサポートしていません
 - すべての座標は内部的に WGS84 で保存されます
 - 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリを使用しています
 
@@ -2032,7 +2034,7 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Landmark&crs=EPSG:6668" \
 
 ## データカタログ API
 
-DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest 互換のエンドポイントを提供します。
+エンティティタイプ情報を DCAT-AP 形式で出力し、CKAN ハーベスト互換エンドポイントを提供します。
 
 ### DCAT-AP カタログ
 
@@ -2040,7 +2042,7 @@ DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest �
 GET /catalog
 ```
 
-カタログ全体を DCAT-AP 形式で JSON-LD として出力します。
+カタログ全体を DCAT-AP 形式の JSON-LD として出力します。
 
 **レスポンス例**
 
@@ -2068,7 +2070,7 @@ GET /catalog
 GET /catalog/datasets
 ```
 
-DCAT 形式でデータセットの一覧を出力します。
+データセットの一覧を DCAT 形式で出力します。
 
 **クエリパラメータ**
 
@@ -2099,17 +2101,17 @@ GET /catalog/datasets/{datasetId}/sample
 |-----------|-------------|---------|
 | `limit` | 取得するサンプル数 | 5 |
 
-### CKAN 互換 API
+### CKAN互換API
 
 CKAN データカタログハーベスターと互換性のある API を提供します。
 
-#### パッケージ一覧
+#### パッケージリスト
 
 ```http
 GET /catalog/ckan/package_list
 ```
 
-すべてのパッケージ(データセット)の ID 一覧を取得します。
+すべてのパッケージ (データセット) の ID リストを取得します。
 
 **レスポンス例**
 
@@ -2149,28 +2151,28 @@ GET /catalog/ckan/package_show?id={package_id}
 }
 ```
 
-#### リソース付きパッケージ一覧
+#### リソース情報を含むパッケージリスト
 
 ```http
 GET /catalog/ckan/current_package_list_with_resources
 ```
 
-リソース情報を含むパッケージの一覧をページネーション形式で取得します。
+リソース情報を含むパッケージのページネーションされたリストを取得します。
 
 **クエリパラメータ**
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `limit` | 取得するパッケージ数 |
-| `offset` | スキップするパッケージ数 |
+| `limit` | 取得するパッケージの数 |
+| `offset` | スキップするパッケージの数 |
 
-詳細は外部連携ドキュメントを参照してください。
+詳細については、外部統合ドキュメントを参照してください。
 
 ---
 
-## CADDE 連携
+## CADDE 統合
 
-CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの連携機能を提供します。
+CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの統合機能を提供します。
 
 ### 概要
 
@@ -2192,52 +2194,52 @@ curl -X PUT "https://api.example.com/admin/cadde" \
   }'
 ```
 
-| 設定項目 | デフォルト値 | 説明 |
+| 設定項目 | デフォルト | 説明 |
 |--------------------|---------|-------------|
 | `enabled` | `false` | CADDE 機能を有効化 |
 | `authEnabled` | `false` | Bearer 認証を有効化 |
-| `defaultProvider` | - | デフォルトのプロバイダ ID |
-| `jwtIssuer` | - | JWT 検証における期待される発行者 (`iss`) クレーム |
-| `jwtAudience` | - | JWT 検証における期待される対象者 (`aud`) クレーム |
-| `jwksUrl` | - | 署名検証用の JWKS エンドポイント URL (HTTPS が必要) |
+| `defaultProvider` | - | デフォルトのプロバイダー ID |
+| `jwtIssuer` | - | JWT 検証のための期待される発行者 (`iss`) クレーム |
+| `jwtAudience` | - | JWT 検証のための期待されるオーディエンス (`aud`) クレーム |
+| `jwksUrl` | - | 署名検証のための JWKS エンドポイント URL (HTTPS が必要) |
 
-設定は MongoDB に保存されるため、デプロイ後に API 経由で動的に変更できます。
+設定は MongoDB に保存され、デプロイ後に API 経由で動的に変更できます。
 
-### リクエストヘッダ
+### リクエストヘッダー
 
-CADDE コネクタからのリクエストには以下のヘッダが含まれます:
+CADDE コネクタからのリクエストには、以下のヘッダーが含まれます:
 
-| ヘッダ | 必須 | 説明 |
+| ヘッダー | 必須 | 説明 |
 |--------|----------|-------------|
-| `x-cadde-resource-url` | - | アクセスされるリソースの URL |
+| `x-cadde-resource-url` | - | アクセス対象のリソースの URL |
 | `x-cadde-resource-api-type` | - | API タイプ (例: `api/ngsi`) |
-| `x-cadde-provider` | - | データプロバイダ ID |
-| `x-cadde-options` | - | 追加オプション (テナントヘッダなど) |
+| `x-cadde-provider` | - | データプロバイダー ID |
+| `x-cadde-options` | - | 追加オプション (テナントヘッダーなど) |
 
-### x-cadde-options のフォーマット
+### x-cadde-options 形式
 
-テナント情報やその他の詳細は `x-cadde-options` ヘッダで指定できます:
+テナント情報とその他の詳細は、`x-cadde-options` ヘッダーで指定できます。
 
 ```text
 x-cadde-options: Fiware-Service:smartcity, Fiware-ServicePath:/sensors
 ```
 
-このヘッダで指定された値は、通常の HTTP ヘッダよりも優先されます。
+このヘッダーで指定された値は、通常の HTTP ヘッダーよりも優先されます。
 
-### プロヴェナンスレスポンスヘッダ
+### プロバナンス応答ヘッダー
 
-CADDE リクエストへのレスポンスには以下のプロヴェナンスヘッダが含まれます:
+CADDE リクエストへの応答には、以下のプロバナンスヘッダーが含まれます。
 
-| ヘッダ | 説明 |
+| ヘッダー | 説明 |
 |--------|-------------|
-| `x-cadde-provenance-id` | リクエストの一意識別子 (Fiware-Correlator を使用) |
-| `x-cadde-provenance-timestamp` | レスポンス生成時刻 (ISO 8601 形式) |
-| `x-cadde-provenance-provider` | データプロバイダ ID |
+| `x-cadde-provenance-id` | リクエストの一意識別子(Fiware-Correlator を使用) |
+| `x-cadde-provenance-timestamp` | 応答生成時刻(ISO 8601 形式) |
+| `x-cadde-provenance-provider` | データプロバイダー ID |
 | `x-cadde-provenance-resource-url` | アクセスされたリソースの URL |
 
 ### 認証
 
-`CADDE_AUTH_ENABLED=true` が設定されている場合、CADDE リクエストには Bearer 認証が必要です:
+`CADDE_AUTH_ENABLED=true` の場合、CADDE リクエストには Bearer 認証が必要です。
 
 ```http
 Authorization: Bearer <token>
@@ -2245,17 +2247,17 @@ Authorization: Bearer <token>
 
 トークンが存在しない場合、`401 Unauthorized` エラーが返されます。
 
-#### JWT 検証 (オプション)
+#### JWT 検証(オプション)
 
-`CADDE_JWKS_URL` を設定すると、Bearer トークンの完全な JWT 検証が有効になります:
+`CADDE_JWKS_URL` を設定すると、Bearer トークンの完全な JWT 検証が有効になります。
 
 | 機能 | 説明 |
 |---------|-------------|
-| **署名検証** | RS256 または ES256 アルゴリズムをサポート。JWKS エンドポイントから公開鍵を自動取得 |
+| **署名検証** | RS256 または ES256 アルゴリズムをサポート。JWKS エンドポイントから公開鍵を自動的に取得 |
 | **有効期限検証** | `exp` (有効期限) クレームを検証し、期限切れトークンを拒否 |
 | **発行時刻検証** | `iat` (発行時刻) クレームを検証し、未来に発行されたトークンを拒否 |
-| **発行者検証** | `iss` クレームが `CADDE_JWT_ISSUER` が設定されている場合に検証 |
-| **対象者検証** | `aud` クレームが `CADDE_JWT_AUDIENCE` が設定されている場合に検証 |
+| **発行者検証** | `CADDE_JWT_ISSUER` が設定されている場合、`iss` クレームを検証 |
+| **オーディエンス検証** | `CADDE_JWT_AUDIENCE` が設定されている場合、`aud` クレームを検証 |
 
 **設定例:**
 
@@ -2273,22 +2275,22 @@ curl -X PUT "https://api.example.com/admin/cadde" \
   }'
 ```
 
-**エラーレスポンス:**
+**エラー応答:**
 
-JWT 検証が失敗した場合、詳細なエラーメッセージが返されます:
+JWT 検証が失敗した場合、詳細なエラーメッセージが返されます。
 
 | エラー | 説明 |
 |-------|-------------|
 | `Malformed JWT token` | 無効なトークン形式 |
 | `Invalid token signature` | 無効な署名 |
-| `Token has expired` | トークンの有効期限切れ |
-| `Invalid token issuer` | 発行者クレームが一致しない |
-| `Invalid token audience` | 対象者クレームが一致しない |
-| `Unsupported signing algorithm` | サポートされていないアルゴリズム (RS256/ES256 以外) |
+| `Token has expired` | トークンの有効期限が切れています |
+| `Invalid token issuer` | 発行者クレームが一致しません |
+| `Invalid token audience` | オーディエンスクレームが一致しません |
+| `Unsupported signing algorithm` | サポートされていないアルゴリズム(RS256/ES256 以外) |
 | `Unable to fetch signing keys` | JWKS エンドポイントへのアクセスに失敗 |
-| `Signing key not found` | 指定された kid を持つ鍵が JWKS に存在しない |
+| `Signing key not found` | 指定された kid を持つキーが JWKS に存在しません |
 
-**注意:** `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます (後方互換性のため)。
+**注:** `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます(後方互換性のため)。
 
 ### 使用例
 
@@ -2309,7 +2311,7 @@ curl "http://localhost:3000/v2/entities" \
 
 ### NGSI-LD API での使用
 
-CADDE ヘッダは NGSI-LD API でも使用できます:
+CADDE ヘッダーは NGSI-LD API でも使用できます。
 
 ```bash
 curl "http://localhost:3000/ngsi-ld/v1/entities" \
@@ -2318,6 +2320,7 @@ curl "http://localhost:3000/ngsi-ld/v1/entities" \
   -H "x-cadde-provider: ld-provider" \
   -H "x-cadde-options: Fiware-Service:smartcity"
 ```
+
 ### CADDE Connector v4 API
 
 CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE 設定が有効な場合のみ利用可能、`PUT /admin/cadde` で設定)。
@@ -2338,12 +2341,12 @@ CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE �
 
 | 検索タイプ | ヘッダー値 | 説明 |
 |-------------|--------------|-------------|
-| 横断検索 | `x-cadde-search: meta` | CKAN 形式のデータセット一覧を返却 (`q` パラメータによるキーワードフィルタリング) |
-| 詳細検索 | `x-cadde-search: detail` | 個別データセットの詳細を返却 (`id` または `fq` パラメータで指定) |
+| 横断検索 | `x-cadde-search: meta` | CKAN 形式でデータセット一覧を返す (`q` パラメータでキーワードフィルタリング) |
+| 詳細検索 | `x-cadde-search: detail` | 個別データセットの詳細を返す (`id` または `fq` パラメータで指定) |
 
 CADDE 固有のフィールドがレスポンスに追加されます:
-- `caddec_dataset_id_for_detail`: 詳細検索用のデータセット ID
-- `caddec_provider_id`: プロバイダ ID (`CADDE_DEFAULT_PROVIDER` が設定されている場合)
+- `caddec_dataset_id_for_detail`: 詳細検索用データセット ID
+- `caddec_provider_id`: プロバイダー ID (`CADDE_DEFAULT_PROVIDER` が設定されている場合)
 - `caddec_resource_type`: リソースタイプ (`api/ngsi`)
 
 ```bash
@@ -2367,9 +2370,9 @@ curl "http://localhost:3000/cadde/api/v4/catalog?id=sensor" \
 
 | ヘッダー | 必須 | 説明 |
 |--------|----------|-------------|
-| `x-cadde-resource-url` | Yes | リソース URL (type、id、q、attrs、limit、offset をクエリパラメータとして含む) |
+| `x-cadde-resource-url` | はい | リソース URL (クエリパラメータとして type、id、q、attrs、limit、offset を含む) |
 | `x-cadde-resource-api-type` | - | レスポンス形式: `api/ngsi` (デフォルト) または `api/ngsi-ld` |
-| `x-cadde-provider` | - | データプロバイダ ID |
+| `x-cadde-provider` | - | データプロバイダー ID |
 
 ```bash
 # Retrieve entities in NGSIv2 format
@@ -2397,11 +2400,11 @@ CADDE v4 エンドポイントのエラーレスポンスは以下の形式で�
 
 #### 認証
 
-CADDE v4 エンドポイントは GeonicDB 認証 (`requireAuth`) をバイパスします。認証は CADDE JWT 検証 (`processCaddeRequestAsync`) によって処理されます。
+CADDE v4 エンドポイントは GeonicDB 認証 (`requireAuth`) をバイパスします。認証は CADDE JWT 検証 (`processCaddeRequestAsync`) で処理されます。
 
 ### 参考資料
 
-- [CADDE (分野間データ連携基盤)](https://www.data-ex.jp/)
+- [CADDE (Cross-sector Data Exchange Infrastructure)](https://www.data-ex.jp/)
 - [CADDE-sip/connector](https://github.com/CADDE-sip/connector)
 - [DATA-EX](https://data-ex.jp/)
 
@@ -2409,7 +2412,7 @@ CADDE v4 エンドポイントは GeonicDB 認証 (`requireAuth`) をバイパ�
 
 ## イベントストリーミング
 
-WebSocket API Gateway を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化します。
+WebSocket API Gateway を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化されます。
 
 ### 接続
 
@@ -2421,18 +2424,18 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 
 | アクション | 説明 |
 |--------|-------------|
-| `subscribe` | エンティティタイプ / ID パターンでフィルタを設定 |
+| `subscribe` | エンティティタイプ / ID パターンによるフィルタの設定 |
 | `ping` | キープアライブ (`pong` レスポンス) |
 
 ### サーバーイベント
 
 | タイプ | 説明 |
 |------|-------------|
-| `entityCreated` | エンティティが作成されました |
-| `entityUpdated` | エンティティが更新されました |
-| `entityDeleted` | エンティティが削除されました |
+| `entityCreated` | エンティティが作成された |
+| `entityUpdated` | エンティティが更新された |
+| `entityDeleted` | エンティティが削除された |
 
-詳細は [イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
+詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
 
 ---
 
@@ -2449,8 +2452,8 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 
 ### NGSI-LD エラーフォーマット (RFC 7807 ProblemDetails)
 
-NGSI-LD API のエラーレスポンスは [RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
-Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` ではなく標準の JSON MIME タイプが使用されます)。
+NGSI-LD API のエラーレスポンスは、[RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
+Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` の代わりに標準的な JSON MIME タイプが使用されます)。
 
 ```json
 {
@@ -2466,9 +2469,9 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 | コード | 説明 |
 |------|-------------|
 | `200` | 成功 (データあり) |
-| `201` | 正常に作成されました |
+| `201` | 正常に作成された |
 | `204` | 成功 (データなし) |
-| `207` | 部分的な成功 (バッチ操作) |
+| `207` | 部分的成功 (バッチ操作) |
 | `400` | 不正なリクエスト |
 | `403` | 禁止 (認可エラー) |
 | `404` | リソースが見つかりません |
@@ -2486,7 +2489,7 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 |---------|--------|---------|
 | エンティティ CRUD | Yes | Yes |
 | 属性操作 | Yes | Yes |
-| 属性値の直接取得/更新 | Yes | - |
+| 直接属性値の取得/更新 | Yes | - |
 | バッチ操作 | Yes | Yes |
 | サブスクリプション (HTTP 通知) | Yes | Yes |
 | サブスクリプション (MQTT 通知) | Yes | Yes |
@@ -2495,17 +2498,17 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 | クエリ言語 (q パラメータ) | Yes | Yes |
 | ソート (orderBy, orderDirection) | Yes | Yes |
 | メタデータ制御 (metadata / sysAttrs) | Yes | Yes |
-| 地理クエリ (coveredBy, within, intersects, disjoint) | Yes | Yes |
-| 空間 ID 検索 (ZFXY フォーマット) | Yes | Yes |
+| ジオクエリ (coveredBy, within, intersects, disjoint) | Yes | Yes |
+| 空間 ID 検索 (ZFXY 形式) | Yes | Yes |
 | GeoJSON 出力 | Yes | Yes |
 | 座標参照系 (CRS) 変換 | Yes | Yes |
 | マルチテナンシー | Yes | Yes |
 | ページネーション | Yes | Yes |
-| keyValues フォーマット | Yes | Yes |
-| レジストレーション | Yes | Yes |
-| コンテキストプロバイダー (フェデレーション/クエリ転送) | Yes | Yes |
+| keyValues 形式 | Yes | Yes |
+| 登録 | Yes | Yes |
+| コンテキストプロバイダー (連携/クエリ転送) | Yes | Yes |
 | コンテキストプロバイダー (更新転送) | Yes | Yes |
-| CADDE 連携 | Yes | Yes |
+| CADDE 統合 | Yes | Yes |
 | 認証 API (JWT ベース) | Yes | Yes |
 | ユーザー/テナント管理 API | Yes | Yes |
 | `/version` エンドポイント | Yes | - |
@@ -2516,14 +2519,14 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 
 | 機能 | ステータス | 備考 |
 |---------|--------|-------|
-| `near` 地理クエリ (近接検索) | サポート済み | ポイントジオメトリのみ。`orderByDistance=true` による距離ソートと距離情報をサポート |
+| `near` ジオクエリ (近接検索) | サポート済み | Point ジオメトリのみ; `orderByDistance=true` で距離ソートと距離情報をサポート |
 | `minDistance` / `maxDistance` | サポート済み | メートル単位で指定 |
 
 ---
 
 ## 使用例
 
-### cURL でエンティティを作成する
+### cURL でエンティティを作成
 
 ```bash
 curl -X POST "https://api.example.com/v2/entities" \
@@ -2538,7 +2541,7 @@ curl -X POST "https://api.example.com/v2/entities" \
   }'
 ```
 
-### エンティティを取得する
+### エンティティを取得
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities/Room1" \
@@ -2546,21 +2549,21 @@ curl -X GET "https://api.example.com/v2/entities/Room1" \
   -H "Fiware-ServicePath: /buildings"
 ```
 
-### 条件クエリ
+### 条件付きクエリ
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities?type=Room&q=temperature>25" \
   -H "Fiware-Service: smartcity"
 ```
 
-### ジオクエリ(ポリゴンエリア検索)
+### ジオクエリ (ポリゴンエリア検索)
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities?type=Place&georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138" \
   -H "Fiware-Service: smartcity"
 ```
 
-### サブスクリプションを作成する
+### サブスクリプションを作成
 
 ```bash
 curl -X POST "https://api.example.com/v2/subscriptions" \
@@ -2582,7 +2585,7 @@ curl -X POST "https://api.example.com/v2/subscriptions" \
   }'
 ```
 
-### NGSI-LD エンティティを作成する
+### NGSI-LD エンティティを作成
 
 ```bash
 curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
@@ -2600,25 +2603,25 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
 
 ## エンドポイントリファレンス
 
-このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、ステータスコード情報をまとめています。
+このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、およびステータスコード情報を要約します。
 
 ### API カテゴリ
 
 | API カテゴリ | ベースパス | 認証 | Content-Type |
 |--------------|-----------|----------------|--------------|
 | Meta/Health | `/` | 不要*† | `application/json` |
-| Authentication | `/auth` | 不要 | `application/json` |
-| User | `/me` | 必要 | `application/json` |
-| NGSIv2 | `/v2` | 必要* | `application/json` |
-| NGSI-LD | `/ngsi-ld/v1` | 必要* | `application/ld+json` |
-| Admin | `/admin` | 必要 (super_admin / tenant_admin) | `application/json` |
-| Catalog | `/catalog` | 必要* | `application/json` |
+| 認証 | `/auth` | 不要 | `application/json` |
+| ユーザー | `/me` | 必須 | `application/json` |
+| NGSIv2 | `/v2` | 必須* | `application/json` |
+| NGSI-LD | `/ngsi-ld/v1` | 必須* | `application/ld+json` |
+| 管理者 | `/admin` | 必須 (super_admin / tenant_admin) | `application/json` |
+| カタログ | `/catalog` | 必須* | `application/json` |
 
 \* `AUTH_ENABLED=false` の場合は認証不要
 
 † `/statistics`、`/cache/statistics`、`/metrics` は `AUTH_ENABLED=true` の場合に認証が必要
 
-### パブリックエンドポイント (Meta/Health)
+### 公開エンドポイント (Meta/Health)
 
 認証なしでアクセス可能なエンドポイント。
 
@@ -2626,21 +2629,21 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
 |----------|--------|-------------|---------|-------|
 | `/llms.txt` | GET | API ドキュメント (llms.txt) | 200 | - |
 | `/version` | GET | FIWARE Orion 互換バージョン情報 | 200 | - |
-| `/health` | GET | 基本ヘルスチェック | 200 | - |
+| `/health` | GET | 基本的なヘルスチェック | 200 | - |
 | `/health/live` | GET | Kubernetes liveness プローブ | 200 | - |
 | `/health/ready` | GET | Kubernetes readiness プローブ | 200 | 503 |
 | `/.well-known/ngsi-ld` | GET | NGSI-LD API ディスカバリー | 200 | - |
 | `/api.json` | GET | API リファレンス (JSON) | 200 | - |
 | `/openapi.json` | GET | OpenAPI 3.0 仕様 | 200 | - |
-| `/statistics` | GET | FIWARE Orion 互換統計情報(認証必要) | 200 | 401 |
-| `/cache/statistics` | GET | キャッシュ統計情報(認証必要) | 200 | 401 |
-| `/metrics` | GET | Prometheus メトリクス(認証必要) | 200 | 401 |
+| `/statistics` | GET | FIWARE Orion 互換統計情報 (認証必須) | 200 | 401 |
+| `/cache/statistics` | GET | キャッシュ統計情報 (認証必須) | 200 | 401 |
+| `/metrics` | GET | Prometheus メトリクス (認証必須) | 200 | 401 |
 | `/tools.json` | GET | AI ツール定義 (Claude Tool Use / OpenAI Function Calling) | 200 | - |
 | `/.well-known/ai-plugin.json` | GET | AI プラグインマニフェスト | 200 | - |
 | `/mcp` | POST | MCP (Model Context Protocol) Streamable HTTP エンドポイント | 200 | 400, 405, 500 |
 | `/.well-known/agent-card.json` | GET | A2A Agent Card | 200 | - |
 
-### AI エージェントエンドポイント (AUTH_ENABLED=true の場合は認証必要)
+### AI エージェントエンドポイント (AUTH_ENABLED=true の場合は認証必須)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー |
 |----------|--------|-------------|---------|-------|
@@ -2649,38 +2652,38 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
 ### 認証エンドポイント
 
 - `/auth/*` は `AUTH_ENABLED=true` の場合のみ利用可能
-- `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能(常に有効; `OAUTH_ENABLED` は非推奨)
+- `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能 (常に有効; `OAUTH_ENABLED` は非推奨)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー |
 |----------|--------|-------------|---------|-------|
 | `/auth/login` | POST | ユーザーログイン (JWT) | 200 | 400, 401 |
-| `/auth/refresh` | POST | トークンリフレッシュ | 200 | 400, 401 |
-| `/auth/logout` | POST | ログアウト(すべてのセッションを無効化、認証必要) | 204 | 401 |
-| `/auth/nonce` | POST | Nonce + PoW チャレンジによる API キートークン交換 | 200 | 400 |
-| `/oauth/token` | POST | OAuth トークン取得 (M2M: `grant_type=client_credentials`、Browser SDK: `grant_type=api_key`) | 200 | 400, 401 |
+| `/auth/refresh` | POST | トークン更新 | 200 | 400, 401 |
+| `/auth/logout` | POST | ログアウト (全セッション無効化、認証必須) | 204 | 401 |
+| `/auth/nonce` | POST | API キートークン交換用の Nonce + PoW チャレンジ | 200 | 400 |
+| `/oauth/token` | POST | OAuth トークン取得 (M2M: `grant_type=client_credentials`、ブラウザ SDK: `grant_type=api_key`) | 200 | 400, 401 |
 
 ### SDK
 
-JavaScript SDK は npm パッケージとして提供されています: `npm install @geolonia/geonicdb-sdk`SDK は完全なパブリック API を提供します: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー(`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
+JavaScript SDK は npm パッケージとして利用可能: `npm install @geolonia/geonicdb-sdk`SDK は完全な公開 API を提供: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー (`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
 
 ### ユーザーエンドポイント
 
-認証されたユーザーが自分の情報を管理するためのエンドポイントです。
+認証済みユーザーが自分の情報を管理するためのエンドポイント。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | 最小ロール |
 |----------|--------|-------------|---------|-------|--------------|
 | `/me` | GET | 自分のプロフィールを取得 | 200 | 401 | user |
-| `/me/password` | POST | パスワードを変更 | 204 | 400, 401 | user |
+| `/me/password` | POST | パスワード変更 | 204 | 400, 401 | user |
 
 ### NGSIv2 / NGSI-LD エンドポイント
 
-エンドポイントの詳細な仕様については、以下を参照してください:
+詳細なエンドポイント仕様については、以下を参照してください:
 - [NGSIv2 API リファレンス](./ngsiv2.md)
 - [NGSI-LD API リファレンス](./ngsild.md)
 
-### Admin API
+### 管理 API
 
-テナントとユーザーを管理するための API です。エンドポイントには `super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントスコープのみ)。
+テナントおよびユーザを管理するための API です。エンドポイントには `super_admin` または `tenant_admin` ロールが必要です（`tenant_admin` は自テナントスコープのみ）。
 
 #### テナント管理
 
@@ -2690,32 +2693,32 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 | `/admin/tenants` | POST | テナント作成 | 201 | 400, 401, 403, 409 | - |
 | `/admin/tenants/{tenantId}` | GET | テナント取得 | 200 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}` | PATCH | テナント更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/tenants/{tenantId}` | DELETE | テナント削除 (`?shred=true` による Crypto-Shredding) | 204 / 200 | 400, 401, 403, 404 | - |
+| `/admin/tenants/{tenantId}` | DELETE | テナント削除（`?shred=true` による Crypto-Shredding） | 204 / 200 | 400, 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/deletion-report` | GET | 削除レポート取得 | 200 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/activate` | POST | テナント有効化 | 204 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/deactivate` | POST | テナント無効化 | 204 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/ip-restrictions` | GET | テナント IP 制限取得 | 200 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/ip-restrictions` | PUT | テナント IP 制限更新 | 200 | 400, 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | テナント IP 制限削除 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users` | GET | テナントメンバー一覧取得 (tenant_admin: 自テナントのみ) | 200 | 401, 403, 404 | あり (最大: 100) |
-| `/admin/tenants/{tenantId}/users/{userId}` | PUT | テナントにユーザーを追加 (tenant_admin: 自テナントのみ) | 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | テナントからユーザーを削除 (tenant_admin: 自テナントのみ) | 204 | 400, 401, 403, 404 | - |
+| `/admin/tenants/{tenantId}/users` | GET | テナントメンバー一覧取得（tenant_admin: 自テナントのみ） | 200 | 401, 403, 404 | あり (最大: 100) |
+| `/admin/tenants/{tenantId}/users/{userId}` | PUT | テナントにユーザを追加（tenant_admin: 自テナントのみ） | 200 | 400, 401, 403, 404 | - |
+| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | テナントからユーザを削除（tenant_admin: 自テナントのみ） | 204 | 400, 401, 403, 404 | - |
 
-#### ユーザー管理
+#### ユーザ管理
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/admin/users` | GET | ユーザー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/users` | POST | ユーザー作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/users/{userId}` | GET | ユーザー取得 | 200 | 401, 403, 404 | - |
-| `/admin/users/{userId}` | PATCH | ユーザー更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/users/{userId}` | DELETE | ユーザー削除 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/activate` | POST | ユーザー有効化 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/deactivate` | POST | ユーザー無効化 | 204 | 401, 403, 404 | - |
+| `/admin/users` | GET | ユーザ一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/admin/users` | POST | ユーザ作成 | 201 | 400, 401, 403, 409 | - |
+| `/admin/users/{userId}` | GET | ユーザ取得 | 200 | 401, 403, 404 | - |
+| `/admin/users/{userId}` | PATCH | ユーザ更新 | 204 | 400, 401, 403, 404, 409 | - |
+| `/admin/users/{userId}` | DELETE | ユーザ削除 | 204 | 401, 403, 404 | - |
+| `/admin/users/{userId}/activate` | POST | ユーザ有効化 | 204 | 401, 403, 404 | - |
+| `/admin/users/{userId}/deactivate` | POST | ユーザ無効化 | 204 | 401, 403, 404 | - |
 | `/admin/users/{userId}/unlock` | POST | ログインロック解除 | 200 | 400, 401, 403, 404 | - |
-| `/admin/users/{userId}/tenants` | GET | ユーザーが所属するテナント一覧取得 (自分自身または super_admin) | 200 | 401, 403 | あり (最大: 100) |
+| `/admin/users/{userId}/tenants` | GET | ユーザが所属するテナント一覧取得（自身または super_admin） | 200 | 401, 403 | あり (最大: 100) |
 
-#### ポリシー管理 (XACML 3.0 認可、super_admin / tenant_admin)
+#### ポリシー管理（XACML 3.0 認可、super_admin / tenant_admin）
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
@@ -2728,19 +2731,19 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 | `/admin/policies/{policyId}/activate` | POST | ポリシー有効化 | 200 | 401, 403, 404 | - |
 | `/admin/policies/{policyId}/deactivate` | POST | ポリシー無効化 | 200 | 401, 403, 404 | - |
 
-ポリシー Target `resources` で利用可能な **リソース属性**:
+**リソース属性**（ポリシー Target `resources` で利用可能）:
 
 | attributeId | 説明 | ソース |
 |-------------|-------------|--------|
-| `path` | HTTP リクエストパス (例: `/v2/entities/Room1`) | リクエスト |
-| `tenantService` | テナントサービス名 (`Fiware-Service` ヘッダー) | リクエスト |
-| `servicePath` | ServicePath (`Fiware-ServicePath` ヘッダー) | リクエスト |
-| `scope` | NGSI-LD エンティティスコープ (カンマ区切り) | エンティティコンテキスト |
-| `entityId` | 対象エンティティ ID (例: `Room1`) | エンティティコンテキスト |
-| `entityType` | 対象エンティティタイプ (例: `Room`) | リクエスト (自動抽出) / エンティティコンテキスト |
-| `entityOwner` | エンティティ作成者の userId (`createdBy` フィールド) | エンティティコンテキスト |
+| `path` | HTTP リクエストパス（例: `/v2/entities/Room1`） | リクエスト |
+| `tenantService` | テナントサービス名（`Fiware-Service` ヘッダ） | リクエスト |
+| `servicePath` | ServicePath（`Fiware-ServicePath` ヘッダ） | リクエスト |
+| `scope` | NGSI-LD エンティティスコープ（カンマ区切り） | エンティティコンテキスト |
+| `entityId` | 対象エンティティ ID（例: `Room1`） | エンティティコンテキスト |
+| `entityType` | 対象エンティティタイプ（例: `Room`） | リクエスト（自動抽出） / エンティティコンテキスト |
+| `entityOwner` | エンティティ作成者のユーザ ID（`createdBy` フィールド） | エンティティコンテキスト |
 
-> `entityType` は、HTTP リクエストのパスレベルから自動的に抽出されます。`?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから取得され、エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、`scope` は、エンティティレベルの認可チェック(`requireEntityAuthz` 経由)でのみ利用可能です。`scope` は、NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したもので、柔軟なマッチングには `string-regexp` または `glob` を使用してください。
+> `entityType` は HTTP リクエストからパスレベルで自動抽出されます（`?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから）。これにより、エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御が可能です。`entityId`、`entityOwner`、`scope` は、エンティティレベルの認可チェック（`requireEntityAuthz` 経由）でのみ利用可能です。`scope` は NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したもので、柔軟なマッチングには `string-regexp` または `glob` を使用してください。
 
 #### OAuth クライアント管理
 
@@ -2754,19 +2757,19 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 
 #### セルフサービス OAuth クライアント管理
 
-ユーザーは自分自身の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアント。オプションの `policyId` により、クライアントを既存の XACML ポリシーにバインドできます。
+ユーザは自身の OAuth クライアントを管理できます。1 ユーザあたり最大 5 クライアントまで。オプションの `policyId` は既存の XACML ポリシーにクライアントをバインドします。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/me/oauth-clients` | GET | 自分の OAuth クライアント一覧取得 | 200 | 400, 401 | あり (最大: 100) |
-| `/me/oauth-clients` | POST | 自分の OAuth クライアント作成 | 201 | 400, 401, 403 | - |
-| `/me/oauth-clients/{clientId}` | PATCH | 自分の OAuth クライアント更新 (部分更新) | 200 | 400, 401, 403, 404 | - |
-| `/me/oauth-clients/{clientId}` | DELETE | 自分の OAuth クライアント削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/oauth-clients/{clientId}/regenerate-secret` | POST | 自分のクライアントシークレット再生成 | 200 | 400, 401, 403, 404 | - |
+| `/me/oauth-clients` | GET | 自身の OAuth クライアント一覧取得 | 200 | 400, 401 | あり (最大: 100) |
+| `/me/oauth-clients` | POST | 自身の OAuth クライアント作成 | 201 | 400, 401, 403 | - |
+| `/me/oauth-clients/{clientId}` | PATCH | 自身の OAuth クライアント更新（部分更新） | 200 | 400, 401, 403, 404 | - |
+| `/me/oauth-clients/{clientId}` | DELETE | 自身の OAuth クライアント削除 | 204 | 400, 401, 403, 404 | - |
+| `/me/oauth-clients/{clientId}/regenerate-secret` | POST | 自身のクライアントシークレット再生成 | 200 | 400, 401, 403, 404 | - |
 
 #### API キー管理
 
-`X-Api-Key` ヘッダーによる認証用の API キーを管理します。新しいキーはプレーン UUID 形式(`randomUUID()`)を使用します。既存の `gdb_` プレフィックス付きキーは引き続き有効です。保存時は SHA-256 でハッシュ化され、平文キーは作成時と更新時のみ返されます。一覧取得/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドにより、キーを既存の XACML ポリシーにバインドできます(バインドされたポリシーのターゲットは評価時にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト(api_key = All Deny)にフォールバックします。
+`X-Api-Key` ヘッダによる認証用の API キーを管理します。新しいキーはプレーン UUID 形式（`randomUUID()`）を使用します。`gdb_` プレフィックス付きの既存キーは引き続き有効です。保存時は SHA-256 でハッシュ化されます。平文キーは作成時と更新時にのみ返されます。一覧取得/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドは既存の XACML ポリシーにキーをバインドします（バインドされたポリシーのターゲットは評価中にバイパスされます）。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト（api_key = 全て拒否）にフォールバックします。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
@@ -2775,27 +2778,28 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 | `/admin/api-keys/{keyId}` | GET | API キー取得 | 200 | 401, 403, 404 | - |
 | `/admin/api-keys/{keyId}` | PATCH | API キー更新 | 204 | 400, 401, 403, 404 | - |
 | `/admin/api-keys/{keyId}` | DELETE | API キー削除 | 204 | 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}/refresh` | POST | API キー更新 (再生成) | 200 | 401, 403, 404 | - |
+| `/admin/api-keys/{keyId}/refresh` | POST | API キー更新（再生成） | 200 | 401, 403, 404 | - |
+#### セルフサービス API キー管理
 
-#### セルフサービス API キー管理ユーザーは自分の API キーを管理できます。1 ユーザーにつき最大 5 つのキーまで作成可能です。
+ユーザーは自分自身の API キーを管理できます。ユーザーあたり最大 5 つのキーまで。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/me/api-keys` | POST | 自分の API キーを作成 | 201 | 400, 401, 403 | - |
-| `/me/api-keys` | GET | 自分の API キーを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
-| `/me/api-keys/{keyId}` | PATCH | 自分の API キーを更新(部分更新) | 200 | 400, 401, 403, 404 | - |
+| `/me/api-keys` | GET | 自分の API キーを一覧表示 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/me/api-keys/{keyId}` | PATCH | 自分の API キーを更新 (部分更新) | 200 | 400, 401, 403, 404 | - |
 | `/me/api-keys/{keyId}` | DELETE | 自分の API キーを削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/api-keys/{keyId}/refresh` | POST | 自分の API キーをリフレッシュ(再生成) | 200 | 401, 403, 404 | - |
+| `/me/api-keys/{keyId}/refresh` | POST | 自分の API キーをリフレッシュ (再生成) | 200 | 401, 403, 404 | - |
 
 #### CADDE 設定管理
 
-API を介して CADDE (分野間データ連携基盤) の設定を管理します。設定は MongoDB に保存され、環境変数は不要です。
+API を介して CADDE (分野間データ連携基盤) 設定を管理します。設定は MongoDB に保存され、環境変数は不要です。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/admin/cadde` | GET | CADDE 設定を取得 | 200 | 401, 403 | - |
-| `/admin/cadde` | PUT | CADDE 設定を更新(upsert) | 200 | 400, 401, 403 | - |
-| `/admin/cadde` | DELETE | CADDE 設定を削除(無効化) | 204 | 401, 403 | - |
+| `/admin/cadde` | PUT | CADDE 設定を更新 (upsert) | 200 | 400, 401, 403 | - |
+| `/admin/cadde` | DELETE | CADDE 設定を削除 (無効化) | 204 | 401, 403 | - |
 
 **リクエストボディ (PUT)**
 
@@ -2812,18 +2816,18 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 | フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `enabled` | boolean | Yes | CADDE 機能を有効/無効化 |
-| `authEnabled` | boolean | Yes | Bearer 認証を有効/無効化 |
+| `enabled` | boolean | はい | CADDE 機能の有効化/無効化 |
+| `authEnabled` | boolean | はい | Bearer 認証の有効化/無効化 |
 | `defaultProvider` | string | - | デフォルトのプロバイダー ID |
-| `jwtIssuer` | string | - | JWT の issuer クレーム検証値 |
-| `jwtAudience` | string | - | JWT の audience クレーム検証値 |
+| `jwtIssuer` | string | - | JWT 発行者クレームの検証値 |
+| `jwtAudience` | string | - | JWT オーディエンスクレームの検証値 |
 | `jwksUrl` | string | - | JWKS 公開鍵エンドポイント URL (HTTPS 必須) |
 
 #### ルールエンジン管理
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/rules` | GET | ルールを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
+| `/rules` | GET | ルールを一覧表示 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/rules` | POST | ルールを作成 | 201 | 400, 401, 403, 409 | - |
 | `/rules/{ruleId}` | GET | ルールを取得 | 200 | 401, 403, 404 | - |
 | `/rules/{ruleId}` | PATCH | ルールを更新 | 204 | 400, 401, 403, 404 | - |
@@ -2833,35 +2837,35 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 ### カスタムデータモデル API
 
-テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要で、XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールがテナント内のカスタムデータモデルを管理できます。
+テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要で、XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールが自分のテナント内でカスタムデータモデルを管理できます。
 
 **関連ドキュメント**: [SMART_DATA_MODELS.md](../features/smart-data-models.md)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/custom-data-models` | GET | カスタムデータモデルの一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/custom-data-models` | POST | カスタムデータモデルの作成 | 201 | 400, 401, 403, 409 | - |
-| `/custom-data-models/{type}` | GET | カスタムデータモデルの取得 | 200 | 401, 403, 404 | - |
-| `/custom-data-models/{type}` | PATCH | カスタムデータモデルの更新 | 200 | 400, 401, 403, 404 | - |
-| `/custom-data-models/{type}` | DELETE | カスタムデータモデルの削除 | 204 | 401, 403, 404 | - |
+| `/custom-data-models` | GET | カスタムデータモデル一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/custom-data-models` | POST | カスタムデータモデル作成 | 201 | 400, 401, 403, 409 | - |
+| `/custom-data-models/{type}` | GET | カスタムデータモデル取得 | 200 | 401, 403, 404 | - |
+| `/custom-data-models/{type}` | PATCH | カスタムデータモデル更新 | 200 | 400, 401, 403, 404 | - |
+| `/custom-data-models/{type}` | DELETE | カスタムデータモデル削除 | 204 | 401, 403, 404 | - |
 
-#### エンティティの検証
+#### エンティティ検証
 
-カスタムデータモデルが定義されている場合、エンティティの作成または更新時に自動的に検証が実行されます。検証は `isActive: true` を持つモデルにのみ適用されます。
+カスタムデータモデルが定義されている場合、エンティティの作成または更新時に自動的に検証が実行されます。検証は `isActive: true` が設定されているモデルにのみ適用されます。
 
 **検証チェック:**
 
 | チェック | 説明 |
 |-------|-------------|
 | 追加プロパティ | `additionalProperties: false` の場合、`propertyDetails` で定義されていない属性は拒否されます (デフォルト: `true` — 任意の属性を許可) |
-| 必須フィールド | `required: true` を持つ属性が存在するかどうか |
+| 必須フィールド | `required: true` が設定されている属性が存在するか |
 | 型チェック | `valueType` に基づく型検証 (string, number, integer, boolean, array, object, GeoJSON) |
 | minLength / maxLength | 文字列長の制約 |
 | minimum / maximum | 数値範囲の制約 |
 | pattern | 正規表現パターンマッチ |
-| enum | 許可された値のリスト |
+| enum | 許可される値のリスト |
 
-検証失敗時は `400 Bad Request` が返されます:
+検証失敗時は `400 Bad Request` を返します:
 
 ```json
 {
@@ -2872,11 +2876,11 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 #### 自動 JSON Schema 生成
 
-カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。また、`jsonSchema` を手動で指定することも可能です。
+カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。`jsonSchema` を手動で指定することも可能です。
 
-#### プロパティ @context (JSON-LD 語彙マッピング)
+#### プロパティ @context (JSON-LD ボキャブラリマッピング)
 
-`propertyDetails` の各プロパティには、JSON-LD 語彙マッピング用の HTTP(S) URL を指定できるオプションの `@context` フィールドを含めることができます。これにより、自動生成された URI の代わりに、よく知られた語彙 (例: schema.org) を使用できます。
+`propertyDetails` の各プロパティには、JSON-LD ボキャブラリマッピングのためのオプショナルな `@context` フィールドを HTTP(S) URL で含めることができます。これにより、自動生成される URI の代わりに既知のボキャブラリ (例: schema.org) を使用できます。
 
 ```json
 {
@@ -2897,54 +2901,54 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 ```
 
 - `@context` を持つプロパティ → 指定された URL が JSON-LD コンテキストで使用されます
-- `@context` を持たないプロパティ → 自動生成された URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
-- プロパティ URI はエンティティタイプに依存しません (同じプロパティ名はテナント内で同じ URI を共有します)
-- `@context` は HTTP(S) URL である必要があります (URN は受け付けません)
+- `@context` を持たないプロパティ → 自動生成 URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
+- プロパティ URI はエンティティタイプに依存しません (同じプロパティ名はテナント内で同じ URI を共有)
+- `@context` は HTTP(S) URL である必要があります (URN は受け入れられません)
 
-#### @context 解決の拡張
+#### @context 解決拡張
 
-NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはエンティティの `@context` に自動的に含まれます (コアコンテキストと一緒に配列として返されます)。
+NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがエンティティの `@context` に自動的に含まれます (コアコンテキストと一緒に配列として返されます)。
 
 ### カタログ API
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/catalog` | GET | DCAT-AP カタログの取得 | 200 | 401 | - |
-| `/catalog/datasets` | GET | データセットの一覧取得 | 200 | 400, 401 | あり (最大: 1000) |
-| `/catalog/datasets/{datasetId}` | GET | データセットの取得 | 200 | 401, 404 | - |
-| `/catalog/datasets/{datasetId}/sample` | GET | サンプルデータの取得 | 200 | 401, 404 | - |
+| `/catalog` | GET | DCAT-AP カタログ取得 | 200 | 401 | - |
+| `/catalog/datasets` | GET | データセット一覧取得 | 200 | 400, 401 | あり (最大: 1000) |
+| `/catalog/datasets/{datasetId}` | GET | データセット取得 | 200 | 401, 404 | - |
+| `/catalog/datasets/{datasetId}/sample` | GET | サンプルデータ取得 | 200 | 401, 404 | - |
 
 ### ベクタータイル API
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー |
 |----------|--------|-------------|---------|-------|
-| `/v2/tiles` | GET | TileJSON メタデータの取得 (NGSIv2) | 200 | 401 |
-| `/v2/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルの取得 (NGSIv2) | 200 | 400, 401 |
-| `/ngsi-ld/v1/tiles` | GET | TileJSON メタデータの取得 (NGSI-LD) | 200 | 401 |
-| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルの取得 (NGSI-LD) | 200 | 400, 401 |
+| `/v2/tiles` | GET | TileJSON メタデータ取得 (NGSIv2) | 200 | 401 |
+| `/v2/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイル取得 (NGSIv2) | 200 | 400, 401 |
+| `/ngsi-ld/v1/tiles` | GET | TileJSON メタデータ取得 (NGSI-LD) | 200 | 401 |
+| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイル取得 (NGSI-LD) | 200 | 400, 401 |
 
 ### イベントストリーミング API
 
-WebSocket を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化されます。
+WebSocket を使用したリアルタイムのエンティティ変更ストリーミングです。`EVENT_STREAMING_ENABLED=true` で有効化されます。
 
 | エンドポイント | プロトコル | 説明 |
 |----------|----------|-------------|
-| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントのストリーム配信 (認証は `Authorization` ヘッダー経由で送信) |
+| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントをストリーム配信 (認証は `Authorization` ヘッダー経由で送信) |
 
 詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
 
-### アクセス許可の概要
+### アクセス権限の概要
 
 | API カテゴリ | user | tenant_admin | super_admin |
 |--------------|------|--------------|-------------|
 | パブリックエンドポイント | Yes | Yes | Yes |
 | `/auth/*` | Yes | Yes | Yes |
 | `/me/*` | Yes | Yes | Yes |
-| `/statistics`、`/metrics`、`/cache/statistics` | Yes | Yes | Yes |
+| `/statistics`, `/metrics`, `/cache/statistics` | Yes | Yes | Yes |
 | `/v2/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
 | `/ngsi-ld/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
 | `/catalog/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/admin/policies`、`/admin/policy-sets` | No | Yes (自テナント) | Yes (全テナント) |
+| `/admin/policies`, `/admin/policy-sets` | No | Yes (自テナント) | Yes (全テナント) |
 | `/admin/*` (その他) | No | No | Yes |
 | `/custom-data-models` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
 | `/rules` | No | Yes (自テナント) | Denied (403) |

--- a/docs/ja/api-reference/ngsild.md
+++ b/docs/ja/api-reference/ngsild.md
@@ -356,8 +356,7 @@ DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 | `datasetId` | string | 削除するマルチ属性インスタンスの datasetId |
 | `deleteAll` | boolean | `true` の場合、すべてのインスタンスを削除します |
 
-**レスポンス**: `204 No Content`
-### マルチ属性 (datasetId)
+**レスポンス**: `204 No Content`### マルチ属性 (datasetId)
 
 > **ETSI GS CIM 009 リファレンス**: Section 4.5.3 - Multi-Attribute
 
@@ -582,9 +581,7 @@ Merge-Patch セマンティクスを使用して、複数のエンティティ�
 | `options=noOverwrite` | 既存の属性を上書きしない |
 
 **レスポンス**
-- すべて成功: `204 No Content`
-- 部分的な成功: `207 Multi-Status`
----
+- すべて成功: `204 No Content`- 部分的な成功: `207 Multi-Status`---
 
 ### 時系列・バッチ操作 (NGSI-LD)
 
@@ -682,8 +679,7 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 
 `options=temporalValues` を指定すると、各属性が `values` 配列 (`[value, timestamp]` のペア) を含む簡易形式で返されます。
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues`
-```json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues````json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -705,8 +701,7 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 | `aggrMethods` | string | 集計メソッド (カンマ区切り): `totalCount`, `distinctCount`, `sum`, `avg`, `min`, `max`, `stddev`, `sumsq` |
 | `aggrPeriodDuration` | string | ISO 8601 期間 (例: `PT1H` は 1 時間)。`aggrMethods` 指定時に必須 |
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z`
-```json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z````json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -1261,8 +1256,7 @@ Content-Type: application/ld+json
 DELETE /ngsi-ld/v1/entityMaps/{entityMapId}
 ```
 
-**レスポンス**: `204 No Content`
-### リンクエンティティの取得 (join/joinLevel)
+**レスポンス**: `204 No Content`### リンクエンティティの取得 (join/joinLevel)
 
 エンティティ取得エンドポイント (`GET /ngsi-ld/v1/entities` と `GET /ngsi-ld/v1/entities/{entityId}`) では、`join` と `joinLevel` のクエリパラメータを使用してリンクされたエンティティを取得できます。
 
@@ -1389,8 +1383,7 @@ PATCH /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 DELETE /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`
-### JSON-LD Context 管理
+**レスポンス**: `204 No Content`### JSON-LD Context 管理
 
 ETSI GS CIM 009 Section 5.12 に準拠した JSON-LD context 管理 API です。ユーザー定義の JSON-LD context の登録と管理が可能です。
 
@@ -1464,8 +1457,7 @@ GET /ngsi-ld/v1/jsonldContexts/{contextId}
 DELETE /ngsi-ld/v1/jsonldContexts/{contextId}
 ```
 
-**レスポンス**: `204 No Content`
-### Vector Tiles (NGSI-LD)
+**レスポンス**: `204 No Content`### Vector Tiles (NGSI-LD)
 
 地図可視化のためにエンティティデータを GeoJSON ベクタータイルとして提供します。TileJSON 3.0 準拠のメタデータと、ズームレベルおよびタイル座標による GeoJSON タイルの取得をサポートします。
 

--- a/docs/ja/api-reference/ngsiv2.md
+++ b/docs/ja/api-reference/ngsiv2.md
@@ -5,11 +5,13 @@ outline: deep
 ---
 # NGSIv2 API
 
-> このドキュメントは[API.md](./endpoints.md)から分割されました。メインの API 仕様については、[API.md](./endpoints.md)を参照してください。
+> このドキュメントは [API.md](./endpoints.md) から分割されました。メインの API 仕様については、[API.md](./endpoints.md) を参照してください。
 
 ---
 
-## エンティティ操作### エンティティの一覧取得
+## エンティティ操作
+
+### エンティティのリスト取得
 
 ```http
 GET /v2/entities
@@ -19,35 +21,35 @@ GET /v2/entities
 
 | パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
-| `id` | string | エンティティ ID でフィルタ (複数の値をカンマ区切りリストで指定可能) | - |
+| `id` | string | エンティティ ID でフィルタリング (カンマ区切りで複数の値を指定可能) | - |
 | `limit` | integer | 取得する結果の数 (最大: 1000) | 20 |
 | `offset` | integer | オフセット (ページネーション用) | 0 |
-| `orderBy` | string | ソート条件 (`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順指定可能 (例: `!temperature`) | - |
-| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張** (公式仕様は `!` プレフィックス方式のみサポート) | `asc` |
-| `type` | string | エンティティタイプでフィルタ | - |
+| `orderBy` | string | ソート基準 (`entityId`、`entityType`、`modifiedAt`、または属性名)。降順の場合は FIWARE Orion 互換の `!` プレフィックス (例: `!temperature`) | - |
+| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張機能** (公式仕様では `!` プレフィックスアプローチのみをサポート) | `asc` |
+| `type` | string | エンティティタイプでフィルタリング | - |
 | `typePattern` | string | エンティティタイプの正規表現パターン | - |
 | `idPattern` | string | エンティティ ID の正規表現パターン | - |
-| `q` | string | 属性値でフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
-| `mq` | string | メタデータでフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
+| `q` | string | 属性値でフィルタリング ([クエリ言語](./endpoints.md#query-language) を参照) | - |
+| `mq` | string | メタデータでフィルタリング ([クエリ言語](./endpoints.md#query-language) を参照) | - |
 | `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張** (公式仕様では `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
-| `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries)を参照) | - |
+| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張機能** (公式仕様ではカンマ区切りの名前リストと `*` ワイルドカードなどを使用) | `on` |
+| `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries) を参照) | - |
 | `geometry` | string | ジオメトリタイプ | - |
-| `coords` | string | 座標 (緯度,経度 形式、セミコロン区切り) | - |
-| `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search)を参照) | - |
+| `coords` | string | 座標 (緯度,経度形式、セミコロン区切り) | - |
+| `spatialId` | string | 空間 ID でフィルタリング (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search) を参照) | - |
 | `spatialIdDepth` | integer | 空間 ID 階層展開の深さ (0-4) | 0 |
-| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs)を参照) | `EPSG:4326` |
+| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs) を参照) | `EPSG:4326` |
 | `options` | string | `keyValues`、`values`、`count`、`geojson`、`sysAttrs`、`unique` | - |
 
 **組み込み属性**
 
-`attrs` パラメータは、ユーザー定義属性に加えて、以下の組み込み属性をサポートします:
+`attrs` パラメータは、ユーザ定義属性に加えて以下の組み込み属性をサポートしています:
 
 | 組み込み属性 | 型 | 説明 |
 |---|---|---|
 | `dateCreated` | DateTime | エンティティ作成タイムスタンプ (`options=sysAttrs` でも利用可能) |
 | `dateModified` | DateTime | 最終更新タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateExpires` | DateTime | 一時エンティティの有効期限タイムスタンプ |
+| `dateExpires` | DateTime | 一時的エンティティの有効期限タイムスタンプ |
 | `servicePath` | Text | エンティティが保存されているServicePath (作成時の `Fiware-ServicePath` ヘッダー値) |
 
 例: `GET /v2/entities?attrs=temperature,servicePath`**レスポンス例**
@@ -131,7 +133,7 @@ POST /v2/entities
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
-| `options` | string | `upsert`: エンティティが既に存在する場合は更新。`keyValues`: リクエストボディを keyValues 形式として解釈 |
+| `options` | string | `upsert`: エンティティが既に存在する場合は更新します。`keyValues`: リクエストボディを keyValues 形式として解釈します |
 
 **リクエストボディ**
 
@@ -150,7 +152,7 @@ POST /v2/entities
 }
 ```
 
-**keyValues 形式入力** (`options=keyValues`)
+**keyValues 形式の入力** (`options=keyValues`)
 
 ```json
 {
@@ -161,14 +163,14 @@ POST /v2/entities
 }
 ```
 
-**Upsert 動作** (`options=upsert`)
+**アップサート動作** (`options=upsert`)
 
 エンティティが存在しない場合は作成され (`201 Created`)、既に存在する場合はその属性が更新されます (`204 No Content`)。
 
 **レスポンス**
-- ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
-- ステータス: `409 AlreadyExists` 同じ ID のエンティティが既に存在する場合 (タイプに関わらず)
-- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID はテナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension)を参照してください。
+- ステータス: `201 Created` (新規作成)、`204 No Content` (アップサートによる更新)
+- ステータス: `409 AlreadyExists` 同じ ID を持つエンティティが既に存在する場合 (型に関係なく)
+- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID は、テナントとServicePathのスコープ内で一意です。同じ ID で異なる型のエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、異なる型の同一 ID エンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
 ### 単一エンティティの取得
 
@@ -180,7 +182,7 @@ GET /v2/entities/{entityId}
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
-| `type` | string | エンティティタイプ (オプションのフィルタ; エンティティ ID は一意であるため、タイプの曖昧さ解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
+| `type` | string | エンティティタイプ (オプションフィルタ; エンティティ ID は一意であるため、型の曖昧性解消は不要です — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
 | `attrs` | string | 取得する属性名 (カンマ区切り) |
 | `options` | string | `keyValues`、`values` |
 
@@ -231,7 +233,7 @@ POST /v2/entities/{entityId}/attrs
 
 新しい属性を追加します (既存の属性は上書きされます)。
 
-`options=append` が指定された場合、既存の属性は上書きされず、新しい属性のみが追加されます (厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
+`options=append` を指定すると、既存の属性は上書きされず、新しい属性のみが追加されます (厳密な追加モード)。既に存在する属性名が含まれている場合、 `422 Unprocessable Entity` エラーが返されます。
 
 **クエリパラメータ**
 
@@ -254,9 +256,11 @@ DELETE /v2/entities/{entityId}
 
 **レスポンス**: `204 No Content`---
 
-## 属性の操作### エンティティの属性を取得
+## 属性の操作
 
-エンティティのすべての属性を取得します (`id` および `type` フィールドは含まれません)。
+### エンティティの属性を取得
+
+エンティティのすべての属性を取得します ( `id` および `type` フィールドは含まれません)。
 
 ```http
 GET /v2/entities/{entityId}/attrs
@@ -268,8 +272,8 @@ GET /v2/entities/{entityId}/attrs
 |-----------|------|-------------|---------|
 | `type` | string | エンティティタイプ | - |
 | `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`) | `on` |
-| `options` | string | `keyValues`、`values`、`sysAttrs` | - |
+| `metadata` | string | メタデータ出力制御 ( `on` 、 `off` ) | `on` |
+| `options` | string | `keyValues` 、 `values` 、 `sysAttrs` | - |
 
 **レスポンス例**
 
@@ -288,7 +292,7 @@ GET /v2/entities/{entityId}/attrs
 }
 ```
 
-**keyValues 形式** (`options=keyValues`)
+**keyValues 形式** ( `options=keyValues` )
 
 ```json
 {
@@ -299,7 +303,7 @@ GET /v2/entities/{entityId}/attrs
 
 > **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` および `type` フィールドが含まれません。属性のみが必要な場合に使用してください。
 
-### 単一属性の取得
+### 単一の属性を取得
 
 ```http
 GET /v2/entities/{entityId}/attrs/{attrName}
@@ -354,13 +358,13 @@ DELETE /v2/entities/{entityId}/attrs/{attrName}
 |-----------|------|-------------|
 | `type` | string | エンティティタイプ |
 
-**レスポンス**: `204 No Content`### 属性値を直接取得
+**レスポンス**: `204 No Content`### 属性値の直接取得
 
 ```http
 GET /v2/entities/{entityId}/attrs/{attrName}/value
 ```
 
-属性の値のみを取得します (型とメタデータは含まれません)。
+属性の値のみを取得します(型とメタデータは含まれません)。
 
 **クエリパラメータ**
 
@@ -394,6 +398,7 @@ curl "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -H "Fiware-Service: smartcity"
 # Response: {"type":"Point","coordinates":[139.76,35.68]} (Content-Type: application/json)
 ```
+
 ### 属性値の直接更新
 
 ```http
@@ -414,8 +419,8 @@ PUT /v2/entities/{entityId}/attrs/{attrName}/value
 
 | Content-Type | 解釈 |
 |--------------|----------------|
-| `application/json` | JSON としてパース |
-| `text/plain` | プリミティブ値 (`null`、`true`、`false`、数値) または文字列 |
+| `application/json` | JSON として解析 |
+| `text/plain` | プリミティブ値 (`null`、`true`、`false`、数値)または文字列 |
 
 **使用例**
 
@@ -433,13 +438,13 @@ curl -X PUT "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -d '{"type":"Point","coordinates":[140.0,36.0]}'
 ```
 
-**レスポンス**: `204 No Content`**注**: この操作では、既存の属性の型やメタデータは変更されず、保持されます。
+**レスポンス**: `204 No Content`**注意**: この操作は既存の属性の型やメタデータを変更しません — それらは保持されます。
 
 ---
 
 ## バッチ操作
 
-> **注**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100、SAM パラメータ `MaxBatchSize` で最大 10,000 まで設定可能)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
+> **注意**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100、SAM パラメータ `MaxBatchSize` で最大 10,000 まで設定可能)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
 
 ### バッチ更新
 
@@ -472,13 +477,13 @@ POST /v2/op/update
 | アクション | 説明 |
 |--------|-------------|
 | `append` | 既存エンティティの属性を追加/更新 |
-| `appendStrict` | 既存エンティティに新しい属性を追加 (既存属性が存在する場合はエラーを返す) |
+| `appendStrict` | 既存エンティティに新しい属性を追加 (既存の属性が存在する場合はエラーを返す) |
 | `update` | 既存の属性のみを更新 (エンティティが存在しない場合はエラー) |
 | `replace` | すべての属性を置換 |
 | `delete` | エンティティまたは属性を削除 |
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的成功/エラー: `200 OK` とエラー詳細
+- すべて成功: `204 No Content`- 部分的に成功/エラー: `200 OK` (エラー詳細を含む)
 
 ```json
 {
@@ -550,7 +555,9 @@ POST /v2/op/notify
 
 **レスポンス**: `200 OK`---
 
-## サブスクリプション### サブスクリプションの作成
+## サブスクリプション
+
+### サブスクリプションの作成
 
 ```http
 POST /v2/subscriptions
@@ -584,7 +591,7 @@ POST /v2/subscriptions
 }
 ```
 
-**httpCustom 通知の例(カスタムテンプレート)**
+**httpCustom 通知の例 (カスタムテンプレート)**
 
 ```json
 {
@@ -609,25 +616,25 @@ POST /v2/subscriptions
 
 **httpCustom フィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `url` | string | ✓ | 通知送信先 URL |
-| `method` | string | - | HTTP メソッド(GET、POST、PUT、PATCH、DELETE)。デフォルト: POST |
+| `url` | string | ✓ | 通知先 URL |
+| `method` | string | - | HTTP メソッド (GET, POST, PUT, PATCH, DELETE)。デフォルト: POST |
 | `headers` | object | - | カスタム HTTP ヘッダー |
-| `qs` | object | - | クエリ文字列パラメータ(`${...}` マクロ置換をサポート) |
-| `payload` | string | - | リクエストボディテンプレート(`${...}` マクロ置換をサポート) |
+| `qs` | object | - | クエリ文字列パラメータ (`${...}` マクロ置換をサポート) |
+| `payload` | string | - | リクエストボディテンプレート (`${...}` マクロ置換をサポート) |
 
 **マクロ置換**
 
-`${...}` 構文を使用して `payload` および `qs` の値にエンティティデータを埋め込むことができます:
+`${...}` 構文を使用して、`payload` と `qs` の値にエンティティデータを埋め込むことができます:
 
 | マクロ | 置換値 |
 |-------|-------------------|
 | `${id}` | エンティティ ID |
 | `${type}` | エンティティタイプ |
-| `${attrName}` | 属性値(正規化された属性から `.value` を抽出) |
+| `${attrName}` | 属性値 (正規化された属性から `.value` を抽出) |
 
-存在しない属性は文字列 `null` に置き換えられます。マクロは attrs/exceptAttrs フィルターが適用される前の完全なエンティティに対して評価されます。
+存在しない属性は文字列 `null` に置換されます。マクロは attrs/exceptAttrs フィルタが適用される前の完全なエンティティに対して評価されます。
 
 **MQTT 通知の例**
 
@@ -658,11 +665,11 @@ POST /v2/subscriptions
 
 **MQTT 通知設定**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
 | `url` | string | ✓ | MQTT ブローカー URL (`mqtt://` または `mqtts://`) |
-| `topic` | string | ✓ | 通知送信先トピック |
-| `qos` | integer | - | QoS レベル(0、1、2)。デフォルト: 0 |
+| `topic` | string | ✓ | 通知先トピック |
+| `qos` | integer | - | QoS レベル (0, 1, 2)。デフォルト: 0 |
 | `retain` | boolean | - | メッセージ保持フラグ。デフォルト: false |
 | `user` | string | - | 認証ユーザー名 |
 | `passwd` | string | - | 認証パスワード |
@@ -699,12 +706,12 @@ POST /v2/subscriptions
 
 | フォーマット | 説明 |
 |--------|-------------|
-| `normalized` | 標準 NGSIv2 フォーマット(デフォルト) |
+| `normalized` | 標準 NGSIv2 フォーマット (デフォルト) |
 | `keyValues` | 簡略化されたキーバリューフォーマット |
 
-**通知属性のフィルタリング**
+**通知属性フィルタリング**
 
-| フィールド | タイプ | 説明 |
+| フィールド | 型 | 説明 |
 |-------|------|-------------|
 | `attrs` | string[] | 通知に含める属性名のリスト |
 | `exceptAttrs` | string[] | 通知から除外する属性名のリスト |
@@ -719,11 +726,11 @@ GET /v2/subscriptions
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
+| パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
 | `limit` | integer | 取得する結果の数 | 20 |
 | `offset` | integer | オフセット | 0 |
-| `status` | string | ステータスでフィルタリング(`active`、`inactive`) | - |
+| `status` | string | ステータスでフィルタリング (`active`, `inactive`) | - |
 
 ### サブスクリプションの取得
 
@@ -745,24 +752,23 @@ PATCH /v2/subscriptions/{subscriptionId}
 }
 ```
 
-**レスポンス**: `204 No Content`
-### サブスクリプションの削除
+**レスポンス**: `204 No Content`### サブスクリプションの削除
 
 ```http
 DELETE /v2/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張機能)
 
-認証が有効になっている場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みると、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
 
 ---
 
-## 登録
+## Registrations
 
-登録は外部コンテキストプロバイダを登録し、エンティティ情報のソースを管理します。
+Registration は外部コンテキストプロバイダを登録し、エンティティ情報のソースを管理します。
 
-### 登録の作成
+### Registration の作成
 
 ```http
 POST /v2/registrations
@@ -791,9 +797,9 @@ POST /v2/registrations
 
 **リクエストフィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `description` | string | - | 登録の説明 |
+| `description` | string | - | Registration の説明 |
 | `dataProvided.entities` | array | ✓ | 対象エンティティ (id、idPattern、type) |
 | `dataProvided.attrs` | array | - | 提供する属性名 |
 | `provider.http.url` | string | ✓ | プロバイダ URL |
@@ -802,7 +808,7 @@ POST /v2/registrations
 | `mode` | string | - | 転送モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`)。NGSI-LD 互換拡張 |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /v2/registrations/{registrationId}`### 登録の一覧取得
+- ステータス: `201 Created`- ヘッダー: `Location: /v2/registrations/{registrationId}`### Registration 一覧の取得
 
 ```http
 GET /v2/registrations
@@ -810,7 +816,7 @@ GET /v2/registrations
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
+| パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
 | `limit` | integer | 取得する結果の数 | 20 |
 | `offset` | integer | オフセット | 0 |
@@ -834,13 +840,13 @@ GET /v2/registrations
 ]
 ```
 
-### 登録の取得
+### Registration の取得
 
 ```http
 GET /v2/registrations/{registrationId}
 ```
 
-### 登録の更新
+### Registration の更新
 
 ```http
 PATCH /v2/registrations/{registrationId}
@@ -854,7 +860,7 @@ PATCH /v2/registrations/{registrationId}
 }
 ```
 
-**レスポンス**: `204 No Content`### 登録の削除
+**レスポンス**: `204 No Content`### Registration の削除
 
 ```http
 DELETE /v2/registrations/{registrationId}
@@ -862,17 +868,17 @@ DELETE /v2/registrations/{registrationId}
 
 **レスポンス**: `204 No Content`### 所有権検証 (GeonicDB 拡張)
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、Registration の更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
 
 ---
 
 ## フェデレーション (クエリ転送 / 更新転送)
 
-登録情報に基づいて、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合して返します。また、更新も転送します。
+Registration に基づき、GeonicDB はクエリを外部コンテキストプロバイダに転送し、結果を統合して返すとともに、更新も転送します。
 
 ### フェデレーションの仕組み
 
-エンティティをクエリする際、一致する登録情報が存在する場合、そのプロバイダーにも並行してクエリが送信され、結果がマージされて返されます。
+エンティティをクエリする際、マッチする Registration が存在すると、そのプロバイダに対しても並行してクエリが送信され、結果がマージされて返されます。
 
 ```text
 Client → Context Broker
@@ -884,18 +890,18 @@ Client → Context Broker
                         └── Results merged → returned to client
 ```
 
-### 登録モード
+### Registration モード
 
 | モード | 動作 |
 |------|----------|
-| `inclusive` | ローカルとリモートの両方の結果を返します (デフォルト) |
-| `exclusive` | リモートの結果のみを返します (ローカルデータは無視されます) |
-| `redirect` | 303 リダイレクト URL を返します |
-| `auxiliary` | ローカルデータが優先され、リモートは不足データを補完します |
+| `inclusive` | ローカルとリモート両方の結果を返す (デフォルト) |
+| `exclusive` | リモートの結果のみを返す (ローカルデータは無視される) |
+| `redirect` | 303 リダイレクト URL を返す |
+| `auxiliary` | ローカルデータを優先し、不足データをリモートで補完する |
 
 ### フェデレーションの例
 
-1. 外部プロバイダーを登録します:
+1. 外部プロバイダを登録する:
 
 ```bash
 curl -X POST "http://localhost:3000/v2/registrations" \
@@ -913,7 +919,7 @@ curl -X POST "http://localhost:3000/v2/registrations" \
   }'
 ```
 
-2. クエリ時にフェデレーションが自動的に行われます:
+2. クエリ時に自動的にフェデレーションが実行される:
 
 ```bash
 curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
@@ -924,7 +930,7 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 ### 更新転送
 
-エンティティを更新または削除する際、一致する登録情報が存在する場合、更新もそのプロバイダーに並行して転送されます。
+エンティティを更新または削除する際、マッチする Registration が存在すると、そのプロバイダに対しても並行して更新が転送されます。
 
 **サポートされる更新操作**
 
@@ -940,24 +946,24 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 | モード | 動作 |
 |------|----------|
-| `inclusive` | ローカルとリモートの両方を更新します |
-| `exclusive` | リモートのみを更新します (ローカルは更新されません) |
-| `redirect` | 303 リダイレクト URL を返します (ローカルは更新されません) |
-| `auxiliary` | ローカルのみを更新します (リモートは読み取り専用) |
+| `inclusive` | ローカルとリモート両方を更新する |
+| `exclusive` | リモートのみを更新する (ローカルは更新されない) |
+| `redirect` | 303 リダイレクト URL を返す (ローカルは更新されない) |
+| `auxiliary` | ローカルのみを更新する (リモートは読み取り専用) |
 
-### エラー処理
+### エラーハンドリング
 
 | シナリオ | 動作 |
 |----------|----------|
-| プロバイダー接続失敗 | 警告をログに記録し、ローカル結果のみを返します |
-| プロバイダータイムアウト | 警告をログに記録し、ローカル結果のみを返します |
-| 排他モードですべてのプロバイダーが失敗 | 502 エラーを返します (オプション) |
+| プロバイダ接続失敗 | 警告をログに記録し、ローカル結果のみを返す |
+| プロバイダタイムアウト | 警告をログに記録し、ローカル結果のみを返す |
+| exclusive モードで全プロバイダが失敗 | 502 エラーを返す (オプション) |
 
 ---
 
 ## エンティティタイプ
 
-### タイプ一覧
+### タイプ一覧の取得
 
 ```http
 GET /v2/types
@@ -967,8 +973,8 @@ GET /v2/types
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `options=count` | エンティティ数を含めます |
-| `options=values` | 属性の詳細を含めます |
+| `options=count` | エンティティ数を含める |
+| `options=values` | 属性の詳細を含める |
 
 **レスポンス例**
 
@@ -1006,18 +1012,18 @@ GET /v2/types/{typeName}
 
 ---
 
-## HTTP キャッシュコントロール
+## HTTP キャッシュ制御
 
-GET エンドポイントは、エンドポイントのクラスごとにキャッシュ関連のヘッダーを返します:
+GET エンドポイントは、エンドポイントクラスごとにキャッシュ関連のヘッダーを返します:
 
-### データエンドポイント (エンティティ、サブスクリプション、登録) — 完全な RFC 7232 + RFC 7234 サポート
+### データエンドポイント (エンティティ、サブスクリプション、レジストレーション) — 完全な RFC 7232 + RFC 7234 サポート
 
 | ヘッダー | 値 | 目的 |
 |--------|-------|---------|
-| `ETag` | `W/"..."` | 弱いバリデーター。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
+| `ETag` | `W/"..."` | 弱い検証子。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと合計カウントおよびスコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
 | `Last-Modified` | RFC 1123 HTTP-date | 結果セット内の最新の `modifiedAt` のタイムスタンプ。 |
-| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュ向けのテナント + 認証 + コンテンツネゴシエーション分離。 |
+| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制します。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュ用のテナント + 認証 + コンテントネゴシエーションの分離。 |
 
 条件付きリクエストがサポートされています:
 
@@ -1025,18 +1031,18 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 |----------------|----------|
 | `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified` (空のボディ) を返します。 |
 | `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。 |
-| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします。 |
+| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` に上書きします。 |
 
-### メタエンドポイント (タイプ) — Cache-Control + Vary のみ (ETag なし / 304 なし)
+### メタエンドポイント (タイプ) — Cache-Control + Vary のみ (ETag / 304 なし)
 
 | ヘッダー | 値 | 目的 |
 |--------|-------|---------|
 | `Cache-Control` | `max-age=60, stale-while-revalidate=120` | バックグラウンド再検証を伴う短期キャッシング。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証分離。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証の分離。 |
 
-メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしていません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
+メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
 
-完全なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
+完全なセマンティクスについては、[API.md §HTTP キャッシュ制御](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
 
 ---
 
@@ -1045,21 +1051,21 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 | ステータスコード | エラーコード | 説明 |
 |-------------|------------|-------------|
 | 400 | BadRequest | 無効なリクエストパラメータまたはボディ |
-| 400 | InvalidModification | 無効な属性変更 (例: id や type の変更) |
+| 400 | InvalidModification | 無効な属性の変更（例: id や type の変更） |
 | 401 | Unauthorized | 認証が必要、またはトークンが無効 |
 | 403 | Forbidden | 権限不足 |
-| 404 | NotFound | エンティティ、サブスクリプションなどが見つかりません |
-| 405 | MethodNotAllowed | HTTP メソッドが許可されていません |
-| 409 | AlreadyExists | エンティティが既に存在します (POST 作成時) |
-| 409 | TooManyResults | 複数のエンティティが一致しました (type が指定されていない場合) |
-| 411 | ContentLengthRequired | Content-Length ヘッダーが必要です |
-| 413 | RequestEntityTooLarge | リクエストボディが大きすぎます |
+| 404 | NotFound | エンティティ、サブスクリプションなどが見つからない |
+| 405 | MethodNotAllowed | HTTP メソッドが許可されていない |
+| 409 | AlreadyExists | エンティティが既に存在する（POST による作成時） |
+| 409 | TooManyResults | 複数のエンティティが一致（type が指定されていない場合） |
+| 411 | ContentLengthRequired | Content-Length ヘッダが必要 |
+| 413 | RequestEntityTooLarge | リクエストボディが大きすぎる |
 | 415 | UnsupportedMediaType | サポートされていない Content-Type |
-| 422 | Unprocessable | エンティティフォーマットが無効です |
-| 429 | TooManyRequests | レート制限を超過しました |
+| 422 | Unprocessable | エンティティの形式が無効 |
+| 429 | TooManyRequests | レート制限を超過 |
 | 500 | InternalError | 内部サーバーエラー |
 
-**エラーレスポンスフォーマット**
+**エラーレスポンス形式**
 
 ```json
 {
@@ -1072,65 +1078,65 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 
 ## エンドポイントリファレンス
 
-FIWARE NGSIv2 互換の Context Broker API です。
+FIWARE NGSIv2 互換 Context Broker API。
 
 ### 共通仕様
 
-- **Content-Type**: `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
+- **Content-Type**: `application/json`- **認証**: `AUTH_ENABLED=true` の場合に必要
 - **テナント分離**: `Fiware-Service` ヘッダーによるテナント分離
-- **ページネーション**: `limit`/`offset` パラメータを使用。総数を取得するには `options=count` を使用
+- **ページネーション**: `limit`/`offset` パラメータ; 総数を取得するには `options=count` を使用
 
 ### エンティティ操作
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/entities` | GET | エンティティ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/entities` | POST | エンティティの作成 | 201 | 400, 401, 409, 415 | - |
-| `/v2/entities/{entityId}` | GET | エンティティの取得 | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}` | DELETE | エンティティの削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | GET | 属性のみを取得 (id/type フィールドなし) | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | PATCH | 属性の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | POST | 属性の追加 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | PUT | 属性の置換 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | GET | 属性の取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | PUT | 属性の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | DELETE | 属性の削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET | 属性値の取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT | 属性値の更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities` | GET | エンティティ一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/entities` | POST | エンティティ作成 | 201 | 400, 401, 409, 415 | - |
+| `/v2/entities/{entityId}` | GET | エンティティ取得 | 200 | 400, 401, 404 | - |
+| `/v2/entities/{entityId}` | DELETE | エンティティ削除 | 204 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs` | GET | 属性のみ取得 (id/type フィールドなし) | 200 | 400, 401, 404 | - |
+| `/v2/entities/{entityId}/attrs` | PATCH | 属性更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs` | POST | 属性追加 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs` | PUT | 属性置換 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}` | GET | 属性取得 | 200 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}` | PUT | 属性更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}` | DELETE | 属性削除 | 204 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET | 属性値取得 | 200 | 401, 404 | - |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT | 属性値更新 | 204 | 400, 401, 404, 415 | - |
 
 ### タイプ操作
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/types` | GET | タイプ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/types/{typeName}` | GET | タイプ詳細の取得 | 200 | 401, 404 | - |
+| `/v2/types` | GET | タイプ一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/types/{typeName}` | GET | タイプ詳細取得 | 200 | 401, 404 | - |
 
 ### サブスクリプション操作
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/subscriptions` | GET | サブスクリプション一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/subscriptions` | POST | サブスクリプションの作成 | 201 | 400, 401, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | GET | サブスクリプションの取得 | 200 | 401, 404 | - |
-| `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプションの更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプションの削除 | 204 | 401, 404 | - |
+| `/v2/subscriptions` | GET | サブスクリプション一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/subscriptions` | POST | サブスクリプション作成 | 201 | 400, 401, 415 | - |
+| `/v2/subscriptions/{subscriptionId}` | GET | サブスクリプション取得 | 200 | 401, 404 | - |
+| `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプション更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプション削除 | 204 | 401, 404 | - |
 
-### 登録操作(フェデレーション)
+### 登録操作 (フェデレーション)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/registrations` | GET | 登録一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/registrations` | POST | 登録の作成 | 201 | 400, 401, 415 | - |
-| `/v2/registrations/{registrationId}` | GET | 登録の取得 | 200 | 401, 404 | - |
-| `/v2/registrations/{registrationId}` | PATCH | 登録の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/registrations/{registrationId}` | DELETE | 登録の削除 | 204 | 401, 404 | - |
+| `/v2/registrations` | GET | 登録一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/registrations` | POST | 登録作成 | 201 | 400, 401, 415 | - |
+| `/v2/registrations/{registrationId}` | GET | 登録取得 | 200 | 401, 404 | - |
+| `/v2/registrations/{registrationId}` | PATCH | 登録更新 | 204 | 400, 401, 404, 415 | - |
+| `/v2/registrations/{registrationId}` | DELETE | 登録削除 | 204 | 401, 404 | - |
 
 ### バッチ操作
 
-> **注意**: バッチ操作(クエリを除く)は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています(デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
+> **注意**: バッチ操作 (クエリを除く) は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティまでに制限されています (デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/op/update` | POST | バッチ更新(最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
+| `/v2/op/update` | POST | バッチ更新 (最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
 | `/v2/op/query` | POST | バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
-| `/v2/op/notify` | POST | 通知の受信 | 200 | 400, 401, 415 | - |
+| `/v2/op/notify` | POST | 通知受信 | 200 | 400, 401, 415 | - |

--- a/docs/ja/changelog.md
+++ b/docs/ja/changelog.md
@@ -59,7 +59,6 @@ outline: deep
     - `tests/unit/infrastructure/sam-template.test.ts` で `infrastructure/template.yaml` の最小構造を検証 (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction が EventBridgeRule で 3 種の detail-type を listen していることを機械的に確認)
     - `tests/unit/handlers/rules/processor.test.ts` で新規 handler 単体の挙動 (3 種イベント委譲・secondary region スキップ・エラー握り潰し・タイムアウト) を検証
   - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
-
 ## [0.6.0] — 2026-05-01
 
 ### 2026-05-01
@@ -625,8 +624,7 @@ outline: deep
   - 暗号化/非暗号化テナントの後方互換共存
   - Temporal/Snapshot リポジトリの暗号化統合
   - SAM テンプレート: KMS IAM ポリシー、DynamoDB SSE 設定、`EncryptionEnabled` パラメータ追加
-  - 依存追加: `@aws-sdk/client-kms`
-### 2026-02-25
+  - 依存追加: `@aws-sdk/client-kms`### 2026-02-25
 - **Feat**: マルチリージョン HA アーキテクチャ Phase 1+2 (#557)
   - Active-Passive 構成 (Primary: ap-northeast-1, Secondary: ap-northeast-3)
   - ヘルスチェック強化: `/health`、`/health/live`、`/health/ready` に `region`、`regionRole` を追加

--- a/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
+++ b/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
@@ -5,13 +5,13 @@ outline: deep
 ---
 # NGSIv2 / NGSI-LD プロトコル分離
 
-GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートしています。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルごとに分離されています** -- NGSIv2 で作成されたエンティティは NGSIv2 でのみアクセス可能で、NGSI-LD についても同様です。
+GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートします。両 API は統一された内部ストレージフォーマットを共有しますが、**エンティティはプロトコルごとに分離されています** -- NGSIv2 で作成されたエンティティは NGSIv2 経由でのみアクセス可能で、NGSI-LD も同様です。
 
 ## 目次
 
 - [概要](#概要)
-- [統一された内部形式](#統一された内部形式)
-- [プロトコルアイソレーション](#プロトコルアイソレーション)
+- [統一された内部フォーマット](#統一された内部フォーマット)
+- [プロトコル分離](#プロトコル分離)
 - [属性タイプマッピングテーブル](#属性タイプマッピングテーブル)
 - [システム属性の違い](#システム属性の違い)
 - [出力フォーマットの違い](#出力フォーマットの違い)
@@ -25,7 +25,7 @@ GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API 
 
 ## 概要
 
-GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートしています。各エンティティには、それを作成したプロトコルのタグが付けられ、2 つの API 間の厳格な分離が保証されます。
+GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートします。各エンティティは作成時に使用されたプロトコルでタグ付けされ、2 つの API 間の厳密な分離を保証します。
 
 ### アーキテクチャ
 
@@ -35,23 +35,23 @@ NGSIv2 API (/v2) ──────> [protocol: 'ngsiv2'] ──┐
 NGSI-LD API (/ngsi-ld/v1) ──> [protocol: 'ngsild'] ┘
 ```
 
-- 両方の API は同じ MongoDB ストレージと統一された内部形式を共有します
-- 各エンティティには作成時に設定される `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)があります
+- 両方の API は同じ MongoDB ストレージと統一された内部フォーマットを共有します
+- 各エンティティは作成時に設定される `protocol` フィールド (`'ngsiv2'` または `'ngsild'`) を持ちます
 - クエリはプロトコルでフィルタリングされます: NGSIv2 API は `protocol: 'ngsiv2'` エンティティのみを返し、NGSI-LD API は `protocol: 'ngsild'` エンティティのみを返します
 - `protocol` フィールドを持たない既存のエンティティは `'ngsild'` として扱われます
 
 ### メリット
 
-- **プロトコル分離** - 明確な境界により、意図しないクロスプロトコルデータ漏洩を防ぎ、各 API が仕様に準拠したエンティティのみを返すことを保証します
-- **仕様準拠** - 各 API は独自の仕様内で厳密に動作し、形式変換によるエッジケースを回避します
+- **プロトコル分離** - 明確な境界により、意図しないクロスプロトコルのデータ漏洩を防ぎ、各 API が仕様に準拠したエンティティのみを返すことを保証します
+- **仕様準拠** - 各 API は独自の仕様内で厳密に動作し、フォーマット変換によるエッジケースを回避します
 - **既存システムとの統合** - NGSIv2 と NGSI-LD のワークロードを干渉なく並行して実行できます
-- **API 選択の自由** - 各ユースケースに最適な API を選択できます。クロスプロトコルのニーズには Federation を使用します
+- **API 選択の自由** - 各ユースケースに最適な API を選択でき、クロスプロトコルのニーズにはフェデレーションを使用します
 
 ---
 
-## 統一された内部形式
+## 統合内部フォーマット
 
-GeonicDB は、両方の API からのデータを統一された内部形式に変換します。
+GeonicDB は両方の API からのデータを統合された内部フォーマットに変換します。
 
 ### 内部エンティティ構造
 
@@ -82,7 +82,7 @@ interface EntityMetadata {
 }
 ```
 
-### MongoDB ストレージ形式
+### MongoDB ストレージフォーマット
 
 ```typescript
 interface EntityDocument {
@@ -108,28 +108,28 @@ interface EntityDocument {
 
 ---
 
-## プロトコルアイソレーション
+## プロトコル分離
 
-エンティティは、それらを作成したプロトコルによって分離されています。各エンティティには `protocol` フィールド (`'ngsiv2'` または `'ngsild'`) があり、どの API がそれにアクセスできるかを決定します。
+エンティティは、それを作成したプロトコルによって分離されます。各エンティティには `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)があり、どの API がアクセスできるかを決定します。
 
 ### ルール
 
 | 操作 | NGSIv2 エンティティ (`protocol: 'ngsiv2'`) | NGSI-LD エンティティ (`protocol: 'ngsild'`) |
 |-----------|--------------------------------------|---------------------------------------|
-| NGSIv2 GET/LIST | 可視 | 不可視 |
-| NGSIv2 UPDATE/DELETE | 許可 | 見つからない (404) |
-| NGSI-LD GET/LIST | 不可視 | 可視 |
-| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可 |
+| NGSIv2 GET/LIST | 表示される | 表示されない |
+| NGSIv2 UPDATE/DELETE | 許可される | 見つからない (404) |
+| NGSI-LD GET/LIST | 表示されない | 表示される |
+| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可される |
 
 ### レガシーエンティティ
 
-プロトコルアイソレーション導入以前に作成されたエンティティ (つまり、データベースに `protocol` フィールドがないもの) は `'ngsild'` として扱われます。これらは NGSI-LD API を介してのみアクセス可能です。
+プロトコル分離の導入前に作成されたエンティティ(つまり、データベースに `protocol` フィールドがないもの)は `'ngsild'` として扱われます。これらは NGSI-LD API を介してのみアクセス可能です。
 
 ### フェデレーション経由のクロスプロトコルアクセス
 
-直接的なクロスプロトコルアクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション** (Context Source Registration) を使用して、一方の GeonicDB インスタンスを他方のプロトコルのコンテキストプロバイダーとして登録してください。詳細は [フェデレーション](#federation) セクションを参照してください。
+直接的なクロスプロトコルアクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション**(コンテキストソース登録)を使用して、一方の GeonicDB インスタンスを他方のプロトコルのコンテキストプロバイダーとして登録してください。詳細については、[フェデレーション](#フェデレーション)セクションを参照してください。
 
-### 例: プロトコルアイソレーションの動作
+### 例:プロトコル分離の動作
 
 ```bash
 # Create an entity via NGSIv2
@@ -151,7 +151,7 @@ curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001 -H "Fiware-S
 
 ## 属性タイプマッピングテーブル
 
-GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ、NGSI-LD タイプを変換します。
+GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ、NGSI-LD タイプ間で変換を行います。
 
 ### 基本データタイプ
 
@@ -176,18 +176,18 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 | NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
 |-------------|---------------|--------------|-------------|
 | `geo:json` | `GeoJSON` | `GeoProperty` | GeoJSON (Point、LineString、Polygon) |
-| `geo:point` | `GeoJSON` (Point) | `GeoProperty` | 緯度/経度ポイント |
+| `geo:point` | `GeoJSON` (Point) | `GeoProperty` | 緯度/経度座標 |
 
 ### NGSI-LD 固有タイプ
 
-以下の NGSI-LD 固有タイプは内部的に保持されますが、NGSIv2 API では `Property` として扱われます。
+以下の NGSI-LD 固有タイプは内部的には保持されますが、NGSIv2 API では `Property` として扱われます。
 
 | NGSI-LD タイプ | 内部タイプ | NGSIv2 変換 | 説明 |
 |--------------|---------------|-------------------|-------------|
 | `Relationship` | `Relationship` | `Relationship` (カスタムタイプ) | エンティティ参照 (`object` プロパティを含む) |
 | `LanguageProperty` | `LanguageProperty` | `StructuredValue` | 多言語文字列 (`languageMap` プロパティを含む) |
 | `JsonProperty` | `JsonProperty` | `Object` | JSON データ (`json` プロパティを含む) |
-| `VocabProperty` | `VocabProperty` | `Object` | ボキャブラリーデータ (`vocab` または `vocabMap` プロパティを含む) |
+| `VocabProperty` | `VocabProperty` | `Object` | 語彙データ (`vocab` または `vocabMap` プロパティを含む) |
 | `ListProperty` | `ListProperty` | `Array` | 順序付き配列 (`valueList` プロパティを含む) |
 | `ListRelationship` | `ListRelationship` | `Array` | エンティティ参照の配列 (`objectList` プロパティを含む) |
 
@@ -203,14 +203,14 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ## システム属性の違い
 
-エンティティメタデータ (作成および変更タイムスタンプ) は、API によって異なる名前を使用します。
+エンティティのメタデータ (作成および変更のタイムスタンプ) は、API によって異なる名前を使用します。
 
-### NGSIv2 システム属性
+### NGSIv2 のシステム属性
 
-| 属性名 | タイプ | 説明 |
+| 属性名 | 型 | 説明 |
 |----------------|------|-------------|
-| `dateCreated` | `DateTime` | エンティティ作成タイムスタンプ (ISO 8601) |
-| `dateModified` | `DateTime` | エンティティ最終変更タイムスタンプ (ISO 8601) |
+| `dateCreated` | `DateTime` | エンティティ作成のタイムスタンプ (ISO 8601) |
+| `dateModified` | `DateTime` | エンティティ最終更新のタイムスタンプ (ISO 8601) |
 
 **例 (NGSIv2 レスポンス、`options=dateCreated,dateModified` 使用時):**
 
@@ -233,14 +233,14 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 }
 ```
 
-### NGSI-LD システム属性
+### NGSI-LD のシステム属性
 
-| 属性名 | タイプ | 説明 |
+| 属性名 | 型 | 説明 |
 |----------------|------|-------------|
-| `createdAt` | ISO 8601 文字列 | エンティティ作成タイムスタンプ |
-| `modifiedAt` | ISO 8601 文字列 | エンティティ最終変更タイムスタンプ |
+| `createdAt` | ISO 8601 文字列 | エンティティ作成のタイムスタンプ |
+| `modifiedAt` | ISO 8601 文字列 | エンティティ最終更新のタイムスタンプ |
 
-**注意:** `pick` パラメータを使用した場合、レスポンスには明示的にリクエストされた属性と、常に存在する `@context`、`id`、`type` が含まれます。ただし、`createdAt` と `modifiedAt` は `pick` を使用しても返されません。これらのシステム属性には `sysAttrs` オプションが必要です。
+**注意:** `pick` パラメータを使用する場合、レスポンスには明示的に要求された属性と、`@context`、`id`、`type` (常に存在) が含まれます。ただし、`createdAt` および `modifiedAt` は、`pick` を使用しても返されません。これらのシステム属性には `sysAttrs` オプションが必要です。
 
 **例 (NGSI-LD レスポンス、システム属性は常に含まれる):**
 
@@ -272,16 +272,16 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ---
 
-## 出力フォーマットの違い
+## 出力形式の違い
 
-各 API は複数のレスポンスフォーマットをサポートしています。
+各 API は複数のレスポンス形式をサポートしています。
 
-### NGSIv2 の出力フォーマット
+### NGSIv2 の出力形式
 
-| フォーマット | options パラメータ | 説明 |
+| 形式 | options パラメータ | 説明 |
 |--------|-------------------|-------------|
-| **normalized** (デフォルト) | (なし) | タイプとメタデータを含む完全フォーマット |
-| **keyValues** | `options=keyValues` | キー・バリューペアのみ (メタデータなし) |
+| **normalized** (デフォルト) | (なし) | 型とメタデータを含む完全形式 |
+| **keyValues** | `options=keyValues` | キーと値のペアのみ (メタデータなし) |
 | **values** | `options=values` | 属性値の配列のみ |
 
 **例:**
@@ -297,13 +297,13 @@ curl http://localhost:3000/v2/entities/Room1?options=keyValues
 curl 'http://localhost:3000/v2/entities?type=Room&options=values&attrs=temperature,humidity'
 ```
 
-### NGSI-LD の出力フォーマット
+### NGSI-LD の出力形式
 
-| フォーマット | Accept ヘッダー | 説明 |
+| 形式 | Accept ヘッダー | 説明 |
 |--------|---------------|-------------|
-| **normalized** (デフォルト) | `application/ld+json` | タイプとメタデータを含む完全フォーマット |
-| **concise** | `application/ld+json` + `options=concise` | 簡潔フォーマット (省略記法) |
-| **keyValues** | `application/ld+json` + `options=keyValues` | キー・バリューペアのみ |
+| **normalized** (デフォルト) | `application/ld+json` | 型とメタデータを含む完全形式 |
+| **concise** | `application/ld+json` + `options=concise` | 簡潔形式 (省略記法) |
+| **keyValues** | `application/ld+json` + `options=keyValues` | キーと値のペアのみ |
 
 **例:**
 
@@ -320,7 +320,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1?options=k
 
 ---
 
-## 共有機能
+## 共通機能
 
 以下の機能は両方の API で共有されています。
 
@@ -328,11 +328,11 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1?options=k
 
 | 機能 | NGSIv2 | NGSI-LD | 説明 |
 |---------|--------|---------|-------------|
-| **シンプルクエリ** | `q` パラメータ | `q` パラメータ | 属性値フィルタ (例: `temperature>20;humidity<80`) |
-| **メタデータクエリ** | `mq` パラメータ | `q` パラメータ (メタデータもクエリ可能) | メタデータフィルタ |
-| **スコープクエリ** | `Fiware-ServicePath` ヘッダー (スコープから独立) | `scopeQ` パラメータ | スコープ階層フィルタ |
+| **シンプルクエリ** | `q` パラメータ | `q` パラメータ | 属性値フィルタ(例: `temperature>20;humidity<80`) |
+| **メタデータクエリ** | `mq` パラメータ | `q` パラメータ(メタデータもクエリ可能) | メタデータフィルタ |
+| **スコープクエリ** | `Fiware-ServicePath` ヘッダー(スコープから独立) | `scopeQ` パラメータ | スコープ階層フィルタ |
 
-**基本例:**
+**基本的な例:**
 
 ```bash
 # NGSIv2: Entities with temperature greater than 20
@@ -344,18 +344,18 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?type=Room&q=temperature>20'
 
 #### メタデータクエリ (mq) の詳細
 
-NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートしています。
+NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートします。
 
-**サポートされる演算子:**
+**サポートされている演算子:**
 
 | 演算子 | 説明 | 例 |
 |----------|-------------|---------|
 | `==` | 等しい | `mq=temperature.accuracy==0.95` |
 | `!=` | 等しくない | `mq=temperature.accuracy!=0` |
-| `>`、`<`、`>=`、`<=` | 比較演算子 | `mq=temperature.accuracy>0.9` |
+| `>`, `<`, `>=`, `<=` | 比較演算子 | `mq=temperature.accuracy>0.9` |
 | `~=` | パターンマッチ | `mq=temperature.unit~=Cel.*` |
-| `..` | 範囲 (両端を含む) | `mq=temperature.accuracy==0.9..1.0` |
-| `,` | リスト (OR) | `mq=temperature.unit==Celsius,Fahrenheit` |
+| `..` | 範囲(両端含む) | `mq=temperature.accuracy==0.9..1.0` |
+| `,` | リスト(OR) | `mq=temperature.unit==Celsius,Fahrenheit` |
 | `;` | AND 条件 | `mq=temperature.accuracy>0.9;temperature.unit==Celsius` |
 | `|` | OR 条件 | `mq=temperature.accuracy>0.9|humidity.accuracy>0.8` |
 
@@ -377,16 +377,16 @@ curl 'http://localhost:3000/v2/entities?type=Room&mq=temperature.accuracy>0.9;te
 
 #### スコープクエリ (scopeQ) の詳細
 
-NGSI-LD の `scopeQ` パラメータは、エンティティのスコープ階層に対するクエリをサポートしています。
+NGSI-LD の `scopeQ` パラメータは、エンティティのスコープ階層に対するクエリをサポートします。
 
-**サポートされる演算子:**
+**サポートされている演算子:**
 
 | 演算子 | 説明 | 例 |
 |----------|-------------|---------|
 | `/path` | 完全一致 | `scopeQ=/Japan/Tokyo` |
-| `/path/+` | 1 階層下のみ | `scopeQ=/Japan/+` (例: Tokyo) |
+| `/path/+` | 1 レベル下のみ | `scopeQ=/Japan/+` (例: Tokyo) |
 | `/path/#` | すべての子孫 | `scopeQ=/Japan/#` (例: Tokyo、Tokyo/Shibuya) |
-| `;` | AND 条件 (複数のスコープ) | `scopeQ=/Japan/Tokyo;/IoT` |
+| `;` | AND 条件(複数スコープ) | `scopeQ=/Japan/Tokyo;/IoT` |
 
 **例:**
 
@@ -408,7 +408,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo;/IoT'
 
 | ジオクエリ演算子 | NGSIv2 | NGSI-LD | 説明 |
 |--------------------|--------|---------|-------------|
-| `near` | ✅ | ✅ | 指定された地点の近く |
+| `near` | ✅ | ✅ | 指定した点の近く |
 | `coveredBy` | ✅ | ✅ | 領域内に完全に含まれる |
 | `within` | ✅ | ✅ | 領域と交差するか領域内に含まれる |
 | `intersects` | ✅ | ✅ | 領域と交差する |
@@ -428,7 +428,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 
 | ヘッダー | NGSIv2 | NGSI-LD | 説明 |
 |--------|--------|---------|-------------|
-| **合計数** | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数 |
+| **総数** | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数 |
 | **次のリンク** | `Link` (rel="next") | `Link` (rel="next") | 次のページへのリンク |
 
 詳細については、[ページネーション](/ja/api-reference/pagination)を参照してください。
@@ -438,23 +438,23 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 | 通知方法 | NGSIv2 | NGSI-LD | 説明 |
 |--------------------|--------|---------|-------------|
 | **HTTP Webhook** | ✅ | ✅ | REST エンドポイントへの POST |
-| **MQTT** | ✅ | ✅ | MQTT ブローカーへの発行 (QoS 0/1/2、TLS) |
+| **MQTT** | ✅ | ✅ | MQTT ブローカーへのパブリッシュ(QoS 0/1/2、TLS) |
 | **WebSocket** | ✅ | ✅ | リアルタイムイベントストリーム |
 
-### 5. フェデレーション (コンテキストソース登録)
+### 5. Federation (コンテキストソース登録)
 
 | 機能 | NGSIv2 | NGSI-LD | 説明 |
 |---------|--------|---------|-------------|
-| **登録 API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダー登録 |
+| **Registration API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダー登録 |
 | **並列クエリ** | ✅ | ✅ | 複数のプロバイダーへの同時クエリ |
-| **結果のマージ** | ✅ | ✅ | ローカルとリモートの結果のマージ |
+| **結果のマージ** | ✅ | ✅ | ローカルとリモート結果のマージ |
 | **ループ検出** | ✅ | ✅ | `Via` ヘッダーによるループ検出 |
 
 ---
 
 ## NGSI-LD 固有の機能
 
-以下の機能は NGSI-LD API でのみサポートされており、NGSIv2 API では直接利用できません。
+以下の機能は NGSI-LD API のみでサポートされており、NGSIv2 API では直接利用できません。
 
 ### 1. Relationship
 
@@ -497,7 +497,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 
 **NGSI-LD で `lang=ja` を使用する場合:**
 
-`lang` クエリパラメータを使用すると、LanguageProperty は標準の Property に変換され、指定された言語の値が `value` フィールドに設定されます。
+`lang` クエリパラメータを使用すると、LanguageProperty は標準的な Property に変換され、指定された言語の値が `value` フィールドに設定されます。
 
 ```bash
 curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
@@ -519,7 +519,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
 
 ### 3. Scope (スコープ階層)
 
-エンティティの論理階層を表します。
+エンティティの論理的な階層を表します。
 
 **NGSI-LD:**
 
@@ -531,7 +531,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
 }
 ```
 
-**Scope クエリ:**
+**スコープクエリ:**
 
 ```bash
 # All entities under /Japan/Tokyo
@@ -540,18 +540,18 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo'
 
 **NGSIv2 互換性:**
 
-- NGSIv2 は階層的なエンティティ管理のために `Fiware-ServicePath` ヘッダを使用します
-- `servicePath` は `?attrs=servicePath` 経由で組み込み属性として利用可能です
-- **servicePath と scope は独立した概念です (#964):** これらは自動的には同期されません
-  - NGSIv2 `Fiware-ServicePath` → DB に `servicePath` として保存されます (インフラレベルの分離)
-  - NGSI-LD `scope` → DB に `scope` として保存されます (ユーザ定義の論理階層)
-  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダを無視します
+- NGSIv2 は階層的なエンティティ管理に `Fiware-ServicePath` ヘッダーを使用
+- `servicePath` は `?attrs=servicePath` 経由で組み込み属性として利用可能
+- **servicePath と scope は独立した概念です (#964):** 自動的には同期されません
+  - NGSIv2 `Fiware-ServicePath` → DB では `servicePath` として保存 (インフラストラクチャレベルの分離)
+  - NGSI-LD `scope` → DB では `scope` として保存 (ユーザー定義の論理階層)
+  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダーを無視
 
-### 4. 属性プロジェクション (pick / omit パラメータ)
+### 4. 属性のプロジェクション (pick / omit パラメータ)
 
-NGSI-LD では、`pick` と `omit` クエリパラメータを使用して、レスポンスに含まれる属性を制御できます。
+NGSI-LD では、`pick` および `omit` クエリパラメータを使用して、レスポンスに含まれる属性を制御できます。
 
-#### pick パラメータ (属性選択)
+#### pick パラメータ (属性の選択)
 
 指定された属性のみをレスポンスに含めます。
 
@@ -580,7 +580,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?pick=temper
 }
 ```
 
-#### omit パラメータ (属性除外)
+#### omit パラメータ (属性の除外)
 
 指定された属性をレスポンスから除外します。
 
@@ -611,9 +611,9 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?omit=locati
 
 **注意事項:**
 
-- `pick` と `omit` を同時に使用することはできません
+- `pick` と `omit` は同時に使用できません
 - `pick` を使用する場合: `@context`、`id`、`type`、および指定された属性のみが含まれます。`createdAt` と `modifiedAt` は含まれません。
-- `omit` を使用する場合: 指定されたもの以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様に基づく)
+- `omit` を使用する場合: 指定された属性を除くすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様に準拠)
 
 **NGSIv2 互換性:**
 
@@ -627,7 +627,7 @@ curl 'http://localhost:3000/v2/entities/urn:ngsi-ld:Room:001?attrs=temperature,h
 
 ### 5. @context (JSON-LD コンテキスト)
 
-NGSI-LD では、エンティティに `@context` を含めることで語彙を定義します。
+NGSI-LD では、エンティティに `@context` を含めることで、ボキャブラリを定義します。
 
 **NGSI-LD:**
 
@@ -646,7 +646,7 @@ NGSI-LD では、エンティティに `@context` を含めることで語彙を
 **NGSIv2 互換性:**
 
 - NGSIv2 には `@context` の概念がありません
-- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API によって返されません
+- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API では返されません
 
 ---
 
@@ -656,24 +656,23 @@ NGSI-LD では、エンティティに `@context` を含めることで語彙を
 
 > **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント (`Fiware-Service`) とServicePath (`Fiware-ServicePath`) のスコープ内で一意です。エンティティ `type` は一意性制約の一部では**ありません**。
 
-これは、両方の API 間で ID のセマンティクスを統一するための意図的な設計上の決定です。
+これは、両方の API で ID セマンティクスを統一する意図的な設計決定です:
 
 - **NGSI-LD** はエンティティ ID を URI として扱い、本質的に一意です
-- **NGSIv2** (標準) は同じ ID を持つが異なるタイプのエンティティの共存を許可します — GeonicDB はこの動作を**サポートしていません**
+- **NGSIv2** (標準) では同じ ID で異なるタイプのエンティティが共存できますが、GeonicDB はこの動作を**サポートしません**
 
 **影響:**
-
-- **直接作成** (`POST /v2/entities`, `POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID を持つエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- **バッチ更新** (`POST /v2/op/update` と `append`/`appendStrict`): `entityId` のみでエンティティをマッチングします。属性は更新されますが、元の `type` は保持されます
-- **バッチ upsert** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティをマッチングします。属性は更新されます (タイプ処理は upsert セマンティクスに従います)
+- **直接作成** (`POST /v2/entities`、`POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID でエンティティを作成する場合 (異なる `type` であっても)、`409 AlreadyExists` が返されます
+- **バッチ更新** (`POST /v2/op/update` with `append`/`appendStrict`): `entityId` のみでエンティティを照合します。属性は更新されますが、元の `type` は保持されます
+- **バッチアップサート** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティを照合します。属性は更新されます (タイプの処理はアップサートセマンティクスに従います)
 - **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複する ID に対してエンティティごとのエラー詳細を含む `207` を返します
-- 同じ ID のエンティティ間のタイプの曖昧性解消のための NGSIv2 `?type=` パラメータは適用されなくなりました
+- 同一 ID のエンティティ間のタイプによる曖昧性解消のための NGSIv2 `?type=` パラメータは適用されなくなりました
 
-この統一により、NGSIv2 のタイプベースの曖昧性解消が NGSI-LD の一意 ID モデルと競合する相互運用性の問題のクラスが排除されます。
+この統一により、NGSIv2 のタイプベースの曖昧性解消が NGSI-LD の一意 ID モデルと競合する相互運用性の問題が解消されます。
 
 ### NGSI-LD URI 要件
 
-NGSI-LD 仕様では、エンティティ ID は URI 形式であることが推奨されています。
+NGSI-LD 仕様では、エンティティ ID を URI 形式にすることを推奨しています。
 
 **推奨形式 (URN):**
 
@@ -691,33 +690,33 @@ urn:ngsi-ld:WeatherObserved:Tokyo-2026-02-08
 
 **NGSIv2 互換性:**
 
-- NGSIv2 では任意の文字列を ID として使用できます (例: `Room1`, `sensor-abc`)
-- 使用する API に関係なく、一貫性と将来の移行のために URN 形式の使用が推奨されます
+- NGSIv2 では任意の文字列を ID として使用できます (例: `Room1`、`sensor-abc`)
+- 一貫性と将来の移行のために、どの API を使用する場合でも URN 形式の使用を推奨します
 
 **ベストプラクティス:**
 
 - NGSIv2 API を使用する場合でも、すべてのエンティティに URN 形式を使用してください
-- NGSIv2 から NGSI-LD に移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコル分離により API 間のアクセスができません)
+- NGSIv2 から NGSI-LD に移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコル分離により API 間のアクセスは防止されます)
 
 ---
 
-## Federation
+## フェデレーション
 
-GeonicDB のフェデレーション機能は、リモートコンテキストプロバイダのプロトコルを自動的に検出します。
+GeonicDB のフェデレーション機能は、リモートコンテキストプロバイダーのプロトコルを自動的に検出します。
 
-### プロトコルの自動検出
+### 自動プロトコル検出
 
-登録されたリモートプロバイダに対して、GeonicDB は以下の順序でプロトコルを検出します:
+登録されたリモートプロバイダーに対して、GeonicDB は以下の順序でプロトコルを検出します：
 
 1. **明示的な指定** - 登録時に `information.format` が指定されている場合、そのプロトコルが使用されます
-2. **自動検出** - URL パスからの自動検出:
+2. **自動検出** - URL パスからの自動検出：
    - `/v2/` を含む → NGSIv2
    - `/ngsi-ld/` を含む → NGSI-LD
-   - それ以外 → NGSIv2 (デフォルト)
+   - それ以外 → NGSIv2（デフォルト）
 
 ### NGSIv2 からのフェデレーション
 
-**NGSIv2 で登録:**
+**NGSIv2 で登録：**
 
 ```bash
 curl -X POST http://localhost:3000/v2/registrations \
@@ -738,22 +737,22 @@ curl -X POST http://localhost:3000/v2/registrations \
   }'
 ```
 
-**NGSIv2 でクエリすると、NGSI-LD プロバイダに自動的に転送されます:**
+**NGSIv2 でクエリすると、NGSI-LD プロバイダーへ自動的に転送されます：**
 
 ```bash
 curl http://localhost:3000/v2/entities/urn:ngsi-ld:Vehicle:V999 \
   -H "Fiware-Service: demo"
 ```
 
-**動作:**
+**動作：**
 
 1. GeonicDB は `urn:ngsi-ld:Vehicle:V999` がローカルに存在しないことを検出します
 2. 登録情報から `http://remote-provider.example.com/ngsi-ld/v1` を特定します
-3. NGSI-LD プロトコルを使用してクエリを転送します: `GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`4. レスポンスを NGSI-LD → 内部フォーマット → NGSIv2 に変換し、クライアントに返します
+3. NGSI-LD プロトコルを使用してクエリを転送します：`GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`4. NGSI-LD → 内部形式 → NGSIv2 とレスポンスを変換してクライアントに返します
 
 ### NGSI-LD からのフェデレーション
 
-**NGSI-LD で登録:**
+**NGSI-LD で登録：**
 
 ```bash
 curl -X POST http://localhost:3000/ngsi-ld/v1/csourceRegistrations \
@@ -773,65 +772,65 @@ curl -X POST http://localhost:3000/ngsi-ld/v1/csourceRegistrations \
   }'
 ```
 
-**NGSI-LD でクエリすると、NGSIv2 プロバイダに自動的に転送されます:**
+**NGSI-LD でクエリすると、NGSIv2 プロバイダーへ自動的に転送されます：**
 
 ```bash
 curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:S888 \
   -H "Fiware-Service: demo"
 ```
 
-**動作:**
+**動作：**
 
 1. GeonicDB は `urn:ngsi-ld:Sensor:S888` がローカルに存在しないことを検出します
 2. 登録情報から `http://legacy-system.example.com/v2` を特定します
-3. NGSIv2 プロトコルを使用してクエリを転送します: `GET /v2/entities/urn:ngsi-ld:Sensor:S888`4. レスポンスを NGSIv2 → 内部フォーマット → NGSI-LD に変換し、クライアントに返します
+3. NGSIv2 プロトコルを使用してクエリを転送します：`GET /v2/entities/urn:ngsi-ld:Sensor:S888`4. NGSIv2 → 内部形式 → NGSI-LD とレスポンスを変換してクライアントに返します
 
 ---
 
 ## ユースケースとベストプラクティス
 
-### どの API を使用すべきか？
+### どの API を使用すべきか?
 
 #### NGSIv2 を選択すべき場合
 
 - **既存の FIWARE Orion 互換システム** - レガシーシステムとの統合
 - **シンプルな IoT データ管理** - センサーデータの収集と可視化
-- **学習曲線が低い** - NGSI-LD よりもシンプルな仕様
-- **豊富な既存のドキュメントとツール** - 成熟した NGSIv2 エコシステム
+- **学習コストの低さ** - NGSI-LD よりもシンプルな仕様
+- **豊富な既存ドキュメントとツール** - 成熟した NGSIv2 エコシステム
 
-**推奨されるユースケース：**
+**推奨されるユースケース:**
 
 - IoT センサーネットワーク
-- 基本的なスマートシティデータ収集
+- 基本的なスマートシティのデータ収集
 - プロトタイピングと PoC
 
 #### NGSI-LD を選択すべき場合
 
-- **セマンティック Web / リンクトデータ** - JSON-LD と RDF の活用
+- **セマンティック Web / Linked Data** - JSON-LD と RDF の活用
 - **複雑なエンティティ関係** - Relationship と LanguageProperty の使用
 - **国際標準への準拠** - ETSI 標準に準拠したシステム
-- **将来の拡張性** - NGSI-LD 仕様は継続的に拡張されています
+- **将来の拡張性** - NGSI-LD 仕様は継続的に拡張されている
 
-**推奨されるユースケース：**
+**推奨されるユースケース:**
 
 - Smart Data Models を活用したデータカタログ
-- 多言語サポートが必要なシステム
+- 多言語サポートを必要とするシステム
 - エンティティ間の複雑な関係を表現する必要があるシステム
-- データ統合とオープンデータ公開
+- データ統合とオープンデータの公開
 
-#### 両方の API の同時実行
+#### 両方の API を同時に実行する
 
-GeonicDB は両方の API を同時にサポートしていますが、エンティティはプロトコルごとに分離されています。各 API は独自のエンティティセットで独立して動作します。
+GeonicDB は両方の API を同時にサポートしていますが、エンティティはプロトコルごとに分離されています。各 API は独自のエンティティセットに対して独立して動作します。
 
-**推奨されるアプローチ：**
+**推奨アプローチ:**
 
 1. **ユースケースごとに 1 つの API を選択** - 同じデータに対してプロトコルを混在させないでください。要件に基づいて NGSIv2 または NGSI-LD を選択し、それに従ってください
-2. **クロスプロトコルのニーズには Federation を使用** - NGSIv2 クライアントが NGSI-LD エンティティにアクセスする必要がある場合（またはその逆）、Federation を介してコンテキストソースを登録します
-3. **マイグレーションには再作成が必要** - エンティティを NGSIv2 から NGSI-LD に移行するには、NGSIv2 API からエクスポートし、NGSI-LD API を介して再作成します。自動的なクロスプロトコルマイグレーションはありません
+2. **プロトコル間のニーズには Federation を使用** - NGSIv2 クライアントが NGSI-LD エンティティにアクセスする必要がある場合(またはその逆)、Federation 経由でコンテキストソースを登録してください
+3. **移行には再作成が必要** - エンティティを NGSIv2 から NGSI-LD に移行するには、NGSIv2 API からエクスポートし、NGSI-LD API 経由で再作成してください。自動的なプロトコル間移行はありません
 
 ### ベストプラクティス
 
-#### 1. エンティティ ID に URN 形式を使用する
+#### 1. エンティティ ID には URN 形式を使用する
 
 **推奨:**
 
@@ -846,9 +845,9 @@ Room1
 sensor-abc
 ```
 
-理由: NGSI-LD 仕様に準拠し、両方の API で互換性を維持できます。
+理由: NGSI-LD 仕様に準拠し、両方の API 間で互換性を維持します。
 
-#### 2. 地理空間データに GeoJSON を使用する
+#### 2. 地理空間データには GeoJSON を使用する
 
 **推奨 (NGSIv2):**
 
@@ -878,11 +877,11 @@ sensor-abc
 }
 ```
 
-理由: ジオクエリは GeoJSON 形式のみをサポートしています。
+理由: ジオクエリは GeoJSON 形式のみをサポートします。
 
 #### 3. Smart Data Models を活用する
 
-GeonicDB は Smart Data Models の `@context` を自動補完します。
+GeonicDB は Smart Data Models `@context` を自動的に補完します。
 
 **推奨 (NGSI-LD):**
 
@@ -902,14 +901,14 @@ GeonicDB は Smart Data Models の `@context` を自動補完します。
 #### 4. 目的に応じてサブスクリプションを選択する
 
 | 目的 | 推奨チャネル | 理由 |
-|------|-------------|------|
-| Web アプリ (リアルタイム更新) | WebSocket | 低レイテンシ、サーバ不要 |
-| サーバ間連携 | HTTP Webhook | 信頼性、リトライ機能 |
+|---------|---------------------|--------|
+| Web アプリ (リアルタイム更新) | WebSocket | 低レイテンシ、サーバー不要 |
+| サーバー間統合 | HTTP Webhook | 信頼性、リトライ機能 |
 | IoT デバイス | MQTT | 軽量、QoS 保証 |
 
 #### 5. テナント分離を活用する
 
-`Fiware-Service` ヘッダを使用してテナントを分離します。
+`Fiware-Service` ヘッダーを使用してテナントを分離します。
 
 ```bash
 # Create entity in tenant "demo"
@@ -923,26 +922,26 @@ curl -X POST http://localhost:3000/v2/entities \
   -d '{...}'
 ```
 
-理由: 開発環境と本番環境の分離、顧客ごとのデータ分離が可能になります。
+理由: 開発環境と本番環境の分離、顧客ごとのデータ分離を可能にします。
 
 ---
 
 ## まとめ
 
 | 項目 | NGSIv2 | NGSI-LD | GeonicDB の動作 |
-|------|--------|---------|----------------|
+|------|--------|---------|-------------------|
 | **プロトコル** | REST/JSON | REST/JSON-LD | 両方サポート; エンティティは `protocol` フィールドで分離 |
-| **エンティティ分離** | `protocol: 'ngsiv2'` | `protocol: 'ngsild'` | 各 API は自身のエンティティのみを参照 |
-| **エンティティ ID** | 任意の文字列 | URI (URN 推奨) | URN 推奨。**ID はテナント + servicePath ごとに一意** (タイプによる曖昧性排除は削除) |
-| **属性タイプ** | シンプル (Number、Text など) | セマンティック (Property、Relationship など) | タイプマッピングルールで対応関係を定義 (上記の表を参照) |
-| **システム属性** | `dateCreated`、`dateModified` | `createdAt`、`modifiedAt` | 内部的に統一、API ごとに変換 |
+| **エンティティ分離** | `protocol: 'ngsiv2'` | `protocol: 'ngsild'` | 各 API は自身のエンティティのみ参照 |
+| **エンティティ ID** | 任意の文字列 | URI (URN 推奨) | URN 推奨。**ID はテナント + servicePath ごとに一意** (型による曖昧性解消は廃止) |
+| **属性タイプ** | シンプル (Number, Text など) | セマンティック (Property, Relationship など) | 型マッピングルールで対応関係を定義 (上記表を参照) |
+| **システム属性** | `dateCreated`, `dateModified` | `createdAt`, `modifiedAt` | 内部的に統合、API ごとに変換 |
 | **ジオクエリ** | ✅ | ✅ | 共有機能 |
-| **サブスクリプション** | ✅ (HTTP、MQTT、WebSocket) | ✅ (HTTP、MQTT、WebSocket) | 共有機能 |
-| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出; プロトコル間アクセスを実現 |
+| **サブスクリプション** | ✅ (HTTP, MQTT, WebSocket) | ✅ (HTTP, MQTT, WebSocket) | 共有機能 |
+| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出; プロトコル間アクセスを可能にする |
 | **プロトコル間アクセス** | 直接サポートなし | 直接サポートなし | プロトコル間アクセスにはフェデレーションを使用 |
-| **ユースケース** | IoT、レガシーシステム | Semantic Web、オープンデータ | ユースケースごとに 1 つの API を選択 |
+| **ユースケース** | IoT、レガシーシステム | セマンティック Web、オープンデータ | ユースケースごとに 1 つの API を選択 |
 
-GeonicDB は NGSIv2 と NGSI-LD の両方の API を提供し、厳格なプロトコル分離を行います。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
+GeonicDB は厳格なプロトコル分離により NGSIv2 と NGSI-LD の両方の API を提供します。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
 
 ---
 

--- a/docs/ja/features/smart-data-models.md
+++ b/docs/ja/features/smart-data-models.md
@@ -37,8 +37,7 @@ GeonicDB は、次のドメインから主要な Smart Data Models をサポー�
 - スキーマ URL
 - サンプル プロパティ
 
-## MCP ツール: `data_models`
-Smart Data Models カタログを参照するための MCP ツールが利用可能です。
+## MCP ツール: `data_models`Smart Data Models カタログを参照するための MCP ツールが利用可能です。
 
 ### アクション
 

--- a/docs/ja/features/subscriptions.md
+++ b/docs/ja/features/subscriptions.md
@@ -5,7 +5,7 @@ outline: deep
 ---
 # WebSocket イベントストリーミング
 
-GeonicDB は WebSocket によるリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムで購読し、Web アプリケーションやダッシュボードに即座に反映できます。
+GeonicDB は WebSocket によるリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムでサブスクリプションライブし、Web アプリケーションやダッシュボードに即座に反映できます。
 
 ## 目次
 
@@ -16,7 +16,7 @@ GeonicDB は WebSocket によるリアルタイムイベントストリーミン
 - [クライアント実装](#クライアント実装)
 - [ベストプラクティス](#ベストプラクティス)
 - [トラブルシューティング](#トラブルシューティング)
-- [制約](#制約)
+- [制約事項](#制約事項)
 
 ---
 
@@ -28,9 +28,9 @@ GeonicDB は WebSocket によるリアルタイムイベントストリーミン
 
 | チャネル | 方向 | フィルタリング | レイテンシ |
 |---------|-----------|-----------|---------|
-| HTTP Webhook (既存) | Push | サブスクリプション条件 | 約 1 分 |
-| MQTT (既存) | Push | サブスクリプション条件 | 約 1 分 |
-| WebSocket (本機能) | Push | テナント + エンティティタイプ/ID パターン | 約 1 分 |
+| HTTP Webhook (既存) | プッシュ | サブスクリプション条件 | 約 1 分 |
+| MQTT (既存) | プッシュ | サブスクリプション条件 | 約 1 分 |
+| WebSocket (本機能) | プッシュ | テナント + エンティティタイプ/ID パターン | 約 1 分 |
 
 ---
 
@@ -78,24 +78,24 @@ ws://localhost:3000?tenant={tenantName}
 ### クエリパラメータ
 
 | パラメータ | 必須 | 説明 |
-|-----------|------|------|
-| `tenant` | ✅ | テナント名 (`Fiware-Service` ヘッダーと同等) |
+|-----------|----------|-------------|
+| `tenant` | ✅ | テナント名(`Fiware-Service` ヘッダーと同等) |
 
 ### 認証
 
-`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは次の優先順位で抽出されます:
+`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは以下の優先順位で抽出されます:
 
-1. **`Authorization` ヘッダー (推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
-2. **`Sec-WebSocket-Protocol` ヘッダー (ブラウザ向け)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用
+1. **`Authorization` ヘッダー(推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
+2. **`Sec-WebSocket-Protocol` ヘッダー(ブラウザ用)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用
 
-> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。これまで URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
+> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。以前 URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
 
-- REST API `/auth/login` エンドポイントから取得した `accessToken` をトークンとして直接使用してください。
-- `super_admin` ロールは、WebSocket ストリーミングのために任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API (`/v2/*`、`/ngsi-ld/*`) にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
+- REST API `/auth/login` エンドポイントから取得した `accessToken` をトークンとして直接使用します。
+- `super_admin` ロールは、WebSocket ストリーミングのために任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API(`/v2/*`、`/ngsi-ld/*`)にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
 - `tenant_admin` / `user` ロールは自分のテナントにのみ接続できます。
 
 | 条件 | 結果 |
-|------|------|
+|-----------|--------|
 | `AUTH_ENABLED=false`、トークンなし | ✅ 接続許可 |
 | `AUTH_ENABLED=true`、トークンなし | ❌ 接続拒否 (1008) |
 | `AUTH_ENABLED=true`、無効なトークン | ❌ 接続拒否 (1008) |
@@ -105,12 +105,12 @@ ws://localhost:3000?tenant={tenantName}
 
 ### 接続フロー
 
-1. クライアントが WebSocket URL に接続 (`tenant` クエリパラメータは必須; 認証が有効な場合はトークンも必須)
-2. サーバーがトークンを検証し、テナントアクセス権限を確認 (認証が有効な場合)
-3. トークンに `cnf.jkt` クレーム (DPoP バインドトークン) が含まれている場合、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります (下記の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
-4. サーバーが DynamoDB に接続を記録 (TTL: 2 時間)
-5. オプション: `subscribe` メッセージでフィルター条件を設定
-6. エンティティが変更されると、サーバーがクライアントにイベントをプッシュ
+1. クライアントが WebSocket URL に接続(`tenant` クエリパラメータは必須。認証が有効な場合はトークンも必要)
+2. サーバーがトークンを検証し、テナントアクセス権を確認(認証が有効な場合)
+3. トークンに `cnf.jkt` クレーム(DPoP バインドトークン)が含まれている場合、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります(下記の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
+4. サーバーが DynamoDB に接続を記録(TTL: 2 時間)
+5. オプション: `subscribe` メッセージでフィルタ条件を設定
+6. エンティティが変更されたときに、サーバーがクライアントにイベントをプッシュ
 
 ---
 
@@ -134,7 +134,7 @@ ws://localhost:3000?tenant={tenantName}
 | `entityTypes` | string[] | フィルタリングするエンティティタイプ |
 | `idPattern` | string | エンティティ ID の正規表現パターン |
 
-#### dpop_bind (DPoP 証明検証)
+#### dpop_bind (DPoP プルーフ検証)
 
 ```json
 {
@@ -143,9 +143,9 @@ ws://localhost:3000?tenant={tenantName}
 }
 ```
 
-DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する場合に必要です。接続後 5 秒以内に送信する必要があります。サーバーは証明の JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` で応答します。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否されます。
+DPoP バウンドトークン (`cnf.jkt` を含む JWT) で接続する際に必須。接続後 5 秒以内に送信する必要がある。サーバーはプルーフの JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` で応答する。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否される。
 
-詳細は AUTH.md — DPoP Token Binding を参照してください。
+詳細は AUTH.md — DPoP Token Binding を参照。
 
 #### ping (キープアライブ)
 
@@ -155,7 +155,7 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 }
 ```
 
-サーバーは `{"type": "pong"}` を返します。10 分間のアイドルタイムアウトを防ぐため、5 分ごとに ping を送信してください。
+サーバーは `{"type": "pong"}` を返す。10 分間のアイドルタイムアウトを防ぐため、5 分ごとに ping を送信する。
 
 ### サーバー → クライアント
 
@@ -189,35 +189,35 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 
 ### フィルタリング
 
-フィルタリングは次の順序で 3 つの層で適用されます:
+フィルタリングは次の 3 つのレイヤーで、この順序で適用される:
 
-1. **テナントフィルタ (必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
-2. **接続側の `subscribe` フィルタ (オプション)** — クライアントが受信したい内容を絞り込みます:
+1. **テナントフィルタ (必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用される。
+2. **接続側の `subscribe` フィルタ (オプション)** — クライアントが受信したいものを絞り込む:
    - `entityTypes`: 受信するエンティティタイプの配列
-   - `idPattern`: `entityId` に対してマッチングされる正規表現
-3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターはアクティブな XACML ポリシーを実行します。サブジェクトがイベントに対して `Permit` された接続のみに配信されます。
+   - `idPattern`: `entityId` に対してマッチする正規表現
+3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターは有効な XACML ポリシーを実行する。サブジェクトがイベントに対して `Permit` された接続のみが配信される。
 
 #### XACML で利用可能なイベントごとのリソース属性 (#1107)
 
-ブロードキャスターが配信を認可する際、以下のエンティティごとのリソース属性を AuthzRequest に注入します:
+ブロードキャスターが配信を認可する際、次のエンティティごとのリソース属性を AuthzRequest に注入する:
 
 | attributeId | ソース |
 |-------------|--------|
 | `entityType` | イベントのエンティティタイプ |
 | `entityId` | イベントのエンティティ ID |
-| `entityOwner` | イベントエンティティの `createdBy` (元々エンティティを `POST` したユーザー) |
+| `entityOwner` | イベントエンティティの `createdBy` (元々そのエンティティを `POST` したユーザー) |
 
-これにより、`${subject.userId}` テンプレート展開と `entityOwner` を使用して、単一の XACML ポリシーで「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった**ユーザーごとの配信フィルタ**を記述できます。完全なポリシー例については `docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性 を参照してください。
+これにより、`entityOwner` に対する `${subject.userId}` テンプレート展開を使用した単一の XACML ポリシーで、「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった **ユーザーごとの配信フィルタ** を記述できる。完全なポリシー例については、`docs/AUTH.md` — Per-entity attributes at broadcast time を参照。
 
-> 認証なしで書き込まれたエンティティ (または `createdBy` を設定しないレガシー / バッチパス経由) は、`owner` 属性のないイベントを発行します — 所有者ベースのルールはこれらのイベントにマッチしないため、このフォールバックを考慮してポリシーを設計してください。
+> 認証なしで書き込まれたエンティティ (または `createdBy` を設定しないレガシー / バッチパスを介して書き込まれたもの) は、`owner` 属性を持たないイベントを発行する。所有者ベースのルールはこれらのイベントにマッチしないため、そのフォールバックを考慮してポリシーを設計すること。
 
 ---
 
 ## クライアント実装
 
-### JavaScript SDK (推奨)
+### JavaScript SDK(推奨)
 
-GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンの更新、DPoP バインディング、再接続を自動的に処理します。
+GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンのリフレッシュ、DPoP バインディング、再接続を自動的に処理します。
 
 ```bash
 npm install @geolonia/geonicdb-sdk
@@ -257,7 +257,7 @@ db.on('connected', function() {
 // db.reconnect();
 ```
 
-Bearer JWT 認証の場合(例: ログインフロー後)、`setCredentials()` で認証情報を注入します:
+Bearer JWT 認証(例:ログインフロー後)の場合、`setCredentials()` で認証情報を注入します:
 
 ```javascript
 import GeonicDB from '@geolonia/geonicdb-sdk';
@@ -282,7 +282,7 @@ db.connect();
 
 完全な API リファレンスについては、SDK ドキュメントを参照してください。
 
-### クイックスタート (raw WebSocket、最小限のセットアップ)
+### クイックスタート(生の WebSocket、最小限のセットアップ)
 
 認証なしの最小限の接続例:
 
@@ -448,7 +448,7 @@ function RoomMonitor() {
 }
 ```
 
-### JavaScript (認証あり)
+### JavaScript(認証あり)
 
 ```javascript
 // Obtain a token
@@ -542,7 +542,7 @@ async def stream_events():
 asyncio.run(stream_events())
 ```
 
-### wscat (デバッグ用)
+### wscat(デバッグ用)
 
 ```bash
 # Connect (when authentication is enabled, send the token via the Authorization header)
@@ -557,9 +557,9 @@ wscat -c "wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant=smart
 
 ---
 
-## WebSocket の DPoP バインディング {#dpop-binding-for-websocket}
+## WebSocket 向け DPoP バインディング
 
-DPoP バインドトークンを使用する WebSocket 接続には、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
+DPoP バインドトークンを使用する WebSocket 接続では、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
 
 ### フロー
 
@@ -584,8 +584,8 @@ Client                               Server
 
 | 状態 | 説明 | 許可されるメッセージ |
 |-------|-------------|------------------|
-| `pending_dpop` | 接続後に DPoP 証明を待機中 | `dpop_bind` のみ |
-| `verified` | DPoP 証明が正常に検証された | `subscribe`、`ping` など |
+| `pending_dpop` | 接続後、DPoP 証明を待機中 | `dpop_bind` のみ |
+| `verified` | DPoP 証明が正常に検証されました | `subscribe`、`ping` など |
 
 `dpop_bind` メッセージが 5 秒以内に受信されない場合、接続は終了されます。
 
@@ -595,9 +595,9 @@ Client                               Server
 
 ### 1. 再接続ロジック
 
-> **注意**: JavaScript SDK を使用している場合、指数バックオフを使用した再接続が組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続試行を追跡できます。以下の例は、raw WebSocket 実装向けです。
+> **注意**: JavaScript SDK を使用している場合、指数バックオフを用いた再接続は組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続の試行を追跡してください。以下の例は、生の WebSocket 実装向けです。
 
-指数バックオフを使用した堅牢な再接続を実装します:
+指数バックオフによる堅牢な再接続を実装します:
 
 ```javascript
 class GeonicDBWebSocket {
@@ -633,7 +633,7 @@ class GeonicDBWebSocket {
 }
 ```
 
-### 2. Keep-Alive
+### 2. キープアライブ
 
 10 分間のアイドルタイムアウトを防ぐために、5 分ごとに ping を送信します:
 
@@ -647,7 +647,7 @@ setInterval(() => {
 
 ### 3. イベント処理の最適化
 
-大量のイベントを受信する場合、デバウンシングで UI 更新を最適化します:
+大量のイベントを受信する場合、デバウンスを使用して UI の更新を最適化します:
 
 ```javascript
 import { debounce } from 'lodash';
@@ -697,7 +697,7 @@ function isTokenExpired(token, bufferSeconds = 60) {
 
 ### 5. メモリ管理
 
-メモリリークを防ぐために、イベント履歴に制限を設定します:
+メモリリークを防ぐために、イベント履歴に上限を設定します:
 
 ```javascript
 const MAX_EVENTS = 1000;
@@ -716,12 +716,12 @@ onUnmounted(() => {
 
 ## トラブルシューティング
 
-### 1. 接続が拒否される (1008 エラー)
+### 1. 接続拒否 (1008 エラー)
 
 **原因:**
 - トークンが無効または期限切れ
 - テナントへのアクセス権限がない
-- `AUTH_ENABLED=true` にもかかわらずトークンが提供されていない
+- `AUTH_ENABLED=true` であるにもかかわらずトークンが提供されていない
 
 **解決方法:**
 
@@ -737,7 +737,7 @@ ws.onclose = (event) => {
 
 ### 2. 10 分後に接続が切断される
 
-**原因:** Keep-alive (ping) メッセージが送信されていない。
+**原因:** キープアライブ (ping) メッセージが送信されていません。
 
 **解決方法:**
 
@@ -755,7 +755,7 @@ setInterval(() => {
 **原因:**
 - フィルタが厳しすぎる
 - テナントが間違っている
-- エンティティの作成/更新が実際に発生していない
+- エンティティの作成/更新が実際には発生していない
 
 **解決方法:**
 
@@ -774,7 +774,7 @@ ws.send(JSON.stringify({
 }));
 ```
 
-### 4. ローカル開発環境で接続できない
+### 4. ローカル開発で接続できない
 
 **原因:**
 - ローカルサーバーが起動していない
@@ -792,7 +792,7 @@ const wsUrl = 'ws://localhost:3000?tenant=demo';
 
 ### 5. デバッグ
 
-ブラウザの開発者ツールの Network タブで、WebSocket 接続と送受信されたメッセージを確認できます。
+ブラウザの開発者ツールの Network タブで、WebSocket 接続と送受信メッセージを検査できます。
 
 ```javascript
 class DebugWebSocket {
@@ -814,22 +814,22 @@ class DebugWebSocket {
 
 ---
 
-## 制約
+## 制約事項
 
 | 項目 | 値 | 説明 |
 |------|-------|-------------|
 | アイドルタイムアウト | 10 分 | クライアントは 5 分ごとに ping を送信する必要があります |
-| 同時接続数 | 500 (デフォルト) | AWS Support 経由で増やすことができます |
+| 同時接続数 | 500 (デフォルト) | AWS サポート経由で増やすことが可能です |
 | フレームサイズ | 128KB | 大きなエンティティは切り詰めが必要です |
-| レイテンシ | ~1 分 | MongoDB Change Stream のポーリング間隔に依存します |
-| 接続 TTL | 2 時間 | DynamoDB TTL によって自動的にクリーンアップされます |
-| ローカル開発 | サポート対象 | ローカル WebSocket サーバー経由で利用可能 |
+| レイテンシ | 約 1 分 | MongoDB Change Stream のポーリング間隔に依存します |
+| 接続 TTL | 2 時間 | DynamoDB TTL により自動的にクリーンアップされます |
+| ローカル開発 | サポート対象 | ローカル WebSocket サーバー経由で利用可能です |
 
 ---
 
 ## 関連ドキュメント
 
-- JavaScript SDK - SDK API リファレンス (ブラウザアプリケーションに推奨)
+- JavaScript SDK - SDK API リファレンス (ブラウザアプリケーション向けに推奨)
 - [API 共通仕様](../api-reference/endpoints.md) - REST API ドキュメント
 - Authentication and Authorization - 認証設定
-- Development Guide - ローカル開発とデプロイ
+- Development Guide - ローカル開発とデプロイメント

--- a/docs/ja/reference/cli.md
+++ b/docs/ja/reference/cli.md
@@ -9,8 +9,7 @@ outline: deep
 
 - **リポジトリ**: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)
 - **ランタイム**: Node.js >= 20
-- **パッケージ**: `@geolonia/geonicdb-cli`
-## 目次
+- **パッケージ**: `@geolonia/geonicdb-cli`## 目次
 
 - [インストール](#インストール)
 - [クイックスタート](#クイックスタート)
@@ -135,26 +134,21 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 }
 ```
 
-**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`
-#
+**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`#
 
-### `geonic config set <key> <value>`
-設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
+### `geonic config set <key> <value>`設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
 
 #
 
-### `geonic config get <key>`
-設定値を取得します。
+### `geonic config get <key>`設定値を取得します。
 
 #
 
-### `geonic config list`
-現在のプロファイルのすべての設定値を表示します。
+### `geonic config list`現在のプロファイルのすべての設定値を表示します。
 
 #
 
-### `geonic config delete <key>`
-設定値を削除します。
+### `geonic config delete <key>`設定値を削除します。
 
 ### プロファイル管理
 
@@ -162,28 +156,23 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 
 #
 
-### `geonic profile list`
-すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
+### `geonic profile list`すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
 
 #
 
-### `geonic profile use <name>`
-アクティブなプロファイルを切り替えます。
+### `geonic profile use <name>`アクティブなプロファイルを切り替えます。
 
 #
 
-### `geonic profile create <name>`
-新しい空のプロファイルを作成します。
+### `geonic profile create <name>`新しい空のプロファイルを作成します。
 
 #
 
-### `geonic profile delete <name>`
-プロファイルを削除します。`default` プロファイルは削除できません。
+### `geonic profile delete <name>`プロファイルを削除します。`default` プロファイルは削除できません。
 
 #
 
-### `geonic profile show [name]`
-プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
+### `geonic profile show [name]`プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
 
 ### 環境変数
 
@@ -343,13 +332,11 @@ CLI は 24 時間ごとに新しいバージョンをチェックし、アップ
 
 ## コマンドリファレンス
 
-### `entities`
-NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
+### `entities`NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
 
 #
 
-### `geonic entities list`
-オプションのフィルタを使用してエンティティをリストします。
+### `geonic entities list`オプションのフィルタを使用してエンティティをリストします。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -384,8 +371,7 @@ geonic entities list --type Sensor --count-only
 
 #
 
-### `geonic entities get <id>`
-ID で単一のエンティティを取得します。
+### `geonic entities get <id>`ID で単一のエンティティを取得します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -393,8 +379,7 @@ ID で単一のエンティティを取得します。
 
 #
 
-### `geonic entities create [json]`
-新しいエンティティを作成します。
+### `geonic entities create [json]`新しいエンティティを作成します。
 
 ```bash
 geonic entities create '{
@@ -410,8 +395,7 @@ geonic entities create '{
 
 #
 
-### `geonic entities update <id> [json]`
-エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
+### `geonic entities update <id> [json]`エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
 
 ```bash
 geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property", "value": 25.0}}'
@@ -419,23 +403,19 @@ geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property"
 
 #
 
-### `geonic entities replace <id> [json]`
-すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
+### `geonic entities replace <id> [json]`すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
 
 #
 
-### `geonic entities upsert [json]`
-エンティティを作成または更新します (`POST /entityOperations/upsert`)。
+### `geonic entities upsert [json]`エンティティを作成または更新します (`POST /entityOperations/upsert`)。
 
 #
 
-### `geonic entities delete <id>`
-エンティティを削除します。
+### `geonic entities delete <id>`エンティティを削除します。
 
 ---
 
-### `entities attrs`
-エンティティの個別の属性を管理します。
+### `entities attrs`エンティティの個別の属性を管理します。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -455,8 +435,7 @@ geonic entities attrs update urn:ngsi-ld:Room:001 temperature '{"type": "Propert
 
 ---
 
-### `entityOperations`
- (バッチ)
+### `entityOperations` (バッチ)
 
 エンティティのバッチ操作 (`/ngsi-ld/v1/entityOperations`)。エイリアス: `batch`。
 
@@ -479,8 +458,7 @@ cat entities.json | geonic batch upsert
 
 ---
 
-### `subscriptions`
- (sub)
+### `subscriptions` (sub)
 
 コンテキストサブスクリプション (`/ngsi-ld/v1/subscriptions`) を管理します。エイリアス: `sub`。
 
@@ -492,8 +470,7 @@ cat entities.json | geonic batch upsert
 | `geonic sub update <id> [json]` | サブスクリプションの更新 |
 | `geonic sub delete <id>` | サブスクリプションの削除 |
 
-**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
-```bash
+**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count````bash
 geonic sub create '{
   "type": "Subscription",
   "entities": [{"type": "Room"}],
@@ -506,8 +483,7 @@ geonic sub create '{
 
 ---
 
-### `registrations`
- (reg)
+### `registrations` (reg)
 
 コンテキストソース登録 (`/ngsi-ld/v1/csourceRegistrations`) を管理します。エイリアス: `reg`。
 
@@ -519,11 +495,9 @@ geonic sub create '{
 | `geonic reg update <id> [json]` | 登録の更新 |
 | `geonic reg delete <id>` | 登録の削除 |
 
-**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
----
+**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`---
 
-### `types`
-利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
+### `types`利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -532,13 +506,11 @@ geonic sub create '{
 
 ---
 
-### `temporal`
-時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
+### `temporal`時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
 
 #
 
-### `geonic temporal entities list`
-時系列エンティティの一覧を取得します。
+### `geonic temporal entities list`時系列エンティティの一覧を取得します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -566,24 +538,19 @@ geonic temporal entities get urn:ngsi-ld:Room:001 \
 
 #
 
-### `geonic temporal entities get <id>`
-エンティティの時系列表現を取得します。
+### `geonic temporal entities get <id>`エンティティの時系列表現を取得します。
 
-**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`
-#
+**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`#
 
-### `geonic temporal entities create [json]`
-時系列エンティティを作成します。
+### `geonic temporal entities create [json]`時系列エンティティを作成します。
 
 #
 
-### `geonic temporal entities delete <id>`
-時系列エンティティを削除します。
+### `geonic temporal entities delete <id>`時系列エンティティを削除します。
 
 #
 
-### `geonic temporal entityOperations query [json]`
-集約サポート付きで POST による時系列エンティティのクエリを実行します。
+### `geonic temporal entityOperations query [json]`集約サポート付きで POST による時系列エンティティのクエリを実行します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -599,8 +566,7 @@ geonic temporal entityOperations query @query.json \
 
 ---
 
-### `snapshots`
-エンティティスナップショットを管理します。
+### `snapshots`エンティティスナップショットを管理します。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -610,11 +576,9 @@ geonic temporal entityOperations query @query.json \
 | `geonic snapshots delete <id>` | スナップショットを削除 |
 | `geonic snapshots clone <id>` | スナップショットをクローン |
 
-**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`
----
+**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`---
 
-### `rules`
-ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
+### `rules`ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -655,13 +619,11 @@ DCAT-AP データカタログを参照します。
 
 ---
 
-### `admin`
-管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
+### `admin`管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
 
 #
 
-### `admin tenants`
-| コマンド | 説明 |
+### `admin tenants`| コマンド | 説明 |
 |---------|-------------|
 | `geonic admin tenants list` | テナント一覧を取得 |
 | `geonic admin tenants get <id>` | テナントを取得 |
@@ -673,8 +635,7 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin users`
-| コマンド | 説明 |
+### `admin users`| コマンド | 説明 |
 |---------|-------------|
 | `geonic admin users list` | ユーザー一覧を取得 |
 | `geonic admin users get <id>` | ユーザーを取得 |
@@ -687,8 +648,7 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin policies`
-XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
+### `admin policies`XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -702,8 +662,7 @@ XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照�
 
 #
 
-### `admin oauth-clients`
-OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
+### `admin oauth-clients`OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -715,8 +674,7 @@ OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照し�
 
 #
 
-### `admin api-keys`
-API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
+### `admin api-keys`API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -759,8 +717,7 @@ geonic admin api-keys update gdb_abc123 '{"name": "renamed-key", "isActive": fal
 
 #
 
-### `admin cadde`
-CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
+### `admin cadde`CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -770,22 +727,19 @@ CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
 
 ---
 
-### `health`
-```bash
+### `health````bash
 geonic health
 ```
 
 サーバーのヘルス状態を確認します (`GET /health`)。
 
-### `version`
-```bash
+### `version````bash
 geonic version
 ```
 
 CLI のバージョンとサーバーのバージョンを表示します (`GET /version`)。
 
-### `me`
-現在認証されているユーザーを表示し、ユーザーリソースを管理します。
+### `me`現在認証されているユーザーを表示し、ユーザーリソースを管理します。
 
 ```bash
 geonic me
@@ -795,8 +749,7 @@ geonic me
 
 #
 
-### `me oauth-clients`
-自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
+### `me oauth-clients`自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -827,8 +780,7 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 
 #
 
-### `me api-keys`
-自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
+### `me api-keys`自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -836,8 +788,7 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 | `geonic me api-keys create [json]` | 新しい API キーを作成 |
 | `geonic me api-keys delete <key-id>` | API キーを削除 |
 
-**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count`
-```bash
+**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count````bash
 # Create a personal API key
 geonic me api-keys create '{
   "name": "my-dev-key",
@@ -854,8 +805,7 @@ geonic me api-keys delete gdb_abc123
 
 > **注意**: 平文の API キーは、作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
 
-### `help`
-WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
+### `help`WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
 
 ```bash
 geonic help                    # All commands overview


### PR DESCRIPTION
## Automated Sync & Translation

**Trigger**: workflow_dispatch
**GeonicDB SHA**: N/A (manual dispatch)

### Changed files
docs/en/ai-integration/examples.md
docs/en/ai-integration/overview.md
docs/en/ai-integration/tools-json.md
docs/en/api-reference/endpoints.md
docs/en/api-reference/ngsiv2.md
docs/en/core-concepts/ngsiv2-vs-ngsild.md
docs/en/features/subscriptions.md

### Process
1. Synced English source docs from geolonia/geonicdb → docs/en/
2. Translated English docs to Japanese via yuuhitsu → docs/ja/
3. Build verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント更新

* **Documentation**
  * AI 統合ガイドを拡充し、ツール定義、MCP サポート、認証、データモデル、JavaScript SDK に関する説明を詳細化しました
  * NGSI-LD および NGSIv2 API リファレンスのクエリパラメータ、レスポンス仕様、機能説明を整理しました
  * CLI リファレンスの見出しと構成を再編成しました
  * WebSocket イベントストリーミングおよび DPoP 検証に関するドキュメントを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->