### PR TITLE
chore: revert yuuhitsu to 0.1.14 (list boundary failure in 0.1.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [feat] Phase 1 — saas-docs-rewrite.ts + YAML rule config (R-DEV-MD + R-SAM-BATCH) 実装（cmd_371）(Closes #152)
 
 ### Changed
+- chore(deps): rollback @geolonia/yuuhitsu 0.1.16 → 0.1.14 (exact pin) — list 境界保護が 0.1.16 で不十分 (integration test 3/5 FAIL)、yuuhitsu 0.1.17 fix 後に再 bump 予定 (Closes #188)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.16 (Phase 4 monitoring: HTML comment sentinel <!--BB--> + 3-pass restore) (Closes #185)
 - chore(deps): rollback @geolonia/yuuhitsu 0.1.15 → 0.1.14 (exact pin) — SF1 P-A4 sentinel が LLM により %%BB%% → %%BB__ に変形される silent failure を確認 (Closes #183)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.15 — SF1 P-A4 newline sentinel (Closes #175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - [feat] Phase 1 — saas-docs-rewrite.ts + YAML rule config (R-DEV-MD + R-SAM-BATCH) 実装（cmd_371）(Closes #152)
 
 ### Changed
-- chore(deps): rollback @geolonia/yuuhitsu 0.1.16 → 0.1.14 (exact pin) — list 境界保護が 0.1.16 で不十分 (integration test 3/5 FAIL)、yuuhitsu 0.1.17 fix 後に再 bump 予定 (Closes #188)
+- [fix] cmd_398 — `@geolonia/yuuhitsu` 0.1.16 → 0.1.14 緊急ロールバック（list 境界保護不備により integration test 3/5 FAIL、0.1.17 fix 後に再 bump）(Closes #188)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.16 (Phase 4 monitoring: HTML comment sentinel <!--BB--> + 3-pass restore) (Closes #185)
 - chore(deps): rollback @geolonia/yuuhitsu 0.1.15 → 0.1.14 (exact pin) — SF1 P-A4 sentinel が LLM により %%BB%% → %%BB__ に変形される silent failure を確認 (Closes #183)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.15 — SF1 P-A4 newline sentinel (Closes #175)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "^0.1.16",
+    "@geolonia/yuuhitsu": "0.1.14",
     "@playwright/test": "^1.58.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: ^0.1.16
-        version: 0.1.16(ws@8.19.0)(zod@4.4.2)
+        specifier: 0.1.14
+        version: 0.1.14(ws@8.19.0)(zod@4.4.2)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -490,8 +490,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.16':
-    resolution: {integrity: sha512-TRdn4kPZ9Byr+b6rWbF7Xcv7jypoTseeNyYtT9DWX9iJtcx7/mK9bdjbL9FCHCDwf5J9fuxrOXMFyN87MlaJ5Q==}
+  '@geolonia/yuuhitsu@0.1.14':
+    resolution: {integrity: sha512-FHRCQIEEv+ZzWMCvkjDQuaveaSQke4zsqaHo3pJPfT54mVaCsXsBTnf5O/mqQeoylnb5zYUmAg3N9kinkUuvNA==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -2356,7 +2356,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.16(ws@8.19.0)(zod@4.4.2)':
+  '@geolonia/yuuhitsu@0.1.14(ws@8.19.0)(zod@4.4.2)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary
- Revert `@geolonia/yuuhitsu` from `^0.1.16` back to `0.1.14` (exact pin)
- yuuhitsu 0.1.16 の list 境界保護が不十分 (integration test 3/5 FAIL)
- `<!--BB-->` sentinel が heading/hr 境界には有効だが list items の連結を防げない
- yuuhitsu 0.1.17 fix (cmd_399 軍師策定 → cmd_400 実装) 後に再 bump 予定

## Related
- Closes #188
- PR#187 close 済み (corrupt translations)
- cmd_397 integration test FAIL report: `queue/reports/ashigaru7_report_397a.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発用パッケージ `@geolonia/yuuhitsu` を緊急ロールバックし `0.1.14` に戻しました。統合テストで境界処理の問題に起因する失敗が発生したための対応で、該当パッケージの修正後に再度バージョンを戻す予定です。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->