### PR TITLE
chore(ci): sync-and-translate workflow に base_branch 入力追加

### DIFF
--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -2,6 +2,12 @@ name: Sync and Translate GeonicDB Docs
 
 on:
   workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'Base branch for sync PR (default: main)'
+        required: false
+        default: 'main'
+        type: string
   repository_dispatch:
     types: [geonicdb-docs-updated]
 
@@ -228,6 +234,7 @@ jobs:
 
             **Trigger**: ${{ github.event_name }}
             **GeonicDB SHA**: ${{ github.event.client_payload.sha || 'N/A (manual dispatch)' }}
+            **Base branch**: ${{ inputs.base_branch || 'main' }}
 
             ### Changed files
             ${{ steps.detect.outputs.file_list }}
@@ -236,6 +243,6 @@ jobs:
             1. Synced English source docs from geolonia/geonicdb → docs/en/
             2. Translated English docs to Japanese via yuuhitsu → docs/ja/
             3. Build verification passed
-          branch: docs/auto-sync-translate
-          base: main
+          branch: docs/auto-sync-translate-${{ inputs.base_branch || 'main' }}
+          base: ${{ inputs.base_branch || 'main' }}
           labels: documentation,automated

--- a/.github/workflows/sync-and-translate.yml
+++ b/.github/workflows/sync-and-translate.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout geonicdb-docs
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.base_branch || 'main' }}
 
       - name: Checkout geolonia/geonicdb (docs/ and CHANGELOG.md via sparse-checkout)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- [chore] cmd_415 — sync-and-translate.yml に `base_branch` 入力追加（任意ブランチへの sync PR 作成対応、dogfood テスト用）(Closes #199)
 - [feat] cmd_387 — vitepress-plugin-mermaid 導入（architecture ページ Mermaid グラフ表示対応）(Closes #179)
 - [feat] cmd_386 — demo-app.md に Live Demo リンク追加 (demo.geonicdb.com) (Closes #177)
 - [feat] cmd_382 — fixListMerge に DEBUG_FIXLISTMERGE=1 制御の debug logging 追加（skip 理由・行番号記録）(Closes #172)


### PR DESCRIPTION
## Summary

- `sync-and-translate.yml` の `workflow_dispatch` に `base_branch` 入力パラメータを追加
- デフォルト値は `main`（既存動作を維持）
- 任意ブランチへの sync PR 作成が可能になり、dogfood テスト用途に対応

## Changes

- `.github/workflows/sync-and-translate.yml`: `workflow_dispatch.inputs.base_branch` 追加
- `create-pull-request` ステップの `base` と `branch` を `base_branch` 入力に対応
- PR body に `Base branch` フィールドを追加

## Usage

```bash
# dogfood ブランチを対象に sync を実行
gh workflow run sync-and-translate.yml \
  --ref feat/cmd411-yuuhitsu-0.2.0-canary \
  -f base_branch=feat/cmd411-yuuhitsu-0.2.0-canary
```

Closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ワークフローで基本ブランチをカスタマイズ可能になりました。選択した基本ブランチに合わせて同期用プルリクエストが作成されます。
  * プルリクエストの本文に「Base branch」が表示され、作成されるブランチ名やベースが選択に応じて設定されます。

* **ドキュメント**
  * 非公開リポジトリ向けの同期PRを記録する変更が追記されました（CHANGELOGに反映）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->