### PR TITLE
chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/.vitepress/cache/
 .geonicdb-upstream/
 test-results/
 playwright-report/
+.code-review-done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [feat] Phase 1 — saas-docs-rewrite.ts + YAML rule config (R-DEV-MD + R-SAM-BATCH) 実装（cmd_371）(Closes #152)
 
 ### Changed
+- chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.17 (list boundary fix + Phase 4 monitoring 再開) (Closes #190)
 - [fix] cmd_398 — `@geolonia/yuuhitsu` 0.1.16 → 0.1.14 緊急ロールバック（list 境界保護不備により integration test 3/5 FAIL、0.1.17 fix 後に再 bump）(Closes #188)
 - chore(deps): bump @geolonia/yuuhitsu 0.1.14 → 0.1.16 (Phase 4 monitoring: HTML comment sentinel <!--BB--> + 3-pass restore) (Closes #185)
 - chore(deps): rollback @geolonia/yuuhitsu 0.1.15 → 0.1.14 (exact pin) — SF1 P-A4 sentinel が LLM により %%BB%% → %%BB__ に変形される silent failure を確認 (Closes #183)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.29.2",
   "devDependencies": {
-    "@geolonia/yuuhitsu": "0.1.14",
+    "@geolonia/yuuhitsu": "^0.1.17",
     "@playwright/test": "^1.58.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@geolonia/yuuhitsu':
-        specifier: 0.1.14
-        version: 0.1.14(ws@8.19.0)(zod@4.4.2)
+        specifier: ^0.1.17
+        version: 0.1.17(ws@8.19.0)(zod@4.4.2)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -490,8 +490,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@geolonia/yuuhitsu@0.1.14':
-    resolution: {integrity: sha512-FHRCQIEEv+ZzWMCvkjDQuaveaSQke4zsqaHo3pJPfT54mVaCsXsBTnf5O/mqQeoylnb5zYUmAg3N9kinkUuvNA==}
+  '@geolonia/yuuhitsu@0.1.17':
+    resolution: {integrity: sha512-OqGwPWwtApKd58SlqRoUmDjnN9VJCeRMRuNt4yOwCc/KH2L0buv395EZ2Hf03yHlFLDVbJjgrofbFCv2AdCQGQ==}
     hasBin: true
 
   '@google/genai@0.7.0':
@@ -2356,7 +2356,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@geolonia/yuuhitsu@0.1.14(ws@8.19.0)(zod@4.4.2)':
+  '@geolonia/yuuhitsu@0.1.17(ws@8.19.0)(zod@4.4.2)':
     dependencies:
       '@anthropic-ai/sdk': 0.39.0
       '@google/genai': 0.7.0


### PR DESCRIPTION
## Summary

- `@geolonia/yuuhitsu` を 0.1.14 から 0.1.17 へ bump
- cmd_398 でロールバックした 0.1.14 から、list boundary 修正済みの 0.1.17 へ再 bump
- Phase 4 monitoring 再開

## Changes

- `package.json`: `@geolonia/yuuhitsu` バージョン指定を `0.1.14` → `^0.1.17` に更新
- `pnpm-lock.yaml`: lockfile 更新

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発用依存パッケージを更新しました（マイナー修正と監視再起動に関する更新を含む）。
  * リポジトリの無視設定に特定の補助ファイルを追加しました。

* **Documentation**
  * リリース履歴を更新しました（未リリース欄に変更を追記）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->