### PR TITLE
docs: sync and translate from geonicdb/docs

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -12,6 +12,8 @@ outline: deep
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-05
+
 ### 2026-05-05
 - **修正**: SDK の `db.request()` が空ボディ + JSON Content-Type のレスポンスで `SyntaxError: Unexpected end of JSON input` を投げて落ちる問題 (issue #1145) (#1146)
   - 背景: NGSI-LD `POST /entities` (201) など仕様上ボディが空のレスポンスでも、サーバ実装は `Content-Type: application/ld+json` を付けて返している。SDK 側 `db.request()` は Content-Type が `json` を含むと無条件に `res.json()` を呼ぶため、空ボディで SyntaxError を投げていた (`db.createEntity` 等の専用メソッドは body を読まないので影響なし、`db.request()` 経由で同パスを叩くと壊れる、という非対称が問題)
@@ -50,7 +52,7 @@ outline: deep
   - 旧: `encodeURIComponent` でフィールドごとに直列化
   - 新: `URLSearchParams` ベースに refactor (DRY 化のため)
   - 影響を受ける文字: 半角スペース `%20` → `+` / `'` 素通し → `%27` / `!` `*` `(` `)` `~` 素通し → `%21` `%2A` `%28` `%29` `%7E`
-  - サーバ側 (GeonicDB 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
+  - サーバ側 (geonicdb 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
   - 公開メソッドのシグネチャは追加のみで完全後方互換 (新パラメータはすべて optional)
 - **改善**: SDK のクエリパラメータ表面を NGSI-LD §5.7.2 (Query Entities) に揃えて拡充 (issue #1132) (#1149)
   - 背景: `db.getEntities()` 等は `type / limit / offset / q` の 4 パラメータしか URL に乗せておらず、サーバが実装している `scopeQ` / `georel` / `geometry` / `coordinates` / `attrs` / `pick` / `omit` / `lang` / `orderBy` / `count` 等を SDK 経由で使えなかった。実アプリで scope に基づくフィルタが必要になり (geonicdb-gis 関連)、SDK を諦めて `db.request()` で素のパスを組み立てる回避が必要だった

--- a/docs/ja/ai-integration/examples.md
+++ b/docs/ja/ai-integration/examples.md
@@ -5,11 +5,11 @@ outline: deep
 ---
 # AI 統合
 
-GeonicDB は AI エージェント（Claude、GPT-4、Gemini など）が API を簡単に利用できるよう、複数の AI 指向インターフェースを提供しています。
+GeonicDB は、AI エージェント（Claude、GPT-4、Gemini など）が API を簡単に利用できるように、複数の AI 指向インターフェースを提供しています。
 
 ## エンドポイント一覧
 
-| エンドポイント | 形式 | 説明 |
+| エンドポイント | フォーマット | 説明 |
 |---------------|------|------|
 | `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
 | `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
@@ -20,36 +20,33 @@ GeonicDB は AI エージェント（Claude、GPT-4、Gemini など）が API �
 ## Tool Use スキーマ (`/tools.json`
 )
 
-Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
+Claude Tool Use と OpenAI Function Calling 互換のツール定義を提供します。
 
-### 利用可能なツール (5 ツール)
+### 利用可能なツール（5 ツール）
 
-各ツールは `action` および `resource` パラメータを介して操作を選択します。
+各ツールは `action` および `resource` パラメータで操作を選択します。
 
 | ツール名 | リソース | アクション | 説明 |
 |---------|---------|-----------|------|
 | `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、型、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作（最大 1,000 件） |
+| `batch` | - | create、upsert、update、merge、delete、query、purge | バルクエンティティ操作（最大 1,000 アイテム）|
 | `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
-| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理（super_admin、get/update/delete） |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理（認証が必要） |
+| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、CADDE 設定管理（super_admin、get/update/delete）|
+| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理（認証が必要）|
 
 ### 自動 NGSI-LD 属性タイプ検出
 
-MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動推論します：
 
 | 値のパターン | 検出されるタイプ | 例 |
 |------------|-----------|-----|
 | `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| GeoJSON オブジェクト（Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString）| `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
 | `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
-タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+タイプを明示的に指定することもできます：
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -83,7 +80,7 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 ## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
 )
 
-API 検出情報を提供します。
+API ディスカバリ情報を提供します。
 
 ```json
 {
@@ -152,16 +149,14 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP（JSON レスポンスモード）
 - **プロトコルバージョン**: 2025-03-26
-- **動作モード**: ステートレス (Lambda 互換)
+- **動作モード**: ステートレス（Lambda 互換）
 - **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発環境（認証なし）
+#### ローカル開発環境（認証なし）
 
 ```json
 {
@@ -180,11 +175,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` は必須です。これは GeonicDB が Streamable HTTP (POST) のみをサポートしており、SSE が利用できないためです。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要です）。
+> **注意**: `--transport http-only` は GeonicDB が Streamable HTTP (POST) のみをサポートしているため必須です。SSE は利用できません。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要）。
 
-
-
-### 本番環境（JWT 認証あり）
+#### 本番環境（JWT 認証を使用）
 
 ```json
 {
@@ -204,21 +197,19 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンは有効期限があり、定期的な更新が必要です。
+JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
 
+#### 本番環境（API キー認証を使用）
 
+API キーには有効期限がなく、Claude Desktop のような長期的な統合に推奨されます。
 
-### 本番環境（API キー認証あり）
-
-API キーは有効期限がなく、Claude Desktop などの長期的な統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**ステップ 1: GeonicDB CLI をインストール**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: ログインと CLI の設定**
+**ステップ 2: ログインして CLI を設定**
 
 ```bash
 # Set the server URL
@@ -228,7 +219,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**ステップ 3: API キーを作成**
 
 ```bash
 geonic me api-keys create \
@@ -239,7 +230,7 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー（`gdb_` で始まる文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のためにキーを CLI 設定に保存します。
+> **重要**: API キー（`gdb_` プレフィックスの文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のためにキーを CLI 設定に保存します。
 
 API キーで利用可能なスコープ:
 
@@ -252,12 +243,11 @@ API キーで利用可能なスコープ:
 | `read:registrations` | コンテキストソース登録の読み取り |
 | `write:registrations` | 登録の作成、更新、削除 |
 
-**ステップ 4: Claude Desktop の設定**
+**ステップ 4: Claude Desktop を設定**
 
-Claude Desktop 設定ファイルを編集します:
+Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -281,15 +271,13 @@ Claude Desktop 設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列から分離できます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、`args` 配列に認証情報を含めずに済みます。
 
-**ステップ 5: Claude Desktop の再起動**
+**ステップ 5: Claude Desktop を再起動**
 
-設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
+設定を保存した後、Claude Desktop を完全に終了して再起動します。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -301,22 +289,20 @@ geonic me api-keys delete <key-id>
 
 ### テナントの指定
 
-各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
+各ツールには、操作の対象となるテナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
+- **認証が無効の場合**: 省略すると `default` テナントが使用されます。
 - **認証が有効の場合**: 省略すると、ログインしているユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
-### ServicePath仕様
+### ServicePathの仕様
 
-`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+`entities`、`types`、`attributes`、`batch`、`temporal` ツールには、階層スコープ内でエンティティを管理できる `servicePath` パラメータがあります。
 
+#### 基本形式
 
-
-### 基本フォーマット
-
-- **フォーマット**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
-- **デフォルト**: 省略された場合、ルートパス `/` が使用されます
-- **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+- **形式**: `/` で始まるパス(例: `/hello`、`/city/sensors`)
+- **デフォルト**: 省略した場合、ルートパス `/` が使用されます
+- **使用例**: 同一テナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -326,12 +312,10 @@ entities tool:
   servicePath: "/hello"
 ```
 
-
-
-### 階層検索 (`/#`
+#### 階層検索(`/#`
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
+`/#` 接尾辞を使用すると、指定されたパスとそのすべての子パスを検索します。
 
 ```yaml
 # Search /Madrid/Gardens and its child paths (e.g., /Madrid/Gardens/ParqueNorte)
@@ -341,11 +325,9 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
+#### 複数パスの指定(カンマ区切り)
 
-
-### 複数パス指定 (カンマ区切り)
-
-カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
+カンマで区切ることで、複数のパスを同時に検索できます(最大 10 パス)。
 
 ```yaml
 # Search both /park1 and /park2
@@ -355,7 +337,7 @@ entities tool:
   servicePath: "/park1, /park2"
 ```
 
-**注意**: 書き込み操作 (作成、更新、削除) は、単一の非階層パスのみをサポートします。
+**注意**: 書き込み操作(作成、更新、削除)は、単一の非階層パスのみをサポートします。
 
 ### NGSI-LD クエリパラメータ
 
@@ -364,17 +346,17 @@ entities tool:
 | パラメータ | 説明 | 例 |
 |---|---|---|
 | `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
-| `idPattern` | エンティティ ID に一致する正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` をプレフィックスとして付与 | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
-| `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
+| `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
+| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を接頭辞として付ける | `"createdAt"`、`"!modifiedAt"` |
+| `orderDirection` | ソート方向(`!` 接頭辞の代替) | `"asc"`、`"desc"` |
+| `sysAttrs` | 結果にシステム属性(`createdAt`、`modifiedAt`)を含める | `true` |
 | `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
 | `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
 | `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
 | `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
-| `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY フォーマットの空間 ID | `"18/232814/103224"` |
-| `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
+| `geoproperty` | ジオクエリの GeoProperty 属性名(デフォルト: `location`) | `"observationArea"` |
+| `spatialId` | ZFXY 形式の空間 ID | `"18/232814/103224"` |
+| `spatialIdDepth` | 空間 ID の階層検索の深さ | `2` |
 
 ```yaml
 # List entities sorted by creation time (newest first) with system attributes
@@ -425,20 +407,20 @@ curl -X POST http://localhost:3000/mcp \
 ### 制限事項
 
 - **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
-- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
+- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp`(SSE)と `DELETE /mcp`(セッション終了)は 405 を返します。
 - **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です(例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
 - **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
 
-## JSON スキーマとカスタムデータモデル
+## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは、作成時に JSON スキーマ (Draft 2020-12) が自動的に生成されます。この JSON スキーマは、AI ツールで以下の目的に活用できます。
+カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は、AI ツールで以下の目的に活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加の属性を許可します)。厳密な検証を強制するには `false` に設定します。この場合、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、任意の追加属性を許可します)。`false` に設定すると厳密な検証が適用され、定義された属性のみが受け入れられます。AI エージェントはエンティティを作成する際にこのフィールドを確認し、追加属性が許可されているかを判断する必要があります。
 
-### AI ツールでの使用例
+### AI ツールを使用したユースケース例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -457,7 +439,7 @@ entities tool:
     unit: "Celsius"    # enum: ["Celsius", "Fahrenheit", "Kelvin"]
 ```
 
-**検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON スキーマを参照してエラーの原因を特定し、有効な値に修正できます。
+**検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON Schema を参照してエラーの原因を特定し、有効な値に修正できます。
 
 ### エンティティテンプレートの生成
 
@@ -471,7 +453,7 @@ config tool:
   type: "TemperatureSensor"
 ```
 
-**レスポンスの例:**
+**レスポンス例:**
 
 ```json
 {
@@ -492,15 +474,16 @@ config tool:
 }
 ```
 
-テンプレートは、以下の優先順位で値を決定します:
-1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` の値
+テンプレートは以下の優先順位で値を決定します:
+1. `defaultValue` が定義されている場合はそれを使用
+2. `example` が定義されている場合はその値を使用
 3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON スキーマを `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
+`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できます。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -508,7 +491,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON スキーマは、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
 
 ```json
 {
@@ -528,9 +511,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### 語彙マッピングのためのプロパティ @context
+### 語彙マッピングのための Property @context
 
-`propertyDetails` の各プロパティには、オプションで HTTP(S) URL を持つ `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
+`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` 値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -569,11 +552,11 @@ config tool:
 
 ### @context 解決の拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使った JavaScript SDK
+## AI コーディングアシスタントと JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加設定なしで完全なパブリック API を自動的に検出できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は追加の設定なしで完全なパブリック API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
@@ -585,31 +568,31 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向け�
 | クエリパラメータ | `GetEntitiesParams` 型 |
 | サブスクリプションオプション | `SubscribeOptions` 型 |
 | イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言に記載 |
+| 全 10 種類のイベントタイプ | 型宣言でドキュメント化 |
 
 ### 仕組み
 
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完がすぐに利用できます。詳細は SDK ドキュメントを参照してください。
+別途ドキュメントの URL や特別な設定は不要です。TypeScript プロジェクトでは、そのまま完全な型チェックと IDE のオートコンプリートが利用できます。詳細は SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/) をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
 
 ### エンドポイント
 
 | エンドポイント | メソッド | 説明 |
 |----------|--------|-------------|
-| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証を記述 |
-| `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
+| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証方法を記述 |
+| `/a2a` | POST | A2A 操作のための JSON-RPC 2.0 エンドポイント |
 
 ### サポートされているメソッド (フェーズ 1)
 
 | JSON-RPC メソッド | 説明 |
 |-----------------|-------------|
-| `message/send` | メッセージを送信し同期レスポンスを受信 |
+| `message/send` | メッセージを送信し、同期レスポンスを受信 |
 | `tasks/get` | タスクの現在の状態を取得 |
 | `tasks/list` | フィルタリングとページネーションを使用してタスクを一覧表示 |
 | `tasks/cancel` | タスクのキャンセルをリクエスト |
@@ -628,11 +611,11 @@ A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピング�
 
 ### 認証
 
-A2A は REST API と同じ認証方法を使用します:
+A2A は REST API と同じ認証方式を使用します:
 - **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
 - **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` によるクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` 証明ヘッダー (有効化時)
+- **OAuth 2.0**: `POST /oauth/token` によるクライアント資格情報フロー
+- **DPoP**: `Authorization: DPoP <token>` + `DPoP` proof ヘッダー (有効化時)
 
 `Fiware-Service` ヘッダーによるテナント指定を推奨します (未指定時はデフォルトテナントにフォールバック)。
 
@@ -663,11 +646,11 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 
 ### MCP との関係
 
-A2A と MCP は補完的です:
+A2A と MCP は補完的な関係にあります:
 - **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
+- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB をピアエージェントとして協調
 
-両方とも同じ基盤となるサービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
+両者は同じ基盤サービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートしています。
 
 ## 参考資料
 

--- a/docs/ja/ai-integration/overview.md
+++ b/docs/ja/ai-integration/overview.md
@@ -5,11 +5,11 @@ outline: deep
 ---
 # AI 統合
 
-GeonicDB は、AI エージェント(Claude、GPT-4、Gemini など)が API を簡単に利用できるように、複数の AI 向けインターフェースを提供しています。
+GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 指向インターフェースを提供しています。
 
 ## エンドポイント一覧
 
-| エンドポイント | 形式 | 説明 |
+| エンドポイント | フォーマット | 説明 |
 |---------------|------|------|
 | `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
 | `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
@@ -20,36 +20,33 @@ GeonicDB は、AI エージェント(Claude、GPT-4、Gemini など)が API を�
 ## Tool Use スキーマ (`/tools.json`
 )
 
-Claude Tool Use と OpenAI Function Calling に互換性のあるツール定義を提供します。
+Claude Tool Use および OpenAI Function Calling 互換のツール定義を提供します。
 
 ### 利用可能なツール (5 ツール)
 
-各ツールは `action` と `resource` パラメータで操作を選択します。
+各ツールは `action` および `resource` パラメータを介して操作を選択します。
 
 | ツール名 | リソース | アクション | 説明 |
 |---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作(最大 1,000 件) |
-| `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
-| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理(super_admin、get/update/delete) |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理(認証が必要) |
+| `entities` | entities (デフォルト), types, attributes | list, get, create, update, delete, replace, search_by_location, search_by_attribute, get_info, get_all, append, patch_all, patch | IoT エンティティ、タイプ、および属性の管理 |
+| `batch` | - | create, upsert, update, merge, delete, query, purge | 一括エンティティ操作 (最大 1,000 項目) |
+| `temporal` | - | get, query, create, delete, add_attributes, delete_attribute, merge, modify_instance, delete_instance, batch_create, batch_upsert, batch_delete, batch_query | 時系列データ管理 |
+| `config` | rules, jsonld_contexts, data_models, cadde_config | list, get, create, update, delete, activate, deactivate, list_domains, list_models, get_model, generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理 (super_admin, get/update/delete) |
+| `admin` | users, tenants, policies | list, get, create, update, delete, activate, deactivate, change_password | ユーザー、テナント、およびポリシー管理 (認証が必要) |
 
-### NGSI-LD 属性タイプの自動検出
+### 自動 NGSI-LD 属性タイプ検出
 
 MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 
 | 値のパターン | 検出されるタイプ | 例 |
 |------------|-----------|-----|
 | `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| GeoJSON オブジェクト (Point, Polygon, LineString, MultiPoint, MultiPolygon, MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
 | `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -83,7 +80,7 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 ## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
 )
 
-API 検出情報を提供します。
+API ディスカバリー情報を提供します。
 
 ```json
 {
@@ -148,20 +145,18 @@ response = client.chat.completions.create(
 
 ## MCP (Model Context Protocol) サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント(Claude Desktop など)はコンテキストブローカーに直接接続できます。
+GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント (Claude Desktop など) はコンテキストブローカーに直接接続できます。
 
 ### 概要
 
 - **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
-- **動作モード**: ステートレス(Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
+- **動作モード**: ステートレス (Lambda 互換)
+- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンを介してアクセス制御とテナント分離が適用されます
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発環境 (認証なし)
+#### ローカル開発環境（認証なし）
 
 ```json
 {
@@ -180,11 +175,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` は、GeonicDB が Streamable HTTP (POST) のみをサポートしているため必須です（SSE は利用できません）。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要）。
+> **注意**: `--transport http-only` は、GeonicDB が Streamable HTTP (POST) のみをサポートしているため必須です。SSE は利用できません。`--allow-http` は `http://` URL に必要です（本番環境の `https://` には不要です）。
 
-
-
-### 本番環境 (JWT 認証を使用)
+#### 本番環境（JWT 認証を使用）
 
 ```json
 {
@@ -204,21 +197,19 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
+JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンは有効期限があり、定期的な更新が必要です。
 
+#### 本番環境（API キー認証を使用）
 
+API キーは有効期限がなく、Claude Desktop のような長期間にわたる統合に推奨されます。
 
-### 本番環境 (API キー認証を使用)
-
-API キーには有効期限がなく、Claude Desktop などの長期間の統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**ステップ 1: GeonicDB CLI をインストール**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: CLI へのログインと設定**
+**ステップ 2: ログインして CLI を設定**
 
 ```bash
 # Set the server URL
@@ -228,7 +219,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**ステップ 3: API キーを作成**
 
 ```bash
 geonic me api-keys create \
@@ -239,9 +230,9 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー (`gdb_` プレフィックスの文字列) は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグを使用すると、自動使用のために CLI 設定にキーが保存されます。
+> **重要**: API キー（`gdb_` で始まる文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグを使用すると、CLI の設定にキーが保存され、自動的に使用されます。
 
-API キーの利用可能なスコープ:
+API キーで利用可能なスコープ:
 
 | スコープ | 説明 |
 |---|---|
@@ -252,13 +243,11 @@ API キーの利用可能なスコープ:
 | `read:registrations` | コンテキストソース登録の読み取り |
 | `write:registrations` | 登録の作成、更新、削除 |
 
-**ステップ 4: Claude Desktop の設定**
+**ステップ 4: Claude Desktop を設定**
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -282,15 +271,13 @@ Claude Desktop の設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保つことができます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列から分離できます。
 
-**ステップ 5: Claude Desktop の再起動**
+**ステップ 5: Claude Desktop を再起動**
 
 設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されます。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -304,20 +291,18 @@ geonic me api-keys delete <key-id>
 
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効な場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効な場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントのみにアクセスできます。
+- **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
+- **認証が有効の場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
-### ServicePathの指定
+### サービス パスの指定
 
 `entities`、`types`、`attributes`、`batch`、および `temporal` ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
 
+#### 基本形式
 
-
-### 基本フォーマット
-
-- **フォーマット**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
-- **デフォルト**: 省略した場合、ルートパス `/` が使用されます
-- **ユースケース**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+- **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
+- **デフォルト**: 省略した場合、ルート パス `/` が使用されます
+- **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -327,9 +312,7 @@ entities tool:
   servicePath: "/hello"
 ```
 
-
-
-### 階層検索 (`/#`
+#### 階層検索 (`/#`
 )
 
 `/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
@@ -342,11 +325,9 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
+#### 複数パスの指定 (カンマ区切り)
 
-
-### 複数パスの指定 (カンマ区切り)
-
-カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
+複数のパスをカンマで区切って同時に検索できます (最大 10 パス)。
 
 ```yaml
 # Search both /park1 and /park2
@@ -358,23 +339,23 @@ entities tool:
 
 **注意**: 書き込み操作 (作成、更新、削除) は、単一の非階層パスのみをサポートします。
 
-### NGSI-LD クエリパラメータ
+### NGSI-LD クエリ パラメータ
 
-`entities` ツールは、NGSI-LD クエリパラメータの完全なセットをサポートします:
+`entities` ツールは、NGSI-LD クエリ パラメータの完全なセットをサポートしています:
 
 | パラメータ | 説明 | 例 |
 |---|---|---|
 | `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
 | `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を前に付ける | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
+| `orderBy` | 属性またはシステム フィールドでソート。降順の場合は `!` を接頭辞として付ける | `"createdAt"`、`"!modifiedAt"` |
+| `orderDirection` | ソート方向 (`!` 接頭辞の代替) | `"asc"`、`"desc"` |
 | `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
-| `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
-| `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
-| `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
+| `pick` | 含める属性名をカンマ区切りで指定 | `"temperature,humidity"` |
+| `omit` | 除外する属性名をカンマ区切りで指定 | `"status"` |
+| `scopeQ` | スコープ クエリ式 | `"/Madrid/Gardens"` |
 | `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
 | `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY フォーマットの空間 ID | `"18/232814/103224"` |
+| `spatialId` | ZFXY 形式の空間 ID | `"18/232814/103224"` |
 | `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
 
 ```yaml
@@ -399,7 +380,7 @@ entities tool:
   q: "temperature>20"
 ```
 
-`batch` ツールの `query` アクションも `orderBy`、`orderDirection`、および `sysAttrs` をサポートします。
+`batch` ツールの `query` アクションは、`orderBy`、`orderDirection`、および `sysAttrs` もサポートしています。
 
 ### 検証
 
@@ -425,21 +406,21 @@ curl -X POST http://localhost:3000/mcp \
 
 ### 制限事項
 
-- **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
+- **ステートレス モード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) および `DELETE /mcp` (セッション終了) は 405 を返します。
-- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
+- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が続行されます。
+- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージ クォータ、およびリクエスト本文サイズ制限の対象となります。
 
 ## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは作成時に、JSON Schema (Draft 2020-12) が自動的に生成されます。この JSON Schema は、以下の目的で AI ツールに活用できます。
+カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は AI ツールで以下の目的に活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持てるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加属性を許可します)。`false` に設定すると厳密な検証が強制され、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加属性が許可されているかどうかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、任意の追加属性を許可) です。`false` に設定すると厳密な検証が適用され、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加属性が許可されているかどうかを判断する必要があります。
 
-### AI ツールでのユースケース例
+### AI ツールでの使用例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -462,7 +443,7 @@ entities tool:
 
 ### エンティティテンプレート生成
 
-`config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+`config` ツールの `generate_template` アクションを使用して、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
 
 ```yaml
 # Generate a template
@@ -494,10 +475,10 @@ config tool:
 ```
 
 テンプレートは以下の優先順位で値を決定します:
-1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` 値
+1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` の値
 3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
@@ -509,7 +490,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema はレスポンスの `components.schemas` に追加されます:
 
 ```json
 {
@@ -529,9 +510,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### ボキャブラリマッピングのための Property @context
+### 語彙マッピングのためのプロパティ @context
 
-`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致するボキャブラリを確認し、それを `@context` 値として設定してください。
+`propertyDetails` の各プロパティには、オプションで HTTP(S) URL を持つ `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -554,7 +535,7 @@ config tool:
       # No @context → auto-generated URL
 ```
 
-生成される JSON-LD `@context` は次のようになります:
+生成される JSON-LD `@context` は以下のようになります:
 
 ```json
 {
@@ -572,9 +553,9 @@ config tool:
 
 NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使用した JavaScript SDK
+## AI コーディングアシスタントと JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加の設定なしで完全なパブリック API を自動的に発見できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は追加の設定なしで完全なパブリック API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
@@ -586,18 +567,18 @@ GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向け�
 | クエリパラメータ | `GetEntitiesParams` 型 |
 | サブスクリプションオプション | `SubscribeOptions` 型 |
 | イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言にドキュメント化 |
+| すべての 10 個のイベントタイプ | 型宣言でドキュメント化 |
 
-### 仕組み
+### 動作の仕組み
 
 1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
 4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがそのまま利用できます。詳細は SDK ドキュメントを参照してください。
+別のドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完がすぐに利用できます。詳細については SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/) をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
 
 ### エンドポイント
 
@@ -606,13 +587,13 @@ GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A
 | `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証方法を記述 |
 | `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
 
-### サポートされているメソッド (フェーズ 1)
+### サポートされるメソッド (フェーズ 1)
 
 | JSON-RPC メソッド | 説明 |
 |-----------------|-------------|
-| `message/send` | メッセージを送信し、同期的なレスポンスを受信 |
+| `message/send` | メッセージを送信し、同期レスポンスを受信 |
 | `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションによるタスクの一覧表示 |
+| `tasks/list` | フィルタリングとページネーションでタスクを一覧表示 |
 | `tasks/cancel` | タスクのキャンセルをリクエスト |
 
 ### スキル
@@ -632,10 +613,10 @@ A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピング�
 A2A は REST API と同じ認証方法を使用します:
 - **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
 - **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` によるクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効な場合)
+- **OAuth 2.0**: `POST /oauth/token` 経由のクライアントクレデンシャルフロー
+- **DPoP**: `Authorization: DPoP <token>` + `DPoP` 証明ヘッダー (有効な場合)
 
-`Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
+`Fiware-Service` ヘッダーによるテナント指定を推奨します (未指定時はデフォルトテナントにフォールバック)。
 
 ### 例: メッセージの送信
 
@@ -664,13 +645,13 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 
 ### MCP との関係
 
-A2A と MCP は補完的な関係にあります:
+A2A と MCP は補完的です:
 - **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして連携
+- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-両方とも同じ基盤となるサービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートしています。
+両方とも同じ基盤サービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
-## 参考文献
+## 参考資料
 
 - [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
 - [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)

--- a/docs/ja/ai-integration/tools-json.md
+++ b/docs/ja/ai-integration/tools-json.md
@@ -3,9 +3,9 @@ title: "tools.json"
 description: "AI tool definitions (tools.json)"
 outline: deep
 ---
-# AI インテグレーション
+# AI 統合
 
-GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 向けインターフェースを提供しています。
+GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 向けインターフェースを提供します。
 
 ## エンドポイント一覧
 
@@ -17,26 +17,26 @@ GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API �
 | `GET /openapi.json` | JSON | OpenAPI 3.0 仕様 |
 | `GET /api.json` | JSON | API リファレンス |
 
-## Tool Use スキーマ (`/tools.json`
+## ツール使用スキーマ (`/tools.json`
 )
 
 Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
 
 ### 利用可能なツール (5 つのツール)
 
-各ツールは `action` および `resource` パラメータで操作を選択します。
+各ツールは `action` と `resource` パラメータで操作を選択します。
 
 | ツール名 | リソース | アクション | 説明 |
 |---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作 (最大 1,000 アイテム) |
+| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、および属性の管理 |
+| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作 (最大 1,000 件) |
 | `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
 | `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理 (super_admin、get/update/delete) |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理 (認証が必要) |
+| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、およびポリシー管理 (認証が必要) |
 
 ### NGSI-LD 属性タイプの自動検出
 
-MCP ツールは、属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 
 | 値のパターン | 検出されるタイプ | 例 |
 |------------|-----------|-----|
@@ -46,10 +46,7 @@ MCP ツールは、属性値から NGSI-LD タイプを自動的に推論しま�
 | その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
-### レスポンス構造
+- `{"type": "Property", "value": 25.5}`- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`### レスポンス構造
 
 ```json
 {
@@ -148,7 +145,7 @@ response = client.chat.completions.create(
 
 ## MCP (Model Context Protocol) サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント (Claude Desktop など) は、コンテキストブローカーに直接接続できます。
+GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント (Claude Desktop など) はコンテキストブローカーに直接接続できます。
 
 ### 概要
 
@@ -159,9 +156,7 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発 (認証なし)
+#### ローカル開発環境（認証なし）
 
 ```json
 {
@@ -180,11 +175,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` が必要です。GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できません。`--allow-http` は `http://` URL に必要です (本番環境の `https://` では不要です)。
+> **注意**: `--transport http-only` が必要です。これは GeonicDB が Streamable HTTP (POST) のみをサポートしているためです。SSE は利用できません。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要です）。
 
-
-
-### 本番環境 (JWT 認証を使用)
+#### 本番環境（JWT 認証を使用）
 
 ```json
 {
@@ -206,19 +199,17 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
 
+#### 本番環境（API キー認証を使用）
 
+API キーは有効期限がなく、Claude Desktop のような長期間の統合に推奨されます。
 
-### 本番環境 (API キー認証を使用)
-
-API キーには有効期限がなく、Claude Desktop などの長期間使用する統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**手順 1: GeonicDB CLI のインストール**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: ログインと CLI の設定**
+**手順 2: CLI へのログインと設定**
 
 ```bash
 # Set the server URL
@@ -228,7 +219,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**手順 3: API キーの作成**
 
 ```bash
 geonic me api-keys create \
@@ -239,7 +230,7 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー (`gdb_` プレフィックスの文字列) は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
+> **重要**: API キー（`gdb_` で始まる文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
 
 API キーで利用可能なスコープ:
 
@@ -252,12 +243,11 @@ API キーで利用可能なスコープ:
 | `read:registrations` | コンテキストソース登録の読み取り |
 | `write:registrations` | 登録の作成、更新、削除 |
 
-**ステップ 4: Claude Desktop の設定**
+**手順 4: Claude Desktop の設定**
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-```json
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json````json
 {
   "mcpServers": {
     "geonicdb": {
@@ -281,15 +271,13 @@ Claude Desktop の設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保持できます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、`args` 配列に認証情報を記述せずに済みます。
 
-**ステップ 5: Claude Desktop の再起動**
+**手順 5: Claude Desktop の再起動**
 
 設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -303,20 +291,18 @@ geonic me api-keys delete <key-id>
 
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効の場合**: 省略すると、ログイン中のユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
+- **認証が無効な場合**: 省略すると、`default` テナントが使用されます。
+- **認証が有効な場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
-### ServicePathの指定
+### ServicePath指定
 
-`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには `servicePath` パラメータがあり、階層的なスコープ内でエンティティを管理できます。
 
-
-
-### 基本形式
+#### 基本形式
 
 - **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
 - **デフォルト**: 省略した場合、ルートパス `/` が使用されます
-- **ユースケース**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+- **用途**: 同一テナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -326,9 +312,7 @@ entities tool:
   servicePath: "/hello"
 ```
 
-
-
-### 階層検索 (`/#`
+#### 階層検索 (`/#`
 )
 
 `/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
@@ -341,11 +325,9 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
+#### 複数パス指定 (カンマ区切り)
 
-
-### 複数パスの指定 (カンマ区切り)
-
-カンマで区切ることで、複数のパス (最大 10 パス) を同時に検索できます。
+複数のパスをカンマで区切って指定することで、同時に検索できます (最大 10 パス)。
 
 ```yaml
 # Search both /park1 and /park2
@@ -363,11 +345,11 @@ entities tool:
 
 | パラメータ | 説明 | 例 |
 |---|---|---|
-| `idList` | 一括取得用のカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
+| `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
 | `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を接頭辞として付ける | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` 接頭辞の代替) | `"asc"`、`"desc"` |
-| `sysAttrs` | システム属性 (`createdAt`、`modifiedAt`) を結果に含める | `true` |
+| `orderBy` | 属性またはシステムフィールドで並べ替え。降順の場合は `!` を前置 | `"createdAt"`、`"!modifiedAt"` |
+| `orderDirection` | 並べ替え方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
+| `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
 | `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
 | `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
 | `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
@@ -427,18 +409,18 @@ curl -X POST http://localhost:3000/mcp \
 - **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
 - **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
 - **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
 - **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
 
 ## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は AI ツールで以下の目的に利用できます。
+カスタムデータモデルは、作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は、AI ツールによって以下の目的で活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加属性を許可) です。`false` に設定すると厳密な検証が適用され、定義された属性のみが受け入れられます。AI エージェントはエンティティ作成時にこのフィールドを確認して、追加属性が許可されているかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` です(NGSI-LD のセマンティクスに従い、追加の属性を許可します)。`false` に設定すると、厳密な検証が強制されます — 定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
 
 ### AI ツールでの使用例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照することで、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -461,7 +443,7 @@ entities tool:
 
 ### エンティティテンプレート生成
 
-`config` ツールの `generate_template` アクションを使用することで、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+`config` ツールの `generate_template` アクションを使用して、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
 
 ```yaml
 # Generate a template
@@ -492,16 +474,16 @@ config tool:
 }
 ```
 
-テンプレートは以下の優先順位で値を決定します:
+テンプレートは、以下の優先順位で値を決定します:
 1. `defaultValue` が定義されている場合はその値
-2. `example` の値が定義されている場合はその値
-3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
+2. `example` 値が定義されている場合はその値
+3. `valueType` に基づくデフォルト値(string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントはこのテンプレートをベースとして、ユーザーの指示に従って値を変更し、エンティティを作成できます。
+AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールは、テナント固有のデータモデルを自動的に認識できるようになります。
+`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -529,9 +511,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### 語彙マッピングのための Property @context
+### 語彙マッピングのためのプロパティ @context
 
-`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
+`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` 値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -566,38 +548,38 @@ config tool:
 }
 ```
 
-プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
+プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名(例: `email`)は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
 ### @context 解決の拡張
 
 NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使用した JavaScript SDK
+## AI コーディングアシスタントと JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は追加設定なしで完全なパブリック API を自動的に認識できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント(Claude Code、Cursor、GitHub Copilot など)は、追加の設定なしに完全なパブリック API を自動的に発見できます。
 
 ### AI ツールが SDK から学習する内容
 
 | 情報 | ソース |
 |------------|--------|
 | コンストラクタオプション | `GeonicDBOptions` 型 |
-| メソッドシグネチャ (17 メソッド) | TypeScript 宣言 |
+| メソッドシグネチャ(17 メソッド) | TypeScript 宣言 |
 | 認証情報の型 | `CredentialsOptions`、`RefreshedCredentials` 型 |
 | クエリパラメータ | `GetEntitiesParams` 型 |
 | サブスクリプションオプション | `SubscribeOptions` 型 |
 | イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言内に文書化 |
+| 全 10 種類のイベントタイプ | 型宣言にドキュメント化 |
 
-### 動作の仕組み
+### 仕組み
 
-1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取り
-4. AI が文書化された API を使用して正しいコードを生成
+1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
+4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細は SDK ドキュメントを参照してください。
+別途ドキュメント URL や特別な設定は必要ありません。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがすぐに使えます。詳細については、SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent プロトコル) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/) をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
 
 ### エンドポイント
 
@@ -610,14 +592,14 @@ GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A
 
 | JSON-RPC メソッド | 説明 |
 |-----------------|-------------|
-| `message/send` | メッセージを送信し、同期レスポンスを受信 |
+| `message/send` | メッセージを送信し、同期的なレスポンスを受信 |
 | `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションによるタスク一覧取得 |
+| `tasks/list` | フィルタリングとページネーションでタスクを一覧表示 |
 | `tasks/cancel` | タスクのキャンセルをリクエスト |
 
 ### スキル
 
-A2A は MCP で利用可能な同じ 5 つのツールにマッピングされます:
+A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピングされます:
 
 | スキル ID | 説明 |
 |----------|-------------|
@@ -632,8 +614,8 @@ A2A は MCP で利用可能な同じ 5 つのツールにマッピングされ�
 A2A は REST API と同じ認証方法を使用します:
 - **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
 - **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` を介したクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効時)
+- **OAuth 2.0**: `POST /oauth/token` 経由のクライアントクレデンシャルフロー
+- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効化時)
 
 `Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
 
@@ -668,12 +650,12 @@ A2A と MCP は補完的な関係にあります:
 - **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
 - **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-両者は同じ基盤サービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
+どちらも同じ基盤サービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
-## 参考資料
+## 参考文献
 
 - [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
 - [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
-- [A2A Protocol](https://google.github.io/A2A/)
+- [A2A プロトコル](https://google.github.io/A2A/)
 - [llms.txt](https://llmstxt.org/)

--- a/docs/ja/api-reference/endpoints.md
+++ b/docs/ja/api-reference/endpoints.md
@@ -9,7 +9,7 @@ outline: deep
 
 ## 目次
 
-- [概要](#概要)
+- [概要](#overview)
 - [認証とマルチテナンシー](#認証とマルチテナンシー)
 - [ページネーション](#ページネーション)
 - [認証 API](#認証-api)
@@ -17,13 +17,13 @@ outline: deep
 - [NGSIv2 API](#ngsiv2-api) (→ [API_NGSIV2.md](./ngsiv2.md))
 - [NGSI-LD API](#ngsi-ld-api) (→ [API_NGSILD.md](./ngsild.md))
 - [クエリ言語](#クエリ言語)
-- [ジオクエリ](#ジオクエリ)
-- [空間 ID 検索](#空間-id-検索)
+- [地理クエリ](#geo-queries)
+- [空間 ID 検索](#spatial-id-search)
 - [GeoJSON 出力](#geojson-出力)
-- [ベクタータイル](#ベクタータイル)
+- [ベクトルタイル](#vector-tiles)
 - [座標参照系 (CRS)](#座標参照系-crs)
-- [データカタログ API](#データカタログ-api)
-- [CADDE 統合](#cadde-統合)
+- [データカタログ API](#data-catalog-api)
+- [CADDE 連携](#cadde-integration)
 - [イベントストリーミング](#イベントストリーミング)
 - [エラーレスポンス](#エラーレスポンス)
 - [実装状況](#実装状況)
@@ -35,7 +35,7 @@ outline: deep
 この Context Broker は、FIWARE NGSI (Next Generation Service Interface) 仕様に準拠した RESTful API を提供します。
 
 **関連ドキュメント:**
-- [NGSIv2 / NGSI-LD 互換性ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の互換性、型マッピング、ベストプラクティス
+- [NGSIv2 / NGSI-LD 相互運用ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の相互運用性、型マッピング、ベストプラクティス
 - [WebSocket イベントストリーミング](../features/subscriptions.md) - リアルタイムイベントサブスクリプション、実装例、ベストプラクティス
 
 ### ベース URL
@@ -53,7 +53,7 @@ https://{api-gateway-url}/{stage}
 
 ### OPTIONS メソッド
 
-`OPTIONS` メソッドはすべてのエンドポイントでサポートされています。CORS プリフライトリクエストに対して、許可されたメソッドとヘッダーに関する情報を返します。
+`OPTIONS` メソッドは全てのエンドポイントでサポートされています。CORS プリフライトリクエストに応答して、許可されているメソッドとヘッダーに関する情報を返します。
 
 #### レスポンス形式
 
@@ -70,7 +70,7 @@ Access-Control-Allow-Headers: Content-Type, Fiware-Service, Fiware-ServicePath, 
 Access-Control-Max-Age: 86400
 ```
 
-NGSI-LD エンドポイントの場合、追加の `Accept-Patch` ヘッダーも返されます:
+NGSI-LD エンドポイントの場合、追加で `Accept-Patch` ヘッダーも返されます:
 
 ```http
 OPTIONS /ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1
@@ -84,21 +84,21 @@ Access-Control-Allow-Headers: Content-Type, NGSILD-Tenant, Fiware-Service, Link,
 Access-Control-Max-Age: 86400
 ```
 
-> **注意**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証や SDK の条件付きリクエストがプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
+> **注意**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証や SDK の条件付きリクエストをプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
 
 ### エンティティ ID の一意性 (GeonicDB 拡張)
 
-> **GeonicDB 拡張**: この動作は、同じ ID で異なる型を持つエンティティの共存を許可する標準 NGSIv2 仕様とは異なります。
+> **GeonicDB 拡張**: この動作は標準 NGSIv2 仕様とは異なります。標準仕様では、同じ ID で異なる型を持つエンティティが共存できます。
 
-GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の一部では **ありません**。
+GeonicDB では、エンティティ ID は**テナント** (`Fiware-Service`) と**ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の一部では**ありません**。
 
-**主な動作:**
+**主要な動作:**
 
-- 既存のエンティティと同じ ID でエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- バッチ upsert 操作は `entityId` のみでエンティティをマッチングします (型は上書き可能)
-- 同一 ID のエンティティ間で型を区別するための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
+- 既存のエンティティと同じ ID を持つエンティティを作成する場合(異なる `type` であっても) `409 AlreadyExists` を返します
+- バッチアップサート操作は `entityId` のみでエンティティをマッチングします(型は上書き可能)
+- 同一 ID エンティティ間の型の曖昧さを解消するための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
 
-この設計は NGSI-LD 仕様に準拠しており、エンティティ ID は URI であり、本質的に一意です。エンティティ ID は、テナント、servicePath、プロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
+この設計は NGSI-LD 仕様と整合しており、エンティティ ID は URI であり本質的に一意です。エンティティ ID は、テナント、servicePath、プロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
 
 ---
 
@@ -106,12 +106,12 @@ GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) 
 
 ### 必須ヘッダー
 
-すべてのリクエストには、以下のヘッダーを含めることを推奨します:
+すべてのリクエストには、以下のヘッダーを含めることが推奨されます。
 
 | ヘッダー | 必須 | 説明 | デフォルト |
 |--------|------|------|---------|
 | `Fiware-Service` / `NGSILD-Tenant` | 推奨 | テナント名 (英数字とアンダースコアのみ) | `default` |
-| `Fiware-ServicePath` | NGSIv2 のみ | テナント内の階層パス (`/` で開始)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/` (クエリ時は `/#` と同等) |
+| `Fiware-ServicePath` | NGSIv2 のみ | テナント内の階層パス (`/` で始まる)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/` (クエリの場合は `/#` と同等) |
 | `Fiware-Correlator` | オプション | リクエストトレーシング用の相関 ID | 自動生成 |
 
 ### 使用例
@@ -122,7 +122,7 @@ curl -X GET "https://api.example.com/v2/entities" \
   -H "Fiware-ServicePath: /buildings/floor1"
 ```
 
-### テナントの分離
+### テナント分離
 
 - 異なる `Fiware-Service` 値のデータは完全に分離されます
 - 同じテナント内では、`Fiware-ServicePath` を使用してデータを階層的に整理できます
@@ -130,13 +130,13 @@ curl -X GET "https://api.example.com/v2/entities" \
 
 ### ServicePathの仕様
 
-[FIWARE Orion 仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html) に準拠しています。
+[FIWARE Orion の仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html) に準拠しています。
 
 #### 基本形式
 
-- `/` で始まる絶対パスのみ許可されます
-- 英数字とアンダースコアのみ許可されます
-- 最大 10 階層、各レベル最大 50 文字
+- `/` で始まる絶対パスのみが許可されます
+- 英数字とアンダースコアのみが許可されます
+- 最大 10 階層、各階層は最大 50 文字まで
 
 ```bash
 # Retrieve entities at a specific path
@@ -172,10 +172,10 @@ curl "http://localhost:3000/v2/entities" \
 
 | 操作 | ヘッダー省略時 | 説明 |
 |------|--------------|------|
-| クエリ (GET) | `/` | ルートパスのみ検索 |
-| 書き込み (POST/PUT/PATCH/DELETE) | `/` | ルートパスで作成/更新 |
+| クエリ (GET) | `/` | ルートパスのみを検索 |
+| 書き込み (POST/PUT/PATCH/DELETE) | `/` | ルートパスに作成/更新 |
 
-**注意**: 書き込み操作では、単一の非階層パスのみ使用できます。`/#` や複数パスを指定するとエラーになります。
+**注意**: 書き込み操作では、階層化されていない単一のパスのみを使用できます。`/#` や複数のパスを指定するとエラーになります。
 
 ---
 
@@ -192,7 +192,7 @@ curl "http://localhost:3000/v2/entities" \
 
 ### レスポンスヘッダー
 
-各 API タイプごとに、合計数を示すヘッダーが返されます:
+各 API タイプに対して、総件数を示すヘッダーが返されます:
 
 | API | ヘッダー名 | 条件 |
 |-----|-------------|-----------|
@@ -209,7 +209,7 @@ curl "http://localhost:3000/v2/entities" \
 Link: <https://api.example.com/v2/entities?limit=10&offset=20>; rel="next", <https://api.example.com/v2/entities?limit=10&offset=0>; rel="prev"
 ```
 
-### 検証
+### バリデーション
 
 無効なページネーションパラメータは `400 Bad Request` を返します:
 
@@ -219,7 +219,7 @@ Link: <https://api.example.com/v2/entities?limit=10&offset=20>; rel="next", <htt
 | 負の offset | `Invalid offset: must not be negative` |
 | limit=0 | `Invalid limit: must be greater than 0` |
 | 最大値を超過 | `Invalid limit: must not exceed 1000` |
-| 数値以外 | `Invalid limit: must be a valid integer` |
+| 非数値 | `Invalid limit: must be a valid integer` |
 
 ### 使用例
 
@@ -235,42 +235,42 @@ curl "http://localhost:3000/v2/entities?limit=10&options=count" \
 
 ### 注意事項
 
-- `offset` が合計数を超える場合、空の配列が返されます (エラーではありません)
-- FIWARE Orion の仕様に準拠しています
+- `offset` が総件数を超える場合、空の配列が返されます (エラーではありません)
+- FIWARE Orion 仕様に準拠しています
 
 ---
 
-## HTTP キャッシュコントロール (ETag / 条件付きリクエスト)
+## HTTP キャッシュ制御 (ETag / 条件付きリクエスト)
 
-GET エンドポイントはエンドポイントクラスに基づいてキャッシュ関連ヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップでき、[RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠しています。
+GET エンドポイントは、エンドポイントクラスに基づいてキャッシュ関連のヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップでき、[RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠します。
 
 ### エンドポイントクラス
 
-| クラス | エンドポイント | バリデータ (ETag/Last-Modified) | 条件付きリクエスト | Cache-Control |
+| クラス | エンドポイント | バリデーター (ETag/Last-Modified) | 条件付きリクエスト | Cache-Control |
 |-------|-----------|-------------------------------|----------------------|---------------|
 | **Data** | `/v2/entities` (リスト、単一、attrs、attrs/{name}、attrs/{name}/value)、`/v2/subscriptions`、`/v2/registrations`、`/ngsi-ld/v1/entities` (リスト、単一、attrs、attrs/{name})、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions` | ✓ | ✓ (`If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache` |
-| **Temporal** | `/ngsi-ld/v1/temporal/entities` (リストと単一、集約を含む) | ✗ (ETag なし — 時系列集約には安価な単調バリデータがない) | ✗ | `private, no-cache` |
-| **Meta** | `/v2/types`、`/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes` (リストと単一) | ✗ (ETag なし、Last-Modified なし) | ✗ (`304` サポートなし) | `max-age=60, stale-while-revalidate=120` |
+| **Temporal** | `/ngsi-ld/v1/temporal/entities` (リストおよび単一、集約を含む) | ✗ (ETag なし — 時系列集約には安価な単調バリデーターが欠けている) | ✗ | `private, no-cache` |
+| **Meta** | `/v2/types`、`/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes` (リストおよび単一) | ✗ (ETag なし、Last-Modified なし) | ✗ (`304` サポートなし) | `max-age=60, stale-while-revalidate=120` |
 
-すべてのキャッシュ制御されたレスポンスは同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーション分離、CloudFront のような共有キャッシュに必要)。
+すべてのキャッシュ制御されたレスポンスは、同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーション分離、CloudFront などの共有キャッシュに必須)。
 
 ### レスポンスヘッダー (Data エンドポイント)
 
 | ヘッダー | 説明 |
 |--------|-------------|
-| `ETag` | 弱いエンティティタグ (`W/"..."`、RFC 7232 §2.3.2 弱いバリデータ)。生成は常に **リソーススコープ** (`path + Accept + tenant + Fiware-ServicePath`) をシードに混ぜ込むため、異なるエンドポイント、Accept フォーマット、**テナント**、または **ServicePath** は、基礎となる状態が同一であっても異なる ETag を生成します。`tenant` スロットは最初に `NGSILD-Tenant` を読み取り、`Fiware-Service` にフォールバックし、`extractTenantContext` の優先順位と一致します。テナント / ServicePathシードは、中間キャッシュが `Vary` を誤って処理した場合でも、テナント間の ETag 衝突を防ぎます。<br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェスト、合計カウントとリソーススコープと組み合わせ。<br>• **単一リソース**: `modifiedAt` のハッシュとリソーススコープの組み合わせ。|
-| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP 日付。|
-| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) への保存を禁止します。`no-cache` はプライベートキャッシュからの再利用前に再検証を強制します。|
+| `ETag` | 弱いエンティティタグ (`W/"..."`、RFC 7232 §2.3.2 弱いバリデーター)。生成時には常に **リソーススコープ** (`path + Accept + tenant + Fiware-ServicePath`) をシードに混合するため、基礎となる状態が同一であっても、異なるエンドポイント、Accept フォーマット、**テナント**、または **ServicePath** では異なる ETag が生成されます。`tenant` スロットは最初に `NGSILD-Tenant` を読み取り、`Fiware-Service` にフォールバックし、`extractTenantContext` の優先順位と一致します。テナント / ServicePathのシードは、中間キャッシュで `Vary` が誤処理された場合でも、クロステナント ETag 衝突を防ぎます。<br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェストを、総数とリソーススコープと組み合わせます。<br>• **単一リソース**: `modifiedAt` のハッシュをリソーススコープと組み合わせます。|
+| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP-date。|
+| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) での保存を禁止します。`no-cache` はプライベートキャッシュから再利用する前に再検証を強制します。|
 | `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`。|
 
 ### レスポンスヘッダー (Meta エンドポイント)
 
 | ヘッダー | 説明 |
 |--------|-------------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証による短期キャッシング。|
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証を伴う短期キャッシング。|
 | `Vary` | Data エンドポイントと同じ。|
 
-Meta エンドポイントは意図的に `ETag` / `Last-Modified` を省略します。これは、そのコンテンツが安価な単調バリデータを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストではなく `max-age` に依存する必要があります。
+Meta エンドポイントは意図的に `ETag` / `Last-Modified` を省略しています。これらのコンテンツは、安価な単調バリデーターを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストではなく `max-age` に依存すべきです。
 
 ### 条件付きリクエスト (Data エンドポイントのみ)
 
@@ -278,7 +278,7 @@ Meta エンドポイントは意図的に `ETag` / `Last-Modified` を省略し�
 
 | リクエストヘッダー | 動作 |
 |----------------|----------|
-| `If-None-Match: <ETag>` | サーバーは現在の `ETag` と比較します。一致する場合、`304` を返します。ワイルドカード `*` は常に一致します。|
+| `If-None-Match: <ETag>` | サーバーは現在の `ETag` と比較します。一致した場合、`304` を返します。ワイルドカード `*` は常に一致します。|
 | `If-Modified-Since: <HTTP-date>` | サーバーは現在の `Last-Modified` と比較します。変更されていない場合、`304` を返します。|
 
 両方のヘッダーが存在する場合、RFC 7232 §6 に従い `If-None-Match` が優先されます。
@@ -304,22 +304,22 @@ curl -i "http://localhost:3000/v2/entities" \
 
 ### 注記
 
-- ETag は弱い (`W/`) です — これらはバイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータを持つが属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
-- ETag 生成はリソースパスと `Accept` ヘッダーをシードに含めます。異なるエンドポイントと異なるコンテンツネゴシエーションは、基礎となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
+- ETag は弱い (`W/`) — バイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータだが属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
+- ETag 生成には、リソースパスと `Accept` ヘッダーがシードに含まれます。基礎となる状態 (例: 空のリスト) が同一であっても、異なるエンドポイントと異なるコンテンツネゴシエーションでは常に異なる ETag が生成され、クロスエンドポイントまたはクロス Accept キャッシュポイズニングを防ぎます。
 - `304` レスポンスは `ETag`、`Last-Modified`、`Cache-Control`、`Vary`、および CORS ヘッダーを保持します。
-- 条件評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
-- キャッシュコントロールは以下に適用されます:
-  - **NGSIv2**: `/v2/entities` (リスト / 単一 / attrs / attrs+name / attrs+name+value)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`  - **NGSI-LD Data**: `/ngsi-ld/v1/entities` (リスト / 単一 / attrs / attrs+name)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`  - **NGSI-LD Meta**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`  - **NGSI-LD Temporal**: `/ngsi-ld/v1/temporal/entities` (リストと単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
+- 条件付き評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
+- キャッシュ制御が適用される対象:
+  - **NGSIv2**: `/v2/entities` (リスト / 単一 / attrs / attrs+name / attrs+name+value)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`  - **NGSI-LD Data**: `/ngsi-ld/v1/entities` (リスト / 単一 / attrs / attrs+name)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`  - **NGSI-LD Meta**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`  - **NGSI-LD Temporal**: `/ngsi-ld/v1/temporal/entities` (リストおよび単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
 
-### クライアント主導のキャッシュコントロール
+### クライアント主導のキャッシュ制御
 
 クライアントは `Cache-Control` リクエストヘッダーを送信して、キャッシング動作に影響を与えることができます:
 
 | リクエストヘッダー | サーバーの動作 |
 |----------------|-----------------|
-| `Cache-Control: no-store` | サーバーはレスポンス `Cache-Control` を `no-store` にオーバーライドします (CDN / 中間キャッシュ抑制ヒント)。|
-| `Cache-Control: no-cache` | サーバーは特別なオーバーライドを行いません; エンドポイントのデフォルトポリシーが引き続き適用されます (data → 再検証; meta → `max-age=60` など)。|
-| `Cache-Control: max-age=N` | エッジキャッシュレイヤー用に予約済み (Phase 3 / CloudFront)。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。|
+| `Cache-Control: no-store` | サーバーはレスポンス `Cache-Control` を `no-store` にオーバーライドします (CDN/中間キャッシュ抑制ヒント)。|
+| `Cache-Control: no-cache` | サーバーは特別なオーバーライドを行いません。エンドポイントのデフォルトポリシーが引き続き適用されます (data → 再検証; meta → `max-age=60` など)。|
+| `Cache-Control: max-age=N` | エッジキャッシュレイヤー (Phase 3 / CloudFront) 用に予約されています。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。|
 
 ---
 
@@ -331,9 +331,9 @@ curl -i "http://localhost:3000/v2/entities" \
 
 認証はデフォルトで無効になっています。以下の環境変数で有効化できます。
 
-**注意**: `AUTH_ENABLED=false` の場合、認証関連のエンドポイント (`/auth/*`、`/me`、`/me/*`、`/admin/*`) は 404 を返します。
+**注意**: `AUTH_ENABLED=false` の場合、認証関連のエンドポイント (`/auth/*`, `/me`, `/me/*`, `/admin/*`) は 404 を返します。
 
-**重要**: `AUTH_ENABLED=true` の場合、NGSI API エンドポイント (`/v2/*`、`/ngsi-ld/*`、`/catalog/*`) へのアクセスには認証が必要です。認証なしでアクセスすると `401 Unauthorized` エラーが返されます。
+**重要**: `AUTH_ENABLED=true` の場合、NGSI API エンドポイント (`/v2/*`, `/ngsi-ld/*`, `/catalog/*`) へのアクセスには認証が必要です。認証なしでアクセスすると `401 Unauthorized` エラーが返されます。
 
 | 環境変数 | デフォルト | 説明 |
 |---------|-----------|------|
@@ -341,17 +341,17 @@ curl -i "http://localhost:3000/v2/entities" \
 | `JWT_SECRET` | - | JWT トークン署名用のシークレット (32 文字以上推奨) |
 | `JWT_EXPIRES_IN` | `1h` | アクセストークンの有効期限 |
 | `JWT_REFRESH_EXPIRES_IN` | `7d` | リフレッシュトークンの有効期限 |
-| `SUPER_ADMIN_EMAIL` | - | 環境変数で設定されるスーパー管理者のメールアドレス |
-| `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定されるスーパー管理者のパスワード |
+| `SUPER_ADMIN_EMAIL` | - | 環境変数で設定するスーパー管理者のメールアドレス |
+| `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定するスーパー管理者のパスワード |
 | `ADMIN_ALLOWED_IPS` | - | Admin API へのアクセスを許可する IP/CIDR (カンマ区切り) |
 
 ### ロールと権限
 
 | ロール | 説明 | 権限 |
-|-------|------|------|
-| `super_admin` | スーパー管理者 | `/admin/*`、`/auth/*`、`/me/*`、監視エンドポイントのみ。データ API (`/v2/*`、`/ngsi-ld/*`、`/catalog*`、`/rules*`) にはアクセス**できません** — 403 を返します |
-| `tenant_admin` | テナント管理者 | 自分のテナント内のユーザーを管理 |
-| `user` | 一般ユーザー | 自分のプロフィール表示とパスワード変更のみ |
+|--------|------|------|
+| `super_admin` | スーパー管理者 | `/admin/*`, `/auth/*`, `/me/*`, 監視エンドポイントのみ。データ API (`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`) へのアクセスは**不可** — 403 を返します |
+| `tenant_admin` | テナント管理者 | 自身のテナント内のユーザーを管理 |
+| `user` | 一般ユーザー | 自身のプロフィールの閲覧とパスワード変更のみ |
 
 ### ログイン
 
@@ -375,13 +375,13 @@ Content-Type: application/json
 ```
 
 | パラメータ | 型 | 必須 | 説明 |
-|-----------|------|------|------|
-| `email` | string | はい | メールアドレス |
-| `password` | string | はい | パスワード |
-| `tenantId` | string | いいえ | 指定された場合、そのテナントにスコープされた JWT を発行します。省略時はプライマリテナントがデフォルト |
-| `resourceScopes` | ResourceScope[] | いいえ | エンティティレベルのアクセス制御スコープ。省略時は完全アクセス。詳細は AUTH.md を参照 |
+|-----------|-----|------|------|
+| `email` | string | Yes | メールアドレス |
+| `password` | string | Yes | パスワード |
+| `tenantId` | string | No | 指定した場合、そのテナントにスコープされた JWT を発行。省略時はプライマリテナントがデフォルト |
+| `resourceScopes` | ResourceScope[] | No | エンティティレベルのアクセス制御スコープ。省略時は完全アクセス。詳細は AUTH.md を参照 |
 
-**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダー経由でテナントを指定できます (テナント名で解決)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダー値は `^[a-z0-9_]+$` と一致する必要があります。
+**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダーでテナントを指定できます (テナント名で解決)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダーの値は `^[a-z0-9_]+$` と一致する必要があります。
 
 **レスポンス例**
 
@@ -417,7 +417,7 @@ Content-Type: application/json
 
 **レスポンス**: ログインと同じ形式
 
-### 現在のユーザー情報取得
+### 現在のユーザー情報を取得
 
 ```http
 GET /me
@@ -453,7 +453,7 @@ Content-Type: application/json
 }
 ```
 
-**レスポンス**: `204 No Content`**注意**: パスワード変更後、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
+**レスポンス**: `204 No Content`**注意**: パスワード変更後、既存のすべてのアクセストークンとリフレッシュトークンは無効化されます。新しいトークンを取得するには、再度ログインしてください。
 
 ### ログアウト
 
@@ -462,10 +462,10 @@ POST /auth/logout
 Authorization: Bearer <accessToken>
 ```
 
-すべてのセッションを無効化します。このユーザーに対して発行されたすべてのアクセストークンとリフレッシュトークンが即座に無効化されます。
+すべてのセッションを無効化します。このユーザーに発行されたすべてのアクセストークンとリフレッシュトークンは即座に無効化されます。
 
 **レスポンス**: `204 No Content`
-### API キー トークン交換
+### API Key Token Exchange
 
 #### Nonce の取得
 
@@ -477,9 +477,7 @@ Origin: https://example.com
 {"api_key": "gdb_your_api_key_here"}
 ```
 
-**レスポンス**: `200 OK`
-
-```json
+**レスポンス**: `200 OK````json
 {
   "nonce": "base64url_timestamp.hmac_signature",
   "challenge": "sha256_challenge_string",
@@ -487,7 +485,7 @@ Origin: https://example.com
 }
 ```
 
-#### トークンの交換
+#### Token の交換
 
 ```http
 POST /oauth/token
@@ -502,9 +500,7 @@ Origin: https://example.com
 }
 ```
 
-**レスポンス**: `200 OK`
-
-```json
+**レスポンス**: `200 OK````json
 {
   "access_token": "<session_jwt>",
   "token_type": "Bearer",
@@ -513,13 +509,13 @@ Origin: https://example.com
 }
 ```
 
-**DPoP トークン バインディング**(オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明キーにバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を必要とします — 最初のリクエストは `DPoP-Nonce` ヘッダーと共に `400 use_dpop_nonce` を返します。証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
+**DPoP token binding** (オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って、ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明キーにバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を要求します — 最初のリクエストは `DPoP-Nonce` ヘッダーと共に `400 use_dpop_nonce` を返します; 証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
 
-### 管理 API
+### Admin API
 
-管理 API は `super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセス可能です。
+Admin API は `super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセスできます。
 
-#### ユーザー一覧
+#### ユーザー一覧の取得
 
 ```http
 GET /admin/users
@@ -530,12 +526,12 @@ Authorization: Bearer <accessToken>
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `tenantId` | テナント ID でフィルター (super_admin のみ) |
-| `role` | ロールでフィルター |
+| `tenantId` | テナント ID でフィルタリング (super_admin のみ) |
+| `role` | ロールでフィルタリング |
 | `limit` | 取得する結果の数 |
 | `offset` | オフセット |
 
-#### ユーザー作成
+#### ユーザーの作成
 
 ```http
 POST /admin/users
@@ -554,14 +550,14 @@ Content-Type: application/json
 }
 ```
 
-#### ユーザー取得
+#### ユーザーの取得
 
 ```http
 GET /admin/users/{userId}
 Authorization: Bearer <accessToken>
 ```
 
-#### ユーザー更新
+#### ユーザーの更新
 
 ```http
 PATCH /admin/users/{userId}
@@ -578,7 +574,7 @@ Content-Type: application/json
 }
 ```
 
-#### ユーザー削除
+#### ユーザーの削除
 
 ```http
 DELETE /admin/users/{userId}
@@ -616,14 +612,14 @@ Authorization: Bearer <accessToken>
 
 ### テナント管理 (super_admin のみ)
 
-#### テナント一覧
+#### テナント一覧の取得
 
 ```http
 GET /admin/tenants
 Authorization: Bearer <accessToken>
 ```
 
-#### テナント作成
+#### テナントの作成
 
 ```http
 POST /admin/tenants
@@ -643,16 +639,16 @@ Content-Type: application/json
 }
 ```
 
-> **注意**: テナント名には小文字の英数字とアンダースコアのみを含める必要があります (`^[a-z0-9_]+$`)。
+> **注意**: テナント名には小文字の英数字とアンダースコアのみを使用できます (`^[a-z0-9_]+$`)。
 
-#### テナント取得
+#### テナントの取得
 
 ```http
 GET /admin/tenants/{tenantId}
 Authorization: Bearer <accessToken>
 ```
 
-#### テナント更新
+#### テナントの更新
 
 ```http
 PATCH /admin/tenants/{tenantId}
@@ -660,7 +656,7 @@ Authorization: Bearer <accessToken>
 Content-Type: application/json
 ```
 
-#### テナント削除
+#### テナントの削除
 
 ```http
 DELETE /admin/tenants/{tenantId}
@@ -679,11 +675,13 @@ Authorization: Bearer <accessToken>
 
 ### カスタムデータモデル管理
 
-> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
+> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細は [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
 
 ### IP 制限
 
-`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます。
+**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。
+
+`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:
 
 ```bash
 # Single IP
@@ -696,11 +694,11 @@ ADMIN_ALLOWED_IPS=192.168.1.100,10.0.0.50
 ADMIN_ALLOWED_IPS=192.168.1.0/24,10.0.0.0/8
 ```
 
-許可されていない IP からのアクセスは `403 Forbidden` エラーとなります。
+許可されていない IP からのアクセスは `403 Forbidden` エラーになります。
 
-#### テナント毎の IP 制限
+#### テナントごとの IP 制限
 
-テナント毎に個別の IP 制限を設定できます。テナントレベルの設定が存在する場合は、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
+テナントごとに個別の IP 制限を設定できます。テナントレベルの設定が存在する場合は、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
 
 ```http
 GET /admin/tenants/{tenantId}/ip-restrictions
@@ -709,15 +707,15 @@ DELETE /admin/tenants/{tenantId}/ip-restrictions
 Authorization: Bearer <accessToken>
 ```
 
-スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかを指定できます。詳細は AUTH.md を参照してください。
+スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかです。詳細は AUTH.md を参照してください。
 
-### ルールエンジン管理（tenant_admin）
+### ルールエンジン管理 (tenant_admin)
 
 エンティティの変更を自動的に処理するルールを管理します。`tenant_admin` ロールが必要です。`AUTH_ENABLED=true` の場合、`super_admin` は `/rules*` エンドポイントにアクセスできません。
 
-- **REACTIVCORE_RULES.md** - ユーザーガイド(使用例、管理 API など)
+- **REACTIVCORE_RULES.md** - ユーザーガイド (使用例、Admin API など)
 
-#### ルール一覧の取得
+#### ルール一覧
 
 ```http
 GET /rules
@@ -727,13 +725,13 @@ Authorization: Bearer <accessToken>
 **クエリパラメータ**
 
 | パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 結果の件数(デフォルト: 20、最大: 100) |
-| `offset` | オフセット(デフォルト: 0) |
+|-----------|------|
+| `limit` | 結果の件数 (デフォルト: 20、最大: 100) |
+| `offset` | オフセット (デフォルト: 0) |
 | `servicePath` | ServicePathでフィルタ |
-| `isActive` | アクティブ/非アクティブでフィルタ(`true` / `false`) |
+| `isActive` | アクティブ/非アクティブでフィルタ (`true` / `false`) |
 
-#### ルールの作成
+#### ルール作成
 
 ```http
 POST /rules
@@ -772,14 +770,14 @@ Content-Type: application/json
 }
 ```
 
-#### ルールの取得
+#### ルール取得
 
 ```http
 GET /rules/{ruleId}
 Authorization: Bearer <accessToken>
 ```
 
-#### ルールの更新
+#### ルール更新
 
 ```http
 PATCH /rules/{ruleId}
@@ -787,7 +785,7 @@ Authorization: Bearer <accessToken>
 Content-Type: application/json
 ```
 
-レスポンス: `204 No Content`#### ルールの削除
+レスポンス: `204 No Content`#### ルール削除
 
 ```http
 DELETE /rules/{ruleId}
@@ -804,15 +802,15 @@ Authorization: Bearer <accessToken>
 
 #### クロスプロトコルアクション
 
-ルールアクション(`createEntity`、`updateAttribute`、`deleteAttribute`)は、プロトコル境界を越えて動作するためのオプションフィールド `protocol` をサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
+ルールアクション (`createEntity`、`updateAttribute`、`deleteAttribute`) は、プロトコル境界をまたいで操作するためのオプションの `protocol` フィールドをサポートしています。`createEntity` アクションは、階層制御のために `servicePath` と `scope` フィールドもサポートしています。
 
 | フィールド | アクション | 型 | 説明 |
 |---|---|---|---|
-| `protocol` | createEntity、updateAttribute、deleteAttribute | `'ngsiv2' \| 'ngsild'` | ターゲットプロトコル(デフォルト: トリガーから継承) |
+| `protocol` | createEntity, updateAttribute, deleteAttribute | `'ngsiv2' \| 'ngsild'` | ターゲットプロトコル (デフォルト: トリガーから継承) |
 | `servicePath` | createEntity | `string` | NGSIv2 のターゲット servicePath (テンプレート変数をサポート) |
-| `scope` | createEntity | `string[]` | NGSI-LD のターゲットスコープ(テンプレート変数をサポート) |
+| `scope` | createEntity | `string[]` | NGSI-LD のターゲット scope (テンプレート変数をサポート) |
 
-プロトコルを越える場合、servicePath ↔ scope は自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` は、トリガーエンティティのコンテキストを参照します。
+プロトコルをまたぐ場合、servicePath ↔ scope は自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` は、トリガーエンティティのコンテキストを参照します。
 
 詳細な例とマッピングルールについては、**REACTIVCORE_RULES.md** を参照してください。
 
@@ -823,83 +821,83 @@ Authorization: Bearer <accessToken>
 OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (M2M) 認証がサポートされています。
 
 **主要なエンドポイント:**
-- `POST /oauth/token` - トークン取得 (Basic 認証)
-- `POST /admin/oauth-clients` - クライアント作成 (管理者)
-- `GET /admin/oauth-clients` - クライアント一覧 (管理者)
-- `POST /admin/oauth-clients/{clientId}/regenerate-secret` - シークレット再生成 (管理者)
-- `POST /me/oauth-clients` - 自分のクライアント作成 (セルフサービス)
-- `GET /me/oauth-clients` - 自分のクライアント一覧 (セルフサービス)
-- `DELETE /me/oauth-clients/{clientId}` - 自分のクライアント削除 (セルフサービス)
-- `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自分のシークレット再生成 (セルフサービス)
+- `POST /oauth/token` - トークン取得(Basic 認証)
+- `POST /admin/oauth-clients` - クライアント作成(管理者)
+- `GET /admin/oauth-clients` - クライアント一覧(管理者)
+- `POST /admin/oauth-clients/{clientId}/regenerate-secret` - シークレット再生成(管理者)
+- `POST /me/oauth-clients` - 自分のクライアント作成(セルフサービス)
+- `GET /me/oauth-clients` - 自分のクライアント一覧(セルフサービス)
+- `DELETE /me/oauth-clients/{clientId}` - 自分のクライアント削除(セルフサービス)
+- `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自分のシークレット再生成(セルフサービス)
 
-**有効化:** `AUTH_ENABLED=true` の場合、OAuth 2.0 は常に有効になります。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
+**有効化:** OAuth 2.0 は `AUTH_ENABLED=true` の場合、常に有効です。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
 
 **利用可能なスコープ:**
 
 | スコープ | 説明 | `user` | `tenant_admin` | `super_admin` |
 |-------|-------------|:------:|:---------------:|:--------------:|
 | `read:entities` | エンティティの読み取り | ✅ | ✅ | ✅ |
-| `write:entities` | エンティティの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
+| `write:entities` | エンティティの書き込み(作成/更新/削除のみ) | ✅ | ✅ | ✅ |
 | `read:subscriptions` | サブスクリプションの読み取り | ✅ | ✅ | ✅ |
-| `write:subscriptions` | サブスクリプションの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
+| `write:subscriptions` | サブスクリプションの書き込み(作成/更新/削除のみ) | ✅ | ✅ | ✅ |
 | `read:registrations` | 登録の読み取り | ✅ | ✅ | ✅ |
-| `write:registrations` | 登録の書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
+| `write:registrations` | 登録の書き込み(作成/更新/削除のみ) | ✅ | ✅ | ✅ |
 | `read:rules` | ルールの読み取り | ✅ | ✅ | ✅ |
-| `write:rules` | ルールの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
+| `write:rules` | ルールの書き込み(作成/更新/削除のみ) | ✅ | ✅ | ✅ |
 | `read:custom-data-models` | カスタムデータモデルの読み取り | ✅ | ✅ | ✅ |
-| `write:custom-data-models` | カスタムデータモデルの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
+| `write:custom-data-models` | カスタムデータモデルの書き込み(作成/更新/削除のみ) | ✅ | ✅ | ✅ |
 | `admin:users` | ユーザー管理 API | ❌ | ✅ | ✅ |
 | `admin:policies` | ポリシー管理 API | ❌ | ✅ | ✅ |
 | `admin:oauth-clients` | OAuth クライアント管理 API | ❌ | ✅ | ✅ |
 | `admin:metrics` | メトリクス API | ❌ | ✅ | ✅ |
 | `admin:tenants` | テナント管理 API | ❌ | ❌ | ✅ |
 | `permanent` | トークンが期限切れにならない | — | — | — |
-| `jwt` | JWT 形式のトークン | — | — | — |
+| `jwt` | JWT フォーマットのトークン | — | — | — |
 
-> ロール列は、セルフサービス (`/me/oauth-clients`) 経由でリクエスト可能なスコープを示します。管理者が作成したクライアント (`/admin/oauth-clients`) には、これらの制限は適用されません。
+> ロール列は、セルフサービス(`/me/oauth-clients`)でリクエスト可能なスコープを示しています。管理者が作成したクライアント(`/admin/oauth-clients`)には、これらの制限は適用されません。
 
-**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ (JSON 文字列) を指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細は AUTH.md を参照してください。
+**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ(JSON 文字列)を指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細は AUTH.md を参照してください。
 
 **詳細:** AUTH.md の OAuth 2.0 セクションを参照してください。
 
 ---
 
-## API キートークン交換 (ブラウザ SDK)
+## API キートークン交換(ブラウザ SDK)
 
-ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短時間有効なセッション JWT に交換できます。
+ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短期間有効なセッション JWT と交換できます。
 
 **主要なエンドポイント:**
-- `POST /auth/nonce` - Nonce + PoW チャレンジのリクエスト (API キー + Origin ヘッダーが必要)
-- `POST /oauth/token` (`grant_type=api_key`) - API キー + nonce + PoW 証明をセッション JWT に交換
+- `POST /auth/nonce` - Nonce + PoW チャレンジのリクエスト(API キー + Origin ヘッダーが必要)
+- `POST /oauth/token` (`grant_type=api_key`) - API キー + nonce + PoW 証明をセッション JWT と交換
 
 **JavaScript SDK:** `npm install @geolonia/geonicdb-sdk` — トークン交換、DPoP、WebSocket、再接続を自動的に処理します。
 
-**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60 秒 TTL) → Proof of Work → 短時間有効な JWT (1 時間)
+**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60 秒 TTL) → Proof of Work → 短期間有効な JWT (1 時間)
 
-**詳細:** AUTH.md の API Key Token Exchange セクションおよび SDK ドキュメントで完全な API リファレンスを参照してください。
+**詳細:** AUTH.md の API キートークン交換セクションと SDK ドキュメントの完全な API リファレンスを参照してください。
 
 ---
 
 ## メタエンドポイント
 
-メタエンドポイントは認証を必要とせず、システムステータスと API 情報を提供します。
+メタエンドポイントは認証不要で、システムステータスと API 情報を提供します。
 
-### API ドキュメント (llms.txt 形式)
+### API ドキュメント(llms.txt 形式)
 
 ```http
 GET /llms.txt
 ```
 
-AI フレンドリーな [llms.txt](https://llmstxt.org/) 形式で API ドキュメントを返します。AI エージェントや LLM が理解しやすいように構造化された Markdown 形式を使用します。
+AI フレンドリーな [llms.txt](https://llmstxt.org/) 形式で API ドキュメントを返します。AI エージェントと LLM が理解しやすいように構造化された Markdown 形式を使用します。
 
 **レスポンス**
-- Content-Type: `text/markdown; charset=utf-8`### API ドキュメント (JSON 形式)
+- Content-Type: `text/markdown; charset=utf-8`### API ドキュメント(JSON 形式)
 
 ```http
 GET /api.json
 ```
 
-JSON 形式で API エンドポイントの一覧を返します。
+API エンドポイントのリストを JSON 形式で返します。
 
 **レスポンス例**
 
@@ -924,7 +922,7 @@ JSON 形式で API エンドポイントの一覧を返します。
 GET /openapi.json
 ```
 
-OpenAPI 3.0 仕様を JSON 形式で返します。Swagger UI や各種 API クライアント生成ツールで使用できます。
+JSON 形式で OpenAPI 3.0 仕様を返します。Swagger UI や各種 API クライアント生成ツールで使用できます。
 
 **レスポンス**
 - Content-Type: `application/json`- OpenAPI バージョン: 3.0.3
@@ -965,7 +963,7 @@ FIWARE Orion 互換のバージョン情報を返します。
 GET /.well-known/ngsi-ld
 ```
 
-NGSI-LD API サポート情報を返します。
+NGSI-LD API のサポート情報を返します。
 
 **レスポンス例**
 
@@ -979,15 +977,15 @@ NGSI-LD API サポート情報を返します。
 
 ### ヘルスチェック
 
-すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返した場合にセカンダリへ切り替えます。
+すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返すとセカンダリに切り替えます。
 
-#### 基本ヘルス
+#### 基本ヘルスチェック
 
 ```http
 GET /health
 ```
 
-サービスの基本的な稼働状態を返します。
+サービスの基本的な動作状態を返します。
 
 **レスポンス例**
 
@@ -1006,7 +1004,7 @@ GET /health
 GET /health/live
 ```
 
-Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中かどうかをチェックします。
+Kubernetes / Route 53 Liveness プローブ用。サービスが実行中かどうかを確認します。
 
 **レスポンス例**
 
@@ -1025,17 +1023,17 @@ Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中か
 GET /health/ready
 ```
 
-Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチェックし、オプションで DynamoDB と EventBridge の詳細ヘルスチェックを実行します。
+Kubernetes / Route 53 Readiness プローブ用。MongoDB の接続性を確認し、オプションで DynamoDB と EventBridge のディープヘルスチェックを実行します。
 
-**環境変数による詳細ヘルスチェックの有効化**
+**環境変数によるディープヘルスチェックの有効化**
 
 | 環境変数 | 説明 |
 |---------|------|
-| `HEALTH_CHECK_DYNAMODB=true` | DynamoDB DescribeTable 接続チェックを追加 |
-| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続チェックを追加 |
+| `HEALTH_CHECK_DYNAMODB=true` | DynamoDB DescribeTable 接続性チェックを追加 |
+| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続性チェックを追加 |
 
 **レスポンス**
-- 成功: `200 OK` と `status: "healthy"`- 失敗: `503 Service Unavailable` と `status: "unhealthy"`**レスポンス例(詳細ヘルスチェック有効時)**
+- 成功: `200 OK` と `status: "healthy"`- 失敗: `503 Service Unavailable` と `status: "unhealthy"`**レスポンス例(ディープヘルスチェック有効時)**
 
 ```json
 {
@@ -1062,7 +1060,7 @@ GET /statistics
 Authorization: Bearer <token>
 ```
 
-サーバーの運用統計を FIWARE Orion 互換形式で返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+FIWARE Orion 互換形式でサーバーの動作統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1102,7 +1100,7 @@ GET /cache/statistics
 Authorization: Bearer <token>
 ```
 
-サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1132,7 +1130,7 @@ GET /metrics
 Authorization: Bearer <token>
 ```
 
-Prometheus エクスポジション形式でメトリクスを返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
+Prometheus 公開形式でメトリクスを返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
 
 **レスポンス**
 - Content-Type: `text/plain; version=0.0.4`**レスポンス例**
@@ -1176,7 +1174,7 @@ geonicdb_notifications_failed_total 10
 GET /tools.json
 ```
 
-Claude Tool Use / OpenAI Function Calling と互換性のある JSON 形式でツール定義を返します。これは AI エージェントが API をツールとして使用するためのスキーマです。
+Claude Tool Use / OpenAI Function Calling と互換性のある JSON 形式でツール定義を返します。これは、AI エージェントが API をツールとして使用するためのスキーマです。
 
 **提供されるツール**: `list_entities`、`get_entity`、`search_by_location`、`search_by_attribute`、`create_entity`、`update_entity`、`delete_entity`、`list_entity_types`、`get_temporal_data`、`subscribe`##### AI プラグインマニフェスト
 
@@ -1194,7 +1192,7 @@ Content-Type: application/json
 Accept: application/json, text/event-stream
 ```
 
-MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、MCP tools/call 経由で 5 つのツールすべてが利用可能です。
+MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、5 つのツールすべてが MCP tools/call 経由で利用可能です。
 
 `AUTH_ENABLED=true` の場合、Bearer トークン(JWT)による認証が必要です。テナントアクセス制御も適用されます。
 
@@ -1217,7 +1215,7 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
 ```
 注意: `headers` は `AUTH_ENABLED=true` の場合のみ必要です。
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+詳細については、[AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
 
 ##### A2A (Agent-to-Agent Protocol)
 
@@ -1225,7 +1223,7 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
 GET /.well-known/agent-card.json
 ```
 
-A2A Agent Card。このエージェントの機能、スキル、認証について説明します。認証は不要です。
+A2A エージェントカード。このエージェントの機能、スキル、および認証について説明します。認証不要。
 
 ```http
 POST /a2a
@@ -1234,17 +1232,17 @@ Authorization: Bearer <token>
 Fiware-Service: <tenant>  (optional, falls back to default tenant)
 ```
 
-エージェント間通信のための A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合、認証が必要です。サポートされるメソッド:
+エージェント間通信のための A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合は認証が必要です。サポートされるメソッド:
 - `message/send` — メッセージを送信し、同期レスポンスを受信
 - `tasks/get` — タスクの現在の状態を取得
-- `tasks/list` — フィルタリングとページネーション付きでタスクを一覧表示
+- `tasks/list` — フィルタリングとページネーションを使用してタスクを一覧表示
 - `tasks/cancel` — タスクのキャンセルをリクエスト
 
-5 つのスキルが利用可能: entities、batch、temporal、config、admin (MCP ツールと同じ)。
+5 つのスキルが利用可能: entities、batch、temporal、config、admin(MCP ツールと同じ)。
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+詳細については、[AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
 
-#### テナント別メトリクス (管理 API)
+#### テナント別メトリクス(管理 API)
 
 ```http
 GET /admin/metrics
@@ -1291,7 +1289,7 @@ NGSI-LD API の詳細については、[API_NGSILD.md](./ngsild.md) を参照し
 
 ## クエリ言語
 
-属性値によるフィルタリングは `q` パラメータを使用して可能です。
+属性値によるフィルタリングは、`q` パラメータを使用して可能です。
 
 ### 基本構文
 
@@ -1323,7 +1321,7 @@ q=temperature>25;humidity<40|status==active
 
 ### 範囲クエリ
 
-`==` 演算子と `..` を組み合わせて範囲フィルタリングを行います (境界値を含む):
+`==` 演算子を `..` と組み合わせて範囲フィルタリングを行います (境界を含む):
 
 ```text
 q=temperature==20..30    # 20 or above and 30 or below
@@ -1348,15 +1346,15 @@ q=name==Room1     # Exact match
 |-----------|-------------|
 | `georel` | 空間関係 (coveredBy、within、intersects、disjoint、equals) |
 | `geometry` | ジオメトリタイプ (point、polygon、line、box) |
-| `coords` | 座標 (NGSIv2: 緯度,経度 形式; NGSI-LD: 経度,緯度 形式; 複数のポイントはセミコロンで区切る) |
+| `coords` | 座標 (NGSIv2: 緯度,経度形式; NGSI-LD: 経度,緯度形式; 複数ポイントはセミコロンで区切る) |
 
-> **注意**: `georel`、`geometry`、`coords` (または NGSI-LD では `coordinates`) はすべて一緒に指定する必要があります。一部のみを指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 4.10)。
+> **注意**: `georel`、`geometry`、および `coords` (または NGSI-LD では `coordinates`) はすべて一緒に指定する必要があります。一部のみを指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 4.10)。
 
 ### 座標形式
 
 NGSIv2 では、座標は **緯度,経度** の順序で指定します (NGSIv2 仕様に準拠)。NGSI-LD では、座標は **経度,緯度** の順序です (GeoJSON 標準に準拠)。
 
-> **重要**: NGSIv2 における緯度,経度の順序は GeoJSON 標準 (経度,緯度) からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用しています。API を使用する際は、使用している API バージョンに合わせて正しい順序で座標を指定してください。
+> **重要**: NGSIv2 の緯度,経度の順序は GeoJSON 標準 (経度,緯度) からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用します。API を使用する際は、使用している API バージョンに応じて正しい順序で座標を指定してください。
 
 ```text
 # NGSIv2 (latitude,longitude)
@@ -1392,7 +1390,7 @@ GET /v2/entities?georel=disjoint&geometry=polygon&coords=34,138;34,141;37,141;37
 ```
 ### 近接検索 (near)
 
-指定された座標から一定の距離内にあるエンティティを検索します。
+指定された座標から一定距離内のエンティティを検索します。
 
 #### パラメータ
 
@@ -1400,7 +1398,7 @@ GET /v2/entities?georel=disjoint&geometry=polygon&coords=34,138;34,141;37,141;37
 |-----------|-------------|
 | `maxDistance` | 最大距離(メートル) |
 | `minDistance` | 最小距離(メートル) |
-| `orderByDistance` | `true` に設定すると、結果を距離順にソートし、各エンティティに距離情報(`@distance`)を付加します |
+| `orderByDistance` | `true` に設定すると、結果を距離でソートし、各エンティティに距離情報 (`@distance`) を付加します |
 
 #### 基本的な使い方 (NGSIv2)
 
@@ -1430,9 +1428,9 @@ GET /ngsi-ld/v1/entities?georel=near;minDistance==100000&geometry=Point&coordina
 GET /ngsi-ld/v1/entities?georel=near;minDistance==500;maxDistance==10000&geometry=Point&coordinates=[139.7671,35.6812]
 ```
 
-#### georel の構文比較
+#### georel 構文の比較
 
-georel パラメータの修飾子構文は NGSIv2 と NGSI-LD で異なります:
+georel パラメータ修飾子の構文は NGSIv2 と NGSI-LD で異なります:
 
 | 機能 | NGSIv2 | NGSI-LD | 説明 |
 |---------|--------|---------|-------------|
@@ -1440,14 +1438,14 @@ georel パラメータの修飾子構文は NGSIv2 と NGSI-LD で異なりま�
 | 最小距離 | `georel=near;minDistance:1000` | `georel=near;minDistance==1000` | `:` と `==` の違い |
 | 距離範囲 | `georel=near;minDistance:500;maxDistance:10000` | `georel=near;minDistance==500;maxDistance==10000` | `:` と `==` の違い |
 
-> **構文が異なる理由**: NGSIv2 では `:` を使用してパラメータ値を指定しますが、NGSI-LD では ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用する API バージョンに対応した構文を使用してください。
+> **構文の違いの理由**: NGSIv2 は `:` を使用してパラメータ値を指定しますが、NGSI-LD は ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用する API バージョンに対応した構文を使用してください。
 
-#### 距離のソートと距離情報
+#### 距離ソートと距離情報
 
 `orderByDistance=true` パラメータを指定すると、以下の機能が有効になります:
 
-1. **距離のソート**: 結果が指定された座標からの距離の昇順でソートされます
-2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定された座標からの距離(メートル単位)が返されます
+1. **距離ソート**: 結果が指定された座標からの距離の昇順でソートされます
+2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定された座標からの距離(メートル)が返されます
 
 この機能は MongoDB の `$geoNear` 集約パイプラインを使用して実装されています。
 
@@ -1494,7 +1492,7 @@ GET /ngsi-ld/v1/entities?georel=near;maxDistance==5000&geometry=Point&coordinate
 
 ##### 降順ソート
 
-`orderDirection=desc` と組み合わせて使用すると、距離の降順(遠い順)でソートされます:
+`orderDirection=desc` と併用して距離の降順(遠い順)でソートします:
 
 ```http
 GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.7671&orderByDistance=true&orderDirection=desc
@@ -1506,9 +1504,9 @@ GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.
 
 ### エラー処理
 
-geo-query パラメータが無効な場合、`400 Bad Request` が返されます。
+ジオクエリパラメータが無効な場合、`400 Bad Request` が返されます。
 
-| エラー条件 | エラーメッセージ例 |
+| エラー条件 | エラーメッセージの例 |
 |----------------|-----------------------|
 | 無効な `georel` 値 | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
 | 無効な `geometry` 値 | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box` |
@@ -1524,9 +1522,9 @@ geo-query パラメータが無効な場合、`400 Bad Request` が返されま�
 
 ---
 
-## 空間 ID 検索
+## Spatial ID 検索
 
-日本のデジタル庁 / IPA が定めた 3 次元空間識別規格 (ZFXY 形式) に基づく空間検索をサポートします。
+日本のデジタル庁 / IPA が策定した3次元空間識別標準 (ZFXY 形式) に基づく空間検索をサポートします。
 
 ### ZFXY 形式
 
@@ -1534,8 +1532,8 @@ geo-query パラメータが無効な場合、`400 Bad Request` が返されま�
 |---------|-------------|-------|
 | Z | ズームレベル | 0-28 |
 | F | 垂直方向 (高度レベル) | 整数 |
-| X | 東西方向 (経度タイル) | 0 to 2^z-1 |
-| Y | 南北方向 (緯度タイル) | 0 to 2^z-1 |
+| X | 東西方向 (経度タイル) | 0 から 2^z-1 |
+| Y | 南北方向 (緯度タイル) | 0 から 2^z-1 |
 
 形式: `{z}/{f}/{x}/{y}` (例: `20/0/929593/410773`)
 
@@ -1553,7 +1551,7 @@ GET /ngsi-ld/v1/entities?spatialId=20/0/929593/410773
 
 ### 階層展開 (spatialIdDepth)
 
-`spatialIdDepth` パラメータを指定すると、指定した空間 ID を中心とした周囲のタイルに検索を拡張します。
+`spatialIdDepth` パラメータを指定すると、指定された Spatial ID を中心に周囲のタイルまで検索を拡大します。
 
 ```http
 # depth=1: Expands to a 3x3 tile grid (9 tiles)
@@ -1565,7 +1563,7 @@ GET /v2/entities?spatialId=20/0/929593/410773&spatialIdDepth=2
 
 | spatialIdDepth | 展開範囲 | タイル数 |
 |----------------|-----------------|------------|
-| 0 (デフォルト) | 指定したタイルのみ | 1 |
+| 0 (デフォルト) | 指定されたタイルのみ | 1 |
 | 1 | 3x3 | 9 |
 | 2 | 5x5 | 25 |
 | 3 | 7x7 | 49 |
@@ -1587,7 +1585,7 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&spatialIdDe
 
 ## GeoJSON 出力
 
-RFC 7946 準拠の GeoJSON FeatureCollection 形式でエンティティを出力できます。
+エンティティは RFC 7946 準拠の GeoJSON FeatureCollection 形式で出力できます。
 
 ### NGSIv2 での使用方法
 
@@ -1653,7 +1651,7 @@ Accept: application/geo+json
 
 ### NGSI-LD における @context
 
-NGSI-LD で GeoJSON を出力する場合、`@context` が FeatureCollection レベルに含まれます:
+NGSI-LD で GeoJSON を出力する場合、`@context` は FeatureCollection レベルに含まれます:
 
 ```json
 {
@@ -1702,7 +1700,7 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&options=geo
 
 ## ベクタータイル
 
-エンティティは XYZ タイル方式に基づいて GeoJSON ベクタータイルとして出力できます。大量のエンティティを地図上に効率的に表示するために最適化されています。
+エンティティは、XYZ タイルスキームに基づいて GeoJSON ベクタータイルとして出力できます。大量のエンティティを地図上に効率的に表示するために最適化されています。
 
 ### エンドポイント
 
@@ -1739,7 +1737,7 @@ curl "http://localhost:3000/v2/tiles" \
 
 ### GeoJSON タイルの取得
 
-XYZ 座標を指定してタイル内のエンティティを GeoJSON 形式で取得します:
+XYZ 座標を指定して、タイル内のエンティティを GeoJSON 形式で取得します:
 
 ```bash
 # Zoom level 14 tile around Tokyo
@@ -1752,7 +1750,7 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson" \
 | パラメータ | 説明 |
 |-----------|-------------|
 | `type` | エンティティタイプでフィルタリング |
-| `attrs` | 出力する属性をカンマ区切りリストで指定 |
+| `attrs` | カンマ区切りで出力する属性を指定 |
 
 **使用例**
 
@@ -1797,7 +1795,7 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 ### クラスタリング
 
-タイル内のエンティティ数が閾値(デフォルト: 1000)を超えた場合、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスター Feature が返されます。
+タイル内のエンティティ数が閾値(デフォルト: 1000)を超えると、自動的にクラスタリングされます。クラスタリングされると、タイル内の全エンティティの重心座標を持つ単一のクラスター Feature が返されます。
 
 **クラスタリング時のレスポンス例**
 
@@ -1836,8 +1834,8 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 | ヘッダー | 説明 |
 |--------|-------------|
-| `X-Tile-Mode` | `individual` (個別のエンティティ) または `clustered` (クラスタリング) |
-| `X-Total-Count` | タイル内のエンティティの総数 |
+| `X-Tile-Mode` | `individual` (個別エンティティ) または `clustered` (クラスタリング) |
+| `X-Total-Count` | タイル内の全エンティティ数 |
 
 ### 設定
 
@@ -1845,11 +1843,11 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 |----------------------|---------|-------------|
 | `MAX_ENTITIES_PER_REQUEST` | `1000` | クラスタリングの閾値(この値以上でクラスタリングが発生) |
 
-### 参考文献
+### 参考資料
 
 - [TileJSON 3.0 仕様](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
 - [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
-- [XYZ タイル方式](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+- [XYZ タイルスキーム](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
 
 ---
 
@@ -1891,9 +1889,9 @@ GET /ngsi-ld/v1/entities?type=Store&crs=EPSG:6668
 GET /ngsi-ld/v1/entities?type=Store&crs=urn:ogc:def:crs:EPSG::6668
 ```
 
-### レスポンスヘッダー
+### レスポンスヘッダ
 
-CRS を指定したリクエストに対するレスポンスには、`Content-Crs` ヘッダーが含まれます:
+CRS を指定したリクエストに対するレスポンスには `Content-Crs` ヘッダが含まれます:
 
 ```text
 Content-Crs: EPSG:6668
@@ -1907,7 +1905,7 @@ Content-Crs: urn:ogc:def:crs:EPSG::6668
 
 ### 座標の入出力
 
-#### クエリ時(入力)
+#### クエリ時 (入力)
 
 ジオクエリの座標は、指定された CRS で解釈されます:
 
@@ -1938,7 +1936,7 @@ curl -X POST "http://localhost:3000/v2/entities?crs=EPSG:3857" \
   }'
 ```
 
-#### 取得時(出力)
+#### 取得時 (出力)
 
 取得時に `crs` パラメータを指定すると、指定された CRS に変換された座標が返されます:
 
@@ -1953,7 +1951,7 @@ curl "http://localhost:3000/v2/entities/Store1?crs=EPSG:6668" \
 | 変換 | 精度 |
 |------------|----------|
 | WGS84 ↔ JGD2011 | 数 cm から数十 cm |
-| WGS84 ↔ Web メルカトル | 計算精度に依存(緯度 ±85 度以内) |
+| WGS84 ↔ Web メルカトル | 計算精度に依存 (緯度 ±85 度以内) |
 
 ### 使用例
 
@@ -2012,15 +2010,15 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Landmark&crs=EPSG:6668" \
 
 | エラー | HTTP コード | 説明 |
 |-------|-----------|-------------|
-| Unsupported CRS | 400 | 指定された CRS コードはサポートされていません |
-| Invalid CRS format | 400 | 無効な CRS 形式が指定されました |
-| Coordinates out of range | 400 | Web メルカトルで緯度 ±85 度を超える座標 |
+| サポートされていない CRS | 400 | 指定された CRS コードはサポートされていません |
+| 無効な CRS 形式 | 400 | 無効な CRS 形式が指定されました |
+| 座標が範囲外 | 400 | Web メルカトルで緯度 ±85 度を超える座標 |
 
 ### 制限事項
 
-- Web メルカトル (EPSG:3857) は緯度 ±85 度を超える範囲をサポートしていません
+- Web メルカトル (EPSG:3857) は緯度 ±85 度を超える領域をサポートしていません
 - すべての座標は内部的に WGS84 で保存されます
-- 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリを使用しています
+- 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリが使用されます
 
 ### 参考資料
 
@@ -2030,17 +2028,17 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Landmark&crs=EPSG:6668" \
 
 ---
 
-## データカタログ API
+## Data Catalog API
 
-DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest 互換のエンドポイントを提供します。
+DCAT-AP 形式のエンティティタイプ情報を出力し、CKAN harvest 互換のエンドポイントを提供します。
 
-### DCAT-AP カタログ
+### DCAT-AP Catalog
 
 ```http
 GET /catalog
 ```
 
-カタログ全体を DCAT-AP 形式で JSON-LD として出力します。
+カタログ全体を DCAT-AP 形式の JSON-LD として出力します。
 
 **レスポンス例**
 
@@ -2062,30 +2060,30 @@ GET /catalog
 }
 ```
 
-### データセット一覧
+### Dataset List
 
 ```http
 GET /catalog/datasets
 ```
 
-DCAT 形式でデータセットの一覧を出力します。
+DCAT 形式のデータセットのリストを出力します。
 
 **クエリパラメータ**
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `limit` | 取得するデータセット数 |
-| `offset` | スキップするデータセット数 |
+| `limit` | 取得するデータセットの数 |
+| `offset` | スキップするデータセットの数 |
 
-### 個別データセット
+### Individual Dataset
 
 ```http
 GET /catalog/datasets/{datasetId}
 ```
 
-個別データセット(エンティティタイプ)の詳細情報を出力します。
+個別のデータセット(エンティティタイプ)の詳細情報を出力します。
 
-### サンプルデータ
+### Sample Data
 
 ```http
 GET /catalog/datasets/{datasetId}/sample
@@ -2097,19 +2095,19 @@ GET /catalog/datasets/{datasetId}/sample
 
 | パラメータ | 説明 | デフォルト |
 |-----------|-------------|---------|
-| `limit` | 取得するサンプル数 | 5 |
+| `limit` | 取得するサンプルの数 | 5 |
 
 ### CKAN 互換 API
 
 CKAN データカタログハーベスターと互換性のある API を提供します。
 
-#### パッケージ一覧
+#### Package List
 
 ```http
 GET /catalog/ckan/package_list
 ```
 
-すべてのパッケージ(データセット)の ID 一覧を取得します。
+すべてのパッケージ(データセット)の ID のリストを取得します。
 
 **レスポンス例**
 
@@ -2120,7 +2118,7 @@ GET /catalog/ckan/package_list
 }
 ```
 
-#### パッケージ詳細
+#### Package Details
 
 ```http
 GET /catalog/ckan/package_show?id={package_id}
@@ -2149,32 +2147,32 @@ GET /catalog/ckan/package_show?id={package_id}
 }
 ```
 
-#### リソース付きパッケージ一覧
+#### Package List with Resources
 
 ```http
 GET /catalog/ckan/current_package_list_with_resources
 ```
 
-リソース情報を含むパッケージの一覧をページネーション形式で取得します。
+リソース情報を含むパッケージのページネーション付きリストを取得します。
 
 **クエリパラメータ**
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `limit` | 取得するパッケージ数 |
-| `offset` | スキップするパッケージ数 |
+| `limit` | 取得するパッケージの数 |
+| `offset` | スキップするパッケージの数 |
 
-詳細は外部連携ドキュメントを参照してください。
+詳細については、外部統合ドキュメントを参照してください。
 
 ---
 
-## CADDE 連携
+## CADDE 統合
 
-CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの連携機能を提供します。
+CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの統合機能を提供します。
 
 ### 概要
 
-CADDE は、異なるセクター間でのデータ共有を可能にする日本のデータ交換アーキテクチャです。この Context Broker は CADDE コネクタからのリクエストを受け付け、来歴情報を含むレスポンスを返します。
+CADDE は、異なるセクター間でのデータ共有を可能にする日本のデータ交換アーキテクチャです。この Context Broker は、CADDE コネクタからのリクエストを受け付け、来歴情報を含むレスポンスを返します。
 
 ### 有効化
 
@@ -2192,52 +2190,52 @@ curl -X PUT "https://api.example.com/admin/cadde" \
   }'
 ```
 
-| 設定項目 | デフォルト値 | 説明 |
+| 設定項目 | デフォルト | 説明 |
 |--------------------|---------|-------------|
 | `enabled` | `false` | CADDE 機能を有効化 |
 | `authEnabled` | `false` | Bearer 認証を有効化 |
 | `defaultProvider` | - | デフォルトのプロバイダ ID |
-| `jwtIssuer` | - | JWT 検証における期待される発行者 (`iss`) クレーム |
-| `jwtAudience` | - | JWT 検証における期待される対象者 (`aud`) クレーム |
-| `jwksUrl` | - | 署名検証用の JWKS エンドポイント URL (HTTPS が必要) |
+| `jwtIssuer` | - | JWT 検証のための期待される発行者 (`iss`) クレーム |
+| `jwtAudience` | - | JWT 検証のための期待される対象者 (`aud`) クレーム |
+| `jwksUrl` | - | 署名検証のための JWKS エンドポイント URL (HTTPS が必須) |
 
-設定は MongoDB に保存されるため、デプロイ後に API 経由で動的に変更できます。
+設定は MongoDB に保存されるため、デプロイ後に API を介して動的に変更できます。
 
-### リクエストヘッダ
+### リクエストヘッダー
 
-CADDE コネクタからのリクエストには以下のヘッダが含まれます:
+CADDE コネクタからのリクエストには、以下のヘッダーが含まれます:
 
-| ヘッダ | 必須 | 説明 |
+| ヘッダー | 必須 | 説明 |
 |--------|----------|-------------|
 | `x-cadde-resource-url` | - | アクセスされるリソースの URL |
 | `x-cadde-resource-api-type` | - | API タイプ (例: `api/ngsi`) |
 | `x-cadde-provider` | - | データプロバイダ ID |
-| `x-cadde-options` | - | 追加オプション (テナントヘッダなど) |
+| `x-cadde-options` | - | 追加オプション (テナントヘッダーなど) |
 
-### x-cadde-options のフォーマット
+### x-cadde-options フォーマット
 
-テナント情報やその他の詳細は `x-cadde-options` ヘッダで指定できます:
+テナント情報やその他の詳細は、`x-cadde-options` ヘッダーで指定できます:
 
 ```text
 x-cadde-options: Fiware-Service:smartcity, Fiware-ServicePath:/sensors
 ```
 
-このヘッダで指定された値は、通常の HTTP ヘッダよりも優先されます。
+このヘッダーで指定された値は、通常の HTTP ヘッダーよりも優先されます。
 
-### プロヴェナンスレスポンスヘッダ
+### プロベナンスレスポンスヘッダー
 
-CADDE リクエストへのレスポンスには以下のプロヴェナンスヘッダが含まれます:
+CADDE リクエストへのレスポンスには、以下のプロベナンスヘッダーが含まれます:
 
-| ヘッダ | 説明 |
+| ヘッダー | 説明 |
 |--------|-------------|
-| `x-cadde-provenance-id` | リクエストの一意識別子 (Fiware-Correlator を使用) |
+| `x-cadde-provenance-id` | リクエストの一意な識別子 (Fiware-Correlator を使用) |
 | `x-cadde-provenance-timestamp` | レスポンス生成時刻 (ISO 8601 形式) |
 | `x-cadde-provenance-provider` | データプロバイダ ID |
 | `x-cadde-provenance-resource-url` | アクセスされたリソースの URL |
 
 ### 認証
 
-`CADDE_AUTH_ENABLED=true` が設定されている場合、CADDE リクエストには Bearer 認証が必要です:
+`CADDE_AUTH_ENABLED=true` の場合、CADDE リクエストには Bearer 認証が必要です:
 
 ```http
 Authorization: Bearer <token>
@@ -2254,8 +2252,8 @@ Authorization: Bearer <token>
 | **署名検証** | RS256 または ES256 アルゴリズムをサポート。JWKS エンドポイントから公開鍵を自動取得 |
 | **有効期限検証** | `exp` (有効期限) クレームを検証し、期限切れトークンを拒否 |
 | **発行時刻検証** | `iat` (発行時刻) クレームを検証し、未来に発行されたトークンを拒否 |
-| **発行者検証** | `iss` クレームが `CADDE_JWT_ISSUER` が設定されている場合に検証 |
-| **対象者検証** | `aud` クレームが `CADDE_JWT_AUDIENCE` が設定されている場合に検証 |
+| **発行者検証** | `iss` が設定されている場合、`CADDE_JWT_ISSUER` クレームを検証 |
+| **対象者検証** | `aud` が設定されている場合、`CADDE_JWT_AUDIENCE` クレームを検証 |
 
 **設定例:**
 
@@ -2286,7 +2284,7 @@ JWT 検証が失敗した場合、詳細なエラーメッセージが返され�
 | `Invalid token audience` | 対象者クレームが一致しない |
 | `Unsupported signing algorithm` | サポートされていないアルゴリズム (RS256/ES256 以外) |
 | `Unable to fetch signing keys` | JWKS エンドポイントへのアクセスに失敗 |
-| `Signing key not found` | 指定された kid を持つ鍵が JWKS に存在しない |
+| `Signing key not found` | 指定された kid のキーが JWKS に存在しない |
 
 **注意:** `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます (後方互換性のため)。
 
@@ -2309,7 +2307,7 @@ curl "http://localhost:3000/v2/entities" \
 
 ### NGSI-LD API での使用
 
-CADDE ヘッダは NGSI-LD API でも使用できます:
+CADDE ヘッダーは NGSI-LD API でも使用できます:
 
 ```bash
 curl "http://localhost:3000/ngsi-ld/v1/entities" \
@@ -2320,7 +2318,7 @@ curl "http://localhost:3000/ngsi-ld/v1/entities" \
 ```
 ### CADDE Connector v4 API
 
-CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE 設定が有効な場合のみ利用可能、`PUT /admin/cadde` で設定)。
+CADDE コネクタ v4 仕様に準拠した専用エンドポイント(CADDE 設定が有効な場合のみ利用可能、`PUT /admin/cadde` で設定)。
 
 参考: https://github.com/CADDE-sip/connector
 
@@ -2328,7 +2326,7 @@ CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE �
 
 | メソッド | パス | 説明 |
 |--------|------|-------------|
-| GET | `/cadde/api/v4/catalog` | カタログ検索 (横断検索 / 詳細検索) |
+| GET | `/cadde/api/v4/catalog` | カタログ検索(横断検索 / 詳細検索) |
 | GET | `/cadde/api/v4/entities` | NGSI データ交換 |
 
 #### カタログ検索 (`/cadde/api/v4/catalog`
@@ -2338,13 +2336,13 @@ CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE �
 
 | 検索タイプ | ヘッダー値 | 説明 |
 |-------------|--------------|-------------|
-| 横断検索 | `x-cadde-search: meta` | CKAN 形式のデータセット一覧を返却 (`q` パラメータによるキーワードフィルタリング) |
-| 詳細検索 | `x-cadde-search: detail` | 個別データセットの詳細を返却 (`id` または `fq` パラメータで指定) |
+| 横断検索 | `x-cadde-search: meta` | CKAN 形式でデータセット一覧を返却(`q` パラメータによるキーワードフィルタリング) |
+| 詳細検索 | `x-cadde-search: detail` | 個別データセットの詳細を返却(`id` または `fq` パラメータで指定) |
 
-CADDE 固有のフィールドがレスポンスに追加されます:
+レスポンスには CADDE 固有のフィールドが追加されます:
 - `caddec_dataset_id_for_detail`: 詳細検索用のデータセット ID
-- `caddec_provider_id`: プロバイダ ID (`CADDE_DEFAULT_PROVIDER` が設定されている場合)
-- `caddec_resource_type`: リソースタイプ (`api/ngsi`)
+- `caddec_provider_id`: プロバイダ ID(`CADDE_DEFAULT_PROVIDER` が設定されている場合)
+- `caddec_resource_type`: リソースタイプ(`api/ngsi`)
 
 ```bash
 # Cross-domain search
@@ -2367,8 +2365,8 @@ curl "http://localhost:3000/cadde/api/v4/catalog?id=sensor" \
 
 | ヘッダー | 必須 | 説明 |
 |--------|----------|-------------|
-| `x-cadde-resource-url` | Yes | リソース URL (type、id、q、attrs、limit、offset をクエリパラメータとして含む) |
-| `x-cadde-resource-api-type` | - | レスポンス形式: `api/ngsi` (デフォルト) または `api/ngsi-ld` |
+| `x-cadde-resource-url` | はい | リソース URL(type、id、q、attrs、limit、offset をクエリパラメータとして含む) |
+| `x-cadde-resource-api-type` | - | レスポンス形式: `api/ngsi`(デフォルト)または `api/ngsi-ld` |
 | `x-cadde-provider` | - | データプロバイダ ID |
 
 ```bash
@@ -2389,7 +2387,7 @@ curl "http://localhost:3000/cadde/api/v4/entities" \
 
 #### エラーレスポンス形式
 
-CADDE v4 エンドポイントのエラーレスポンスは以下の形式です:
+CADDE v4 エンドポイントのエラーレスポンスは次の形式です:
 
 ```json
 { "detail": "Resource not found", "status": 404 }
@@ -2397,7 +2395,7 @@ CADDE v4 エンドポイントのエラーレスポンスは以下の形式で�
 
 #### 認証
 
-CADDE v4 エンドポイントは GeonicDB 認証 (`requireAuth`) をバイパスします。認証は CADDE JWT 検証 (`processCaddeRequestAsync`) によって処理されます。
+CADDE v4 エンドポイントは GeonicDB 認証(`requireAuth`)をバイパスします。認証は CADDE JWT 検証(`processCaddeRequestAsync`)によって処理されます。
 
 ### 参考資料
 
@@ -2421,8 +2419,8 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 
 | アクション | 説明 |
 |--------|-------------|
-| `subscribe` | エンティティタイプ / ID パターンでフィルタを設定 |
-| `ping` | キープアライブ (`pong` レスポンス) |
+| `subscribe` | エンティティタイプ / ID パターンによるフィルタを設定 |
+| `ping` | キープアライブ(`pong` レスポンス) |
 
 ### サーバーイベント
 
@@ -2432,13 +2430,13 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 | `entityUpdated` | エンティティが更新されました |
 | `entityDeleted` | エンティティが削除されました |
 
-詳細は [イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
+詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md)を参照してください。
 
 ---
 
 ## エラーレスポンス
 
-### NGSIv2 エラーフォーマット
+### NGSIv2 エラー形式
 
 ```json
 {
@@ -2447,10 +2445,10 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 }
 ```
 
-### NGSI-LD エラーフォーマット (RFC 7807 ProblemDetails)
+### NGSI-LD エラー形式 (RFC 7807 ProblemDetails)
 
-NGSI-LD API のエラーレスポンスは [RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
-Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` ではなく標準の JSON MIME タイプが使用されます)。
+NGSI-LD API のエラーレスポンスは [RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails 形式で返されます。
+Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` ではなく標準の JSON MIME タイプを使用します)。
 
 ```json
 {
@@ -2472,8 +2470,8 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 | `400` | 不正なリクエスト |
 | `403` | 禁止 (認可エラー) |
 | `404` | リソースが見つかりません |
-| `405` | メソッドが許可されていません (NGSI-LD、`Allow` ヘッダー付き) |
-| `409` | 競合 (既に存在する、など) |
+| `405` | メソッドが許可されていません (NGSI-LD、`Allow` ヘッダーあり) |
+| `409` | 競合 (すでに存在する、など) |
 | `500` | 内部サーバーエラー |
 
 ---
@@ -2493,19 +2491,19 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 | イベントストリーミング (WebSocket) | Yes | Yes |
 | エンティティタイプ | Yes | - |
 | クエリ言語 (q パラメータ) | Yes | Yes |
-| ソート (orderBy, orderDirection) | Yes | Yes |
+| ソート (orderBy、orderDirection) | Yes | Yes |
 | メタデータ制御 (metadata / sysAttrs) | Yes | Yes |
-| 地理クエリ (coveredBy, within, intersects, disjoint) | Yes | Yes |
-| 空間 ID 検索 (ZFXY フォーマット) | Yes | Yes |
+| ジオクエリ (coveredBy、within、intersects、disjoint) | Yes | Yes |
+| 空間 ID 検索 (ZFXY 形式) | Yes | Yes |
 | GeoJSON 出力 | Yes | Yes |
 | 座標参照系 (CRS) 変換 | Yes | Yes |
 | マルチテナンシー | Yes | Yes |
 | ページネーション | Yes | Yes |
-| keyValues フォーマット | Yes | Yes |
-| レジストレーション | Yes | Yes |
-| コンテキストプロバイダー (フェデレーション/クエリ転送) | Yes | Yes |
-| コンテキストプロバイダー (更新転送) | Yes | Yes |
-| CADDE 連携 | Yes | Yes |
+| keyValues 形式 | Yes | Yes |
+| 登録 | Yes | Yes |
+| コンテキストプロバイダ (フェデレーション/クエリ転送) | Yes | Yes |
+| コンテキストプロバイダ (更新転送) | Yes | Yes |
+| CADDE 統合 | Yes | Yes |
 | 認証 API (JWT ベース) | Yes | Yes |
 | ユーザー/テナント管理 API | Yes | Yes |
 | `/version` エンドポイント | Yes | - |
@@ -2514,9 +2512,9 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 
 ### 制限事項
 
-| 機能 | ステータス | 備考 |
+| 機能 | 状態 | 備考 |
 |---------|--------|-------|
-| `near` 地理クエリ (近接検索) | サポート済み | ポイントジオメトリのみ。`orderByDistance=true` による距離ソートと距離情報をサポート |
+| `near` ジオクエリ (近接検索) | サポート済み | Point ジオメトリのみ。`orderByDistance=true` で距離ソートと距離情報をサポート |
 | `minDistance` / `maxDistance` | サポート済み | メートル単位で指定 |
 
 ---
@@ -2553,7 +2551,7 @@ curl -X GET "https://api.example.com/v2/entities?type=Room&q=temperature>25" \
   -H "Fiware-Service: smartcity"
 ```
 
-### ジオクエリ(ポリゴンエリア検索)
+### ジオクエリ (ポリゴンエリア検索)
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities?type=Place&georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138" \
@@ -2600,19 +2598,19 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
 
 ## エンドポイントリファレンス
 
-このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、ステータスコード情報をまとめています。
+このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、およびステータスコード情報をまとめています。
 
 ### API カテゴリ
 
 | API カテゴリ | ベースパス | 認証 | Content-Type |
 |--------------|-----------|----------------|--------------|
 | Meta/Health | `/` | 不要*† | `application/json` |
-| Authentication | `/auth` | 不要 | `application/json` |
-| User | `/me` | 必要 | `application/json` |
+| 認証 | `/auth` | 不要 | `application/json` |
+| ユーザー | `/me` | 必要 | `application/json` |
 | NGSIv2 | `/v2` | 必要* | `application/json` |
 | NGSI-LD | `/ngsi-ld/v1` | 必要* | `application/ld+json` |
-| Admin | `/admin` | 必要 (super_admin / tenant_admin) | `application/json` |
-| Catalog | `/catalog` | 必要* | `application/json` |
+| 管理 | `/admin` | 必要 (super_admin / tenant_admin) | `application/json` |
+| カタログ | `/catalog` | 必要* | `application/json` |
 
 \* `AUTH_ENABLED=false` の場合は認証不要
 
@@ -2626,15 +2624,15 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
 |----------|--------|-------------|---------|-------|
 | `/llms.txt` | GET | API ドキュメント (llms.txt) | 200 | - |
 | `/version` | GET | FIWARE Orion 互換バージョン情報 | 200 | - |
-| `/health` | GET | 基本ヘルスチェック | 200 | - |
+| `/health` | GET | 基本的なヘルスチェック | 200 | - |
 | `/health/live` | GET | Kubernetes liveness プローブ | 200 | - |
 | `/health/ready` | GET | Kubernetes readiness プローブ | 200 | 503 |
 | `/.well-known/ngsi-ld` | GET | NGSI-LD API ディスカバリー | 200 | - |
 | `/api.json` | GET | API リファレンス (JSON) | 200 | - |
 | `/openapi.json` | GET | OpenAPI 3.0 仕様 | 200 | - |
-| `/statistics` | GET | FIWARE Orion 互換統計情報(認証必要) | 200 | 401 |
-| `/cache/statistics` | GET | キャッシュ統計情報(認証必要) | 200 | 401 |
-| `/metrics` | GET | Prometheus メトリクス(認証必要) | 200 | 401 |
+| `/statistics` | GET | FIWARE Orion 互換統計情報 (認証必要) | 200 | 401 |
+| `/cache/statistics` | GET | キャッシュ統計情報 (認証必要) | 200 | 401 |
+| `/metrics` | GET | Prometheus メトリクス (認証必要) | 200 | 401 |
 | `/tools.json` | GET | AI ツール定義 (Claude Tool Use / OpenAI Function Calling) | 200 | - |
 | `/.well-known/ai-plugin.json` | GET | AI プラグインマニフェスト | 200 | - |
 | `/mcp` | POST | MCP (Model Context Protocol) Streamable HTTP エンドポイント | 200 | 400, 405, 500 |
@@ -2649,23 +2647,23 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
 ### 認証エンドポイント
 
 - `/auth/*` は `AUTH_ENABLED=true` の場合のみ利用可能
-- `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能(常に有効; `OAUTH_ENABLED` は非推奨)
+- `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能 (常に有効、`OAUTH_ENABLED` は非推奨)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー |
 |----------|--------|-------------|---------|-------|
 | `/auth/login` | POST | ユーザーログイン (JWT) | 200 | 400, 401 |
 | `/auth/refresh` | POST | トークンリフレッシュ | 200 | 400, 401 |
-| `/auth/logout` | POST | ログアウト(すべてのセッションを無効化、認証必要) | 204 | 401 |
-| `/auth/nonce` | POST | Nonce + PoW チャレンジによる API キートークン交換 | 200 | 400 |
+| `/auth/logout` | POST | ログアウト (すべてのセッションを無効化、認証必要) | 204 | 401 |
+| `/auth/nonce` | POST | API キートークン交換用の Nonce + PoW チャレンジ | 200 | 400 |
 | `/oauth/token` | POST | OAuth トークン取得 (M2M: `grant_type=client_credentials`、Browser SDK: `grant_type=api_key`) | 200 | 400, 401 |
 
 ### SDK
 
-JavaScript SDK は npm パッケージとして提供されています: `npm install @geolonia/geonicdb-sdk`SDK は完全なパブリック API を提供します: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー(`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
+JavaScript SDK は npm パッケージとして利用可能です: `npm install @geolonia/geonicdb-sdk`SDK は完全なパブリック API を提供します: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー (`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
 
 ### ユーザーエンドポイント
 
-認証されたユーザーが自分の情報を管理するためのエンドポイントです。
+認証されたユーザーが自身の情報を管理するためのエンドポイントです。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | 最小ロール |
 |----------|--------|-------------|---------|-------|--------------|
@@ -2674,38 +2672,38 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 
 ### NGSIv2 / NGSI-LD エンドポイント
 
-エンドポイントの詳細な仕様については、以下を参照してください:
+詳細なエンドポイント仕様については、以下を参照してください:
 - [NGSIv2 API リファレンス](./ngsiv2.md)
 - [NGSI-LD API リファレンス](./ngsild.md)
 
 ### Admin API
 
-テナントとユーザーを管理するための API です。エンドポイントには `super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントスコープのみ)。
+テナントとユーザーを管理するための API です。各エンドポイントには `super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントのスコープのみ)。
 
 #### テナント管理
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/admin/tenants` | GET | テナント一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/admin/tenants` | GET | テナント一覧 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/admin/tenants` | POST | テナント作成 | 201 | 400, 401, 403, 409 | - |
 | `/admin/tenants/{tenantId}` | GET | テナント取得 | 200 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}` | PATCH | テナント更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/tenants/{tenantId}` | DELETE | テナント削除 (`?shred=true` による Crypto-Shredding) | 204 / 200 | 400, 401, 403, 404 | - |
+| `/admin/tenants/{tenantId}` | DELETE | テナント削除 (`?shred=true` による暗号化シュレッディング) | 204 / 200 | 400, 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/deletion-report` | GET | 削除レポート取得 | 200 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/activate` | POST | テナント有効化 | 204 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/deactivate` | POST | テナント無効化 | 204 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/ip-restrictions` | GET | テナント IP 制限取得 | 200 | 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/ip-restrictions` | PUT | テナント IP 制限更新 | 200 | 400, 401, 403, 404 | - |
 | `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | テナント IP 制限削除 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users` | GET | テナントメンバー一覧取得 (tenant_admin: 自テナントのみ) | 200 | 401, 403, 404 | あり (最大: 100) |
-| `/admin/tenants/{tenantId}/users/{userId}` | PUT | テナントにユーザーを追加 (tenant_admin: 自テナントのみ) | 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | テナントからユーザーを削除 (tenant_admin: 自テナントのみ) | 204 | 400, 401, 403, 404 | - |
+| `/admin/tenants/{tenantId}/users` | GET | テナントメンバー一覧 (tenant_admin: 自テナントのみ) | 200 | 401, 403, 404 | あり (最大: 100) |
+| `/admin/tenants/{tenantId}/users/{userId}` | PUT | テナントにユーザー追加 (tenant_admin: 自テナントのみ) | 200 | 400, 401, 403, 404 | - |
+| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | テナントからユーザー削除 (tenant_admin: 自テナントのみ) | 204 | 400, 401, 403, 404 | - |
 
 #### ユーザー管理
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/admin/users` | GET | ユーザー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/admin/users` | GET | ユーザー一覧 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/admin/users` | POST | ユーザー作成 | 201 | 400, 401, 403, 409 | - |
 | `/admin/users/{userId}` | GET | ユーザー取得 | 200 | 401, 403, 404 | - |
 | `/admin/users/{userId}` | PATCH | ユーザー更新 | 204 | 400, 401, 403, 404, 409 | - |
@@ -2713,13 +2711,13 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 | `/admin/users/{userId}/activate` | POST | ユーザー有効化 | 204 | 401, 403, 404 | - |
 | `/admin/users/{userId}/deactivate` | POST | ユーザー無効化 | 204 | 401, 403, 404 | - |
 | `/admin/users/{userId}/unlock` | POST | ログインロック解除 | 200 | 400, 401, 403, 404 | - |
-| `/admin/users/{userId}/tenants` | GET | ユーザーが所属するテナント一覧取得 (自分自身または super_admin) | 200 | 401, 403 | あり (最大: 100) |
+| `/admin/users/{userId}/tenants` | GET | ユーザーが所属するテナント一覧 (自分自身または super_admin) | 200 | 401, 403 | あり (最大: 100) |
 
 #### ポリシー管理 (XACML 3.0 認可、super_admin / tenant_admin)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/admin/policies` | GET | ポリシー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/admin/policies` | GET | ポリシー一覧 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/admin/policies` | POST | ポリシー作成 | 201 | 400, 401, 403, 409 | - |
 | `/admin/policies/{policyId}` | GET | ポリシー取得 | 200 | 401, 403, 404 | - |
 | `/admin/policies/{policyId}` | PATCH | ポリシー部分更新 | 200 | 400, 401, 403, 404 | - |
@@ -2728,7 +2726,7 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 | `/admin/policies/{policyId}/activate` | POST | ポリシー有効化 | 200 | 401, 403, 404 | - |
 | `/admin/policies/{policyId}/deactivate` | POST | ポリシー無効化 | 200 | 401, 403, 404 | - |
 
-ポリシー Target `resources` で利用可能な **リソース属性**:
+ポリシー Target `resources` で利用可能な**リソース属性**:
 
 | attributeId | 説明 | ソース |
 |-------------|-------------|--------|
@@ -2740,13 +2738,13 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 | `entityType` | 対象エンティティタイプ (例: `Room`) | リクエスト (自動抽出) / エンティティコンテキスト |
 | `entityOwner` | エンティティ作成者の userId (`createdBy` フィールド) | エンティティコンテキスト |
 
-> `entityType` は、HTTP リクエストのパスレベルから自動的に抽出されます。`?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから取得され、エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、`scope` は、エンティティレベルの認可チェック(`requireEntityAuthz` 経由)でのみ利用可能です。`scope` は、NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したもので、柔軟なマッチングには `string-regexp` または `glob` を使用してください。
+> `entityType` はパスレベルの HTTP リクエストから自動抽出されます — `?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから — エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、`scope` はエンティティレベルの認可チェック (`requireEntityAuthz` 経由) でのみ利用可能です。`scope` は NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したものです — 柔軟なマッチングには `string-regexp` または `glob` を使用してください。
 
 #### OAuth クライアント管理
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/admin/oauth-clients` | GET | OAuth クライアント一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/admin/oauth-clients` | GET | OAuth クライアント一覧 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/admin/oauth-clients` | POST | OAuth クライアント作成 | 201 | 400, 401, 403 | - |
 | `/admin/oauth-clients/{clientId}` | GET | OAuth クライアント取得 | 200 | 401, 403, 404 | - |
 | `/admin/oauth-clients/{clientId}` | PATCH | OAuth クライアント更新 | 200 | 400, 401, 403, 404 | - |
@@ -2754,38 +2752,38 @@ JavaScript SDK は npm パッケージとして提供されています: `npm in
 
 #### セルフサービス OAuth クライアント管理
 
-ユーザーは自分自身の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアント。オプションの `policyId` により、クライアントを既存の XACML ポリシーにバインドできます。
+ユーザーは自分の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアント。オプションの `policyId` はクライアントを既存の XACML ポリシーにバインドします。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/me/oauth-clients` | GET | 自分の OAuth クライアント一覧取得 | 200 | 400, 401 | あり (最大: 100) |
+| `/me/oauth-clients` | GET | 自分の OAuth クライアント一覧 | 200 | 400, 401 | あり (最大: 100) |
 | `/me/oauth-clients` | POST | 自分の OAuth クライアント作成 | 201 | 400, 401, 403 | - |
-| `/me/oauth-clients/{clientId}` | PATCH | 自分の OAuth クライアント更新 (部分更新) | 200 | 400, 401, 403, 404 | - |
+| `/me/oauth-clients/{clientId}` | PATCH | 自分の OAuth クライアント更新 (部分) | 200 | 400, 401, 403, 404 | - |
 | `/me/oauth-clients/{clientId}` | DELETE | 自分の OAuth クライアント削除 | 204 | 400, 401, 403, 404 | - |
 | `/me/oauth-clients/{clientId}/regenerate-secret` | POST | 自分のクライアントシークレット再生成 | 200 | 400, 401, 403, 404 | - |
 
 #### API キー管理
 
-`X-Api-Key` ヘッダーによる認証用の API キーを管理します。新しいキーはプレーン UUID 形式(`randomUUID()`)を使用します。既存の `gdb_` プレフィックス付きキーは引き続き有効です。保存時は SHA-256 でハッシュ化され、平文キーは作成時と更新時のみ返されます。一覧取得/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドにより、キーを既存の XACML ポリシーにバインドできます(バインドされたポリシーのターゲットは評価時にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト(api_key = All Deny)にフォールバックします。
+`X-Api-Key` ヘッダーによる認証用の API キーを管理します。新しいキーはプレーンな UUID 形式 (`randomUUID()`) を使用します。`gdb_` プレフィックス付きの既存キーは有効なままです。保存時は SHA-256 でハッシュ化され、平文のキーは作成時と更新時のみ返されます。一覧 / 取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドはキーを既存の XACML ポリシーにバインドします(バインドされたポリシーのターゲットは評価時にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト (api_key = All Deny) にフォールバックします。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/admin/api-keys` | POST | API キー作成 | 201 | 400, 401, 403 | - |
-| `/admin/api-keys` | GET | API キー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/admin/api-keys` | GET | API キー一覧 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/admin/api-keys/{keyId}` | GET | API キー取得 | 200 | 401, 403, 404 | - |
 | `/admin/api-keys/{keyId}` | PATCH | API キー更新 | 204 | 400, 401, 403, 404 | - |
 | `/admin/api-keys/{keyId}` | DELETE | API キー削除 | 204 | 401, 403, 404 | - |
 | `/admin/api-keys/{keyId}/refresh` | POST | API キー更新 (再生成) | 200 | 401, 403, 404 | - |
 
-#### セルフサービス API キー管理ユーザーは自分の API キーを管理できます。1 ユーザーにつき最大 5 つのキーまで作成可能です。
+#### セルフサービス API キー管理ユーザーは自分自身の API キーを管理できます。1 ユーザーあたり最大 5 つのキーを持つことができます。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/me/api-keys` | POST | 自分の API キーを作成 | 201 | 400, 401, 403 | - |
-| `/me/api-keys` | GET | 自分の API キーを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
-| `/me/api-keys/{keyId}` | PATCH | 自分の API キーを更新(部分更新) | 200 | 400, 401, 403, 404 | - |
+| `/me/api-keys` | GET | 自分の API キーを一覧取得 | 200 | 400, 401, 403 | Yes (max: 100) |
+| `/me/api-keys/{keyId}` | PATCH | 自分の API キーを更新 (部分的) | 200 | 400, 401, 403, 404 | - |
 | `/me/api-keys/{keyId}` | DELETE | 自分の API キーを削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/api-keys/{keyId}/refresh` | POST | 自分の API キーをリフレッシュ(再生成) | 200 | 401, 403, 404 | - |
+| `/me/api-keys/{keyId}/refresh` | POST | 自分の API キーを再生成 | 200 | 401, 403, 404 | - |
 
 #### CADDE 設定管理
 
@@ -2794,8 +2792,8 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/admin/cadde` | GET | CADDE 設定を取得 | 200 | 401, 403 | - |
-| `/admin/cadde` | PUT | CADDE 設定を更新(upsert) | 200 | 400, 401, 403 | - |
-| `/admin/cadde` | DELETE | CADDE 設定を削除(無効化) | 204 | 401, 403 | - |
+| `/admin/cadde` | PUT | CADDE 設定を更新 (upsert) | 200 | 400, 401, 403 | - |
+| `/admin/cadde` | DELETE | CADDE 設定を削除 (無効化) | 204 | 401, 403 | - |
 
 **リクエストボディ (PUT)**
 
@@ -2812,18 +2810,18 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 | フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `enabled` | boolean | Yes | CADDE 機能を有効/無効化 |
-| `authEnabled` | boolean | Yes | Bearer 認証を有効/無効化 |
+| `enabled` | boolean | Yes | CADDE 機能を有効化/無効化 |
+| `authEnabled` | boolean | Yes | Bearer 認証を有効化/無効化 |
 | `defaultProvider` | string | - | デフォルトのプロバイダー ID |
-| `jwtIssuer` | string | - | JWT の issuer クレーム検証値 |
-| `jwtAudience` | string | - | JWT の audience クレーム検証値 |
+| `jwtIssuer` | string | - | JWT issuer クレーム検証値 |
+| `jwtAudience` | string | - | JWT audience クレーム検証値 |
 | `jwksUrl` | string | - | JWKS 公開鍵エンドポイント URL (HTTPS 必須) |
 
 #### ルールエンジン管理
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/rules` | GET | ルールを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
+| `/rules` | GET | ルールを一覧取得 | 200 | 400, 401, 403 | Yes (max: 100) |
 | `/rules` | POST | ルールを作成 | 201 | 400, 401, 403, 409 | - |
 | `/rules/{ruleId}` | GET | ルールを取得 | 200 | 401, 403, 404 | - |
 | `/rules/{ruleId}` | PATCH | ルールを更新 | 204 | 400, 401, 403, 404 | - |
@@ -2833,13 +2831,13 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 ### カスタムデータモデル API
 
-テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要で、XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールがテナント内のカスタムデータモデルを管理できます。
+テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要で、XACML ポリシーベースの認可により `tenant_admin` および `user` ロールが自テナント内のカスタムデータモデルを管理できます。
 
 **関連ドキュメント**: [SMART_DATA_MODELS.md](../features/smart-data-models.md)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/custom-data-models` | GET | カスタムデータモデルの一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
+| `/custom-data-models` | GET | カスタムデータモデル一覧の取得 | 200 | 400, 401, 403 | あり (最大: 100) |
 | `/custom-data-models` | POST | カスタムデータモデルの作成 | 201 | 400, 401, 403, 409 | - |
 | `/custom-data-models/{type}` | GET | カスタムデータモデルの取得 | 200 | 401, 403, 404 | - |
 | `/custom-data-models/{type}` | PATCH | カスタムデータモデルの更新 | 200 | 400, 401, 403, 404 | - |
@@ -2849,19 +2847,19 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 カスタムデータモデルが定義されている場合、エンティティの作成または更新時に自動的に検証が実行されます。検証は `isActive: true` を持つモデルにのみ適用されます。
 
-**検証チェック:**
+**検証チェック項目:**
 
 | チェック | 説明 |
 |-------|-------------|
 | 追加プロパティ | `additionalProperties: false` の場合、`propertyDetails` で定義されていない属性は拒否されます (デフォルト: `true` — 任意の属性を許可) |
 | 必須フィールド | `required: true` を持つ属性が存在するかどうか |
-| 型チェック | `valueType` に基づく型検証 (string, number, integer, boolean, array, object, GeoJSON) |
+| 型チェック | `valueType` に基づく型の検証 (string、number、integer、boolean、array、object、GeoJSON) |
 | minLength / maxLength | 文字列長の制約 |
 | minimum / maximum | 数値範囲の制約 |
 | pattern | 正規表現パターンマッチ |
 | enum | 許可された値のリスト |
 
-検証失敗時は `400 Bad Request` が返されます:
+検証失敗時には `400 Bad Request` が返されます:
 
 ```json
 {
@@ -2872,11 +2870,11 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 #### 自動 JSON Schema 生成
 
-カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。また、`jsonSchema` を手動で指定することも可能です。
+カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。`jsonSchema` を手動で指定することも可能です。
 
 #### プロパティ @context (JSON-LD 語彙マッピング)
 
-`propertyDetails` の各プロパティには、JSON-LD 語彙マッピング用の HTTP(S) URL を指定できるオプションの `@context` フィールドを含めることができます。これにより、自動生成された URI の代わりに、よく知られた語彙 (例: schema.org) を使用できます。
+`propertyDetails` 内の各プロパティには、JSON-LD 語彙マッピング用の HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。これにより、自動生成された URI の代わりに、よく知られた語彙 (例: schema.org) を使用できます。
 
 ```json
 {
@@ -2899,18 +2897,18 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 - `@context` を持つプロパティ → 指定された URL が JSON-LD コンテキストで使用されます
 - `@context` を持たないプロパティ → 自動生成された URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
 - プロパティ URI はエンティティタイプに依存しません (同じプロパティ名はテナント内で同じ URI を共有します)
-- `@context` は HTTP(S) URL である必要があります (URN は受け付けません)
+- `@context` は HTTP(S) URL である必要があります (URN は受け付けられません)
 
 #### @context 解決の拡張
 
-NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはエンティティの `@context` に自動的に含まれます (コアコンテキストと一緒に配列として返されます)。
+NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストが自動的にエンティティの `@context` に含まれます (コアコンテキストと一緒に配列として返されます)。
 
 ### カタログ API
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/catalog` | GET | DCAT-AP カタログの取得 | 200 | 401 | - |
-| `/catalog/datasets` | GET | データセットの一覧取得 | 200 | 400, 401 | あり (最大: 1000) |
+| `/catalog/datasets` | GET | データセット一覧の取得 | 200 | 400, 401 | あり (最大: 1000) |
 | `/catalog/datasets/{datasetId}` | GET | データセットの取得 | 200 | 401, 404 | - |
 | `/catalog/datasets/{datasetId}/sample` | GET | サンプルデータの取得 | 200 | 401, 404 | - |
 
@@ -2925,15 +2923,15 @@ NGSI-LD レスポンスにおいて、カスタムデータモデルに `context
 
 ### イベントストリーミング API
 
-WebSocket を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化されます。
+WebSocket を使用したリアルタイムのエンティティ変更ストリーミングです。`EVENT_STREAMING_ENABLED=true` で有効化されます。
 
 | エンドポイント | プロトコル | 説明 |
 |----------|----------|-------------|
-| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントのストリーム配信 (認証は `Authorization` ヘッダー経由で送信) |
+| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントのストリーミング (認証は `Authorization` ヘッダー経由で送信) |
 
 詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
 
-### アクセス許可の概要
+### アクセス権限の概要
 
 | API カテゴリ | user | tenant_admin | super_admin |
 |--------------|------|--------------|-------------|
@@ -2954,9 +2952,9 @@ WebSocket を使用したリアルタイムエンティティ変更ストリー�
 
 ## 関連リンク
 
-- [FIWARE NGSI v2 仕様](https://fiware.github.io/specifications/ngsiv2/stable/)
-- [ETSI NGSI-LD 仕様](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf)
-- [FIWARE Orion Context Broker ドキュメント](https://fiware-orion.readthedocs.io/)
+- [FIWARE NGSI v2 Specification](https://fiware.github.io/specifications/ngsiv2/stable/)
+- [ETSI NGSI-LD Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf)
+- [FIWARE Orion Context Broker Documentation](https://fiware-orion.readthedocs.io/)
 - [IPA 空間 ID ガイドライン](https://www.ipa.go.jp/digital/architecture/guidelines/4dspatio-temporal-guideline.html)
 - [デジタル庁 空間 ID](https://www.digital.go.jp/policies/mobility_and_infrastructure/spatial-id)
 - [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)

--- a/docs/ja/api-reference/ngsild.md
+++ b/docs/ja/api-reference/ngsild.md
@@ -356,8 +356,7 @@ DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 | `datasetId` | string | 削除するマルチ属性インスタンスの datasetId |
 | `deleteAll` | boolean | `true` の場合、すべてのインスタンスを削除します |
 
-**レスポンス**: `204 No Content`
-### マルチ属性 (datasetId)
+**レスポンス**: `204 No Content`### マルチ属性 (datasetId)
 
 > **ETSI GS CIM 009 リファレンス**: Section 4.5.3 - Multi-Attribute
 
@@ -582,9 +581,7 @@ Merge-Patch セマンティクスを使用して、複数のエンティティ�
 | `options=noOverwrite` | 既存の属性を上書きしない |
 
 **レスポンス**
-- すべて成功: `204 No Content`
-- 部分的な成功: `207 Multi-Status`
----
+- すべて成功: `204 No Content`- 部分的な成功: `207 Multi-Status`---
 
 ### 時系列・バッチ操作 (NGSI-LD)
 
@@ -682,8 +679,7 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 
 `options=temporalValues` を指定すると、各属性が `values` 配列 (`[value, timestamp]` のペア) を含む簡易形式で返されます。
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues`
-```json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues````json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -705,8 +701,7 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 | `aggrMethods` | string | 集計メソッド (カンマ区切り): `totalCount`, `distinctCount`, `sum`, `avg`, `min`, `max`, `stddev`, `sumsq` |
 | `aggrPeriodDuration` | string | ISO 8601 期間 (例: `PT1H` は 1 時間)。`aggrMethods` 指定時に必須 |
 
-**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z`
-```json
+**例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z````json
 {
   "id": "urn:ngsi-ld:Sensor:1",
   "type": "Sensor",
@@ -1261,8 +1256,7 @@ Content-Type: application/ld+json
 DELETE /ngsi-ld/v1/entityMaps/{entityMapId}
 ```
 
-**レスポンス**: `204 No Content`
-### リンクエンティティの取得 (join/joinLevel)
+**レスポンス**: `204 No Content`### リンクエンティティの取得 (join/joinLevel)
 
 エンティティ取得エンドポイント (`GET /ngsi-ld/v1/entities` と `GET /ngsi-ld/v1/entities/{entityId}`) では、`join` と `joinLevel` のクエリパラメータを使用してリンクされたエンティティを取得できます。
 
@@ -1389,8 +1383,7 @@ PATCH /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 DELETE /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`
-### JSON-LD Context 管理
+**レスポンス**: `204 No Content`### JSON-LD Context 管理
 
 ETSI GS CIM 009 Section 5.12 に準拠した JSON-LD context 管理 API です。ユーザー定義の JSON-LD context の登録と管理が可能です。
 
@@ -1464,8 +1457,7 @@ GET /ngsi-ld/v1/jsonldContexts/{contextId}
 DELETE /ngsi-ld/v1/jsonldContexts/{contextId}
 ```
 
-**レスポンス**: `204 No Content`
-### Vector Tiles (NGSI-LD)
+**レスポンス**: `204 No Content`### Vector Tiles (NGSI-LD)
 
 地図可視化のためにエンティティデータを GeoJSON ベクタータイルとして提供します。TileJSON 3.0 準拠のメタデータと、ズームレベルおよびタイル座標による GeoJSON タイルの取得をサポートします。
 

--- a/docs/ja/api-reference/ngsiv2.md
+++ b/docs/ja/api-reference/ngsiv2.md
@@ -5,7 +5,7 @@ outline: deep
 ---
 # NGSIv2 API
 
-> このドキュメントは[API.md](./endpoints.md)から分割されました。メインの API 仕様については、[API.md](./endpoints.md)を参照してください。
+> この文書は [API.md](./endpoints.md) から分割されました。主要な API 仕様については、[API.md](./endpoints.md) を参照してください。
 
 ---
 
@@ -19,35 +19,35 @@ GET /v2/entities
 
 | パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
-| `id` | string | エンティティ ID でフィルタ (複数の値をカンマ区切りリストで指定可能) | - |
+| `id` | string | エンティティ ID でフィルタ (複数の値はカンマ区切りのリストとして指定可能) | - |
 | `limit` | integer | 取得する結果の数 (最大: 1000) | 20 |
 | `offset` | integer | オフセット (ページネーション用) | 0 |
-| `orderBy` | string | ソート条件 (`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順指定可能 (例: `!temperature`) | - |
-| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張** (公式仕様は `!` プレフィックス方式のみサポート) | `asc` |
+| `orderBy` | string | ソート基準 (`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順を指定 (例: `!temperature`) | - |
+| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張** (公式仕様は `!` プレフィックスアプローチのみサポート) | `asc` |
 | `type` | string | エンティティタイプでフィルタ | - |
 | `typePattern` | string | エンティティタイプの正規表現パターン | - |
 | `idPattern` | string | エンティティ ID の正規表現パターン | - |
-| `q` | string | 属性値でフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
-| `mq` | string | メタデータでフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
+| `q` | string | 属性値でフィルタ ([クエリ言語](./endpoints.md#query-language) を参照) | - |
+| `mq` | string | メタデータでフィルタ ([クエリ言語](./endpoints.md#query-language) を参照) | - |
 | `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張** (公式仕様では `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
-| `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries)を参照) | - |
+| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張** (公式仕様は `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
+| `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries) を参照) | - |
 | `geometry` | string | ジオメトリタイプ | - |
 | `coords` | string | 座標 (緯度,経度 形式、セミコロン区切り) | - |
-| `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search)を参照) | - |
+| `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search) を参照) | - |
 | `spatialIdDepth` | integer | 空間 ID 階層展開の深さ (0-4) | 0 |
-| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs)を参照) | `EPSG:4326` |
+| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs) を参照) | `EPSG:4326` |
 | `options` | string | `keyValues`、`values`、`count`、`geojson`、`sysAttrs`、`unique` | - |
 
 **組み込み属性**
 
-`attrs` パラメータは、ユーザー定義属性に加えて、以下の組み込み属性をサポートします:
+`attrs` パラメータは、ユーザー定義属性に加えて以下の組み込み属性をサポートします:
 
 | 組み込み属性 | 型 | 説明 |
 |---|---|---|
 | `dateCreated` | DateTime | エンティティ作成タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateModified` | DateTime | 最終更新タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateExpires` | DateTime | 一時エンティティの有効期限タイムスタンプ |
+| `dateModified` | DateTime | 最終変更タイムスタンプ (`options=sysAttrs` でも利用可能) |
+| `dateExpires` | DateTime | 一時的なエンティティの有効期限タイムスタンプ |
 | `servicePath` | Text | エンティティが保存されているServicePath (作成時の `Fiware-ServicePath` ヘッダー値) |
 
 例: `GET /v2/entities?attrs=temperature,servicePath`**レスポンス例**
@@ -131,7 +131,7 @@ POST /v2/entities
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
-| `options` | string | `upsert`: エンティティが既に存在する場合は更新。`keyValues`: リクエストボディを keyValues 形式として解釈 |
+| `options` | string | `upsert`: エンティティが既に存在する場合は更新します。`keyValues`: リクエストボディを keyValues 形式として解釈します |
 
 **リクエストボディ**
 
@@ -150,7 +150,7 @@ POST /v2/entities
 }
 ```
 
-**keyValues 形式入力** (`options=keyValues`)
+**keyValues 形式の入力** (`options=keyValues`)
 
 ```json
 {
@@ -167,8 +167,8 @@ POST /v2/entities
 
 **レスポンス**
 - ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
-- ステータス: `409 AlreadyExists` 同じ ID のエンティティが既に存在する場合 (タイプに関わらず)
-- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID はテナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension)を参照してください。
+- ステータス: `409 AlreadyExists` 同じ ID のエンティティが既に存在する場合 (タイプに関係なく)
+- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID は、テナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することは許可されておらず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
 ### 単一エンティティの取得
 
@@ -180,7 +180,7 @@ GET /v2/entities/{entityId}
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
-| `type` | string | エンティティタイプ (オプションのフィルタ; エンティティ ID は一意であるため、タイプの曖昧さ解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
+| `type` | string | エンティティタイプ (オプションフィルタ; エンティティ ID が一意であるため、型の曖昧性解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
 | `attrs` | string | 取得する属性名 (カンマ区切り) |
 | `options` | string | `keyValues`、`values` |
 
@@ -231,14 +231,14 @@ POST /v2/entities/{entityId}/attrs
 
 新しい属性を追加します (既存の属性は上書きされます)。
 
-`options=append` が指定された場合、既存の属性は上書きされず、新しい属性のみが追加されます (厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
+`options=append` を指定した場合、既存の属性は上書きされず、新しい属性のみが追加されます (厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
 
 **クエリパラメータ**
 
 | パラメータ | 型 | 説明 |
 |-----------|------|-------------|
 | `type` | string | エンティティタイプ |
-| `options` | string | `append`: 既存の属性の上書きを禁止 (厳密な追加モード) |
+| `options` | string | `append`: 既存属性の上書きを禁止 (厳密な追加モード) |
 
 **レスポンス**: `204 No Content`### エンティティの削除
 
@@ -254,9 +254,9 @@ DELETE /v2/entities/{entityId}
 
 **レスポンス**: `204 No Content`---
 
-## 属性の操作### エンティティの属性を取得
+## 属性操作### エンティティの属性を取得
 
-エンティティのすべての属性を取得します (`id` および `type` フィールドは含まれません)。
+エンティティのすべての属性を取得します(`id` および `type` フィールドは含まれません)。
 
 ```http
 GET /v2/entities/{entityId}/attrs
@@ -267,8 +267,8 @@ GET /v2/entities/{entityId}/attrs
 | パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
 | `type` | string | エンティティタイプ | - |
-| `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`) | `on` |
+| `attrs` | string | 取得する属性名(カンマ区切り) | - |
+| `metadata` | string | メタデータ出力制御(`on`、`off`) | `on` |
 | `options` | string | `keyValues`、`values`、`sysAttrs` | - |
 
 **レスポンス例**
@@ -288,7 +288,7 @@ GET /v2/entities/{entityId}/attrs
 }
 ```
 
-**keyValues 形式** (`options=keyValues`)
+**keyValues 形式**(`options=keyValues`)
 
 ```json
 {
@@ -299,7 +299,7 @@ GET /v2/entities/{entityId}/attrs
 
 > **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` および `type` フィールドが含まれません。属性のみが必要な場合に使用してください。
 
-### 単一属性の取得
+### 単一属性を取得
 
 ```http
 GET /v2/entities/{entityId}/attrs/{attrName}
@@ -321,7 +321,7 @@ GET /v2/entities/{entityId}/attrs/{attrName}
 }
 ```
 
-### 単一属性の更新
+### 単一属性を更新
 
 ```http
 PUT /v2/entities/{entityId}/attrs/{attrName}
@@ -342,7 +342,7 @@ PUT /v2/entities/{entityId}/attrs/{attrName}
 }
 ```
 
-**レスポンス**: `204 No Content`### 単一属性の削除
+**レスポンス**: `204 No Content`### 単一属性を削除
 
 ```http
 DELETE /v2/entities/{entityId}/attrs/{attrName}
@@ -360,7 +360,7 @@ DELETE /v2/entities/{entityId}/attrs/{attrName}
 GET /v2/entities/{entityId}/attrs/{attrName}/value
 ```
 
-属性の値のみを取得します (型とメタデータは含まれません)。
+属性の値のみを取得します(型とメタデータは含まれません)。
 
 **クエリパラメータ**
 
@@ -394,7 +394,7 @@ curl "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -H "Fiware-Service: smartcity"
 # Response: {"type":"Point","coordinates":[139.76,35.68]} (Content-Type: application/json)
 ```
-### 属性値の直接更新
+### 属性値を直接更新
 
 ```http
 PUT /v2/entities/{entityId}/attrs/{attrName}/value
@@ -414,7 +414,7 @@ PUT /v2/entities/{entityId}/attrs/{attrName}/value
 
 | Content-Type | 解釈 |
 |--------------|----------------|
-| `application/json` | JSON としてパース |
+| `application/json` | JSON として解析 |
 | `text/plain` | プリミティブ値 (`null`、`true`、`false`、数値) または文字列 |
 
 **使用例**
@@ -433,13 +433,13 @@ curl -X PUT "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -d '{"type":"Point","coordinates":[140.0,36.0]}'
 ```
 
-**レスポンス**: `204 No Content`**注**: この操作では、既存の属性の型やメタデータは変更されず、保持されます。
+**レスポンス**: `204 No Content`**注意**: この操作は既存の属性の型やメタデータを変更しません。これらは保持されます。
 
 ---
 
 ## バッチ操作
 
-> **注**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100、SAM パラメータ `MaxBatchSize` で最大 10,000 まで設定可能)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
+> **注意**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100)。この制限を超えるリクエストは `400 Bad Request` エラーになります。設定の詳細は DEVELOPMENT.md を参照してください。
 
 ### バッチ更新
 
@@ -472,15 +472,13 @@ POST /v2/op/update
 | アクション | 説明 |
 |--------|-------------|
 | `append` | 既存エンティティの属性を追加/更新 |
-| `appendStrict` | 既存エンティティに新しい属性を追加 (既存属性が存在する場合はエラーを返す) |
-| `update` | 既存の属性のみを更新 (エンティティが存在しない場合はエラー) |
+| `appendStrict` | 既存エンティティに新しい属性を追加 (既存の属性が存在する場合はエラーを返す) |
+| `update` | 既存の属性のみ更新 (エンティティが存在しない場合はエラー) |
 | `replace` | すべての属性を置換 |
 | `delete` | エンティティまたは属性を削除 |
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的成功/エラー: `200 OK` とエラー詳細
-
-```json
+- すべて成功: `204 No Content`- 部分的な成功/エラー: エラー詳細を含む `200 OK````json
 {
   "success": [
     { "entityId": "Room1" }
@@ -528,7 +526,7 @@ POST /v2/op/query
 POST /v2/op/notify
 ```
 
-外部 Context Broker からの通知を受信し、append でエンティティを処理します (存在しない場合は作成、既に存在する場合は更新)。
+外部の Context Broker からの通知を受信し、append でエンティティを処理します (存在しない場合は作成、既に存在する場合は更新)。
 
 **リクエストボディ**
 
@@ -584,7 +582,7 @@ POST /v2/subscriptions
 }
 ```
 
-**httpCustom 通知の例(カスタムテンプレート)**
+**httpCustom 通知の例 (カスタムテンプレート)**
 
 ```json
 {
@@ -609,25 +607,25 @@ POST /v2/subscriptions
 
 **httpCustom フィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
-| `url` | string | ✓ | 通知送信先 URL |
-| `method` | string | - | HTTP メソッド(GET、POST、PUT、PATCH、DELETE)。デフォルト: POST |
+| `url` | string | ✓ | 通知先 URL |
+| `method` | string | - | HTTP メソッド (GET, POST, PUT, PATCH, DELETE)。デフォルト: POST |
 | `headers` | object | - | カスタム HTTP ヘッダー |
-| `qs` | object | - | クエリ文字列パラメータ(`${...}` マクロ置換をサポート) |
-| `payload` | string | - | リクエストボディテンプレート(`${...}` マクロ置換をサポート) |
+| `qs` | object | - | クエリ文字列パラメータ (`${...}` マクロ置換をサポート) |
+| `payload` | string | - | リクエストボディテンプレート (`${...}` マクロ置換をサポート) |
 
 **マクロ置換**
 
-`${...}` 構文を使用して `payload` および `qs` の値にエンティティデータを埋め込むことができます:
+`${...}` 構文を使用して、`payload` と `qs` の値にエンティティデータを埋め込むことができます:
 
 | マクロ | 置換値 |
 |-------|-------------------|
 | `${id}` | エンティティ ID |
 | `${type}` | エンティティタイプ |
-| `${attrName}` | 属性値(正規化された属性から `.value` を抽出) |
+| `${attrName}` | 属性値 (正規化された属性から `.value` を抽出) |
 
-存在しない属性は文字列 `null` に置き換えられます。マクロは attrs/exceptAttrs フィルターが適用される前の完全なエンティティに対して評価されます。
+存在しない属性は文字列 `null` に置換されます。マクロは attrs/exceptAttrs フィルタが適用される前の完全なエンティティに対して評価されます。
 
 **MQTT 通知の例**
 
@@ -658,12 +656,12 @@ POST /v2/subscriptions
 
 **MQTT 通知設定**
 
-| フィールド | タイプ | 必須 | 説明 |
+| フィールド | 型 | 必須 | 説明 |
 |-------|------|----------|-------------|
 | `url` | string | ✓ | MQTT ブローカー URL (`mqtt://` または `mqtts://`) |
-| `topic` | string | ✓ | 通知送信先トピック |
-| `qos` | integer | - | QoS レベル(0、1、2)。デフォルト: 0 |
-| `retain` | boolean | - | メッセージ保持フラグ。デフォルト: false |
+| `topic` | string | ✓ | 通知先トピック |
+| `qos` | integer | - | QoS レベル (0, 1, 2)。デフォルト: 0 |
+| `retain` | boolean | - | メッセージ retain フラグ。デフォルト: false |
 | `user` | string | - | 認証ユーザー名 |
 | `passwd` | string | - | 認証パスワード |
 
@@ -699,16 +697,16 @@ POST /v2/subscriptions
 
 | フォーマット | 説明 |
 |--------|-------------|
-| `normalized` | 標準 NGSIv2 フォーマット(デフォルト) |
-| `keyValues` | 簡略化されたキーバリューフォーマット |
+| `normalized` | 標準 NGSIv2 フォーマット (デフォルト) |
+| `keyValues` | 簡略化されたキー・バリュー形式 |
 
 **通知属性のフィルタリング**
 
-| フィールド | タイプ | 説明 |
+| フィールド | 型 | 説明 |
 |-------|------|-------------|
 | `attrs` | string[] | 通知に含める属性名のリスト |
 | `exceptAttrs` | string[] | 通知から除外する属性名のリスト |
-| `onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせることができます。 |
+| `onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせ可能です。 |
 
 **レスポンス**
 - ステータス: `201 Created`- ヘッダー: `Location: /v2/subscriptions/{subscriptionId}`### サブスクリプションの一覧取得
@@ -719,11 +717,11 @@ GET /v2/subscriptions
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
+| パラメータ | 型 | 説明 | デフォルト |
 |-----------|------|-------------|---------|
 | `limit` | integer | 取得する結果の数 | 20 |
 | `offset` | integer | オフセット | 0 |
-| `status` | string | ステータスでフィルタリング(`active`、`inactive`) | - |
+| `status` | string | ステータスでフィルタリング (`active`, `inactive`) | - |
 
 ### サブスクリプションの取得
 
@@ -754,13 +752,13 @@ DELETE /v2/subscriptions/{subscriptionId}
 
 **レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張)
 
-認証が有効になっている場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
 
 ---
 
 ## 登録
 
-登録は外部コンテキストプロバイダを登録し、エンティティ情報のソースを管理します。
+登録 (Registration) は、外部コンテキストプロバイダーを登録し、エンティティ情報のソースを管理します。
 
 ### 登録の作成
 
@@ -796,7 +794,7 @@ POST /v2/registrations
 | `description` | string | - | 登録の説明 |
 | `dataProvided.entities` | array | ✓ | 対象エンティティ (id、idPattern、type) |
 | `dataProvided.attrs` | array | - | 提供する属性名 |
-| `provider.http.url` | string | ✓ | プロバイダ URL |
+| `provider.http.url` | string | ✓ | プロバイダー URL |
 | `expires` | string | - | 有効期限 (ISO 8601 形式) |
 | `status` | string | - | ステータス (`active` / `inactive`)。デフォルト: `active` |
 | `mode` | string | - | 転送モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`)。NGSI-LD 互換拡張 |
@@ -860,19 +858,19 @@ PATCH /v2/registrations/{registrationId}
 DELETE /v2/registrations/{registrationId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張)
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
 
 ---
 
 ## フェデレーション (クエリ転送 / 更新転送)
 
-登録情報に基づいて、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合して返します。また、更新も転送します。
+登録に基づいて、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合して、更新を転送します。
 
 ### フェデレーションの仕組み
 
-エンティティをクエリする際、一致する登録情報が存在する場合、そのプロバイダーにも並行してクエリが送信され、結果がマージされて返されます。
+エンティティをクエリする際、一致する登録が存在する場合、そのプロバイダーにも並行してクエリが送信され、結果がマージされて返されます。
 
 ```text
 Client → Context Broker
@@ -888,14 +886,14 @@ Client → Context Broker
 
 | モード | 動作 |
 |------|----------|
-| `inclusive` | ローカルとリモートの両方の結果を返します (デフォルト) |
-| `exclusive` | リモートの結果のみを返します (ローカルデータは無視されます) |
-| `redirect` | 303 リダイレクト URL を返します |
-| `auxiliary` | ローカルデータが優先され、リモートは不足データを補完します |
+| `inclusive` | ローカルとリモートの両方の結果を返す (デフォルト) |
+| `exclusive` | リモートの結果のみを返す (ローカルデータは無視される) |
+| `redirect` | 303 リダイレクト URL を返す |
+| `auxiliary` | ローカルデータを優先し、リモートが不足データを補完する |
 
 ### フェデレーションの例
 
-1. 外部プロバイダーを登録します:
+1. 外部プロバイダーを登録する:
 
 ```bash
 curl -X POST "http://localhost:3000/v2/registrations" \
@@ -913,7 +911,7 @@ curl -X POST "http://localhost:3000/v2/registrations" \
   }'
 ```
 
-2. クエリ時にフェデレーションが自動的に行われます:
+2. クエリ時に自動的にフェデレーションが実行される:
 
 ```bash
 curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
@@ -924,7 +922,7 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 ### 更新転送
 
-エンティティを更新または削除する際、一致する登録情報が存在する場合、更新もそのプロバイダーに並行して転送されます。
+エンティティを更新または削除する際、一致する登録が存在する場合、更新もそのプロバイダーに並行して転送されます。
 
 **サポートされる更新操作**
 
@@ -940,24 +938,24 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 | モード | 動作 |
 |------|----------|
-| `inclusive` | ローカルとリモートの両方を更新します |
-| `exclusive` | リモートのみを更新します (ローカルは更新されません) |
-| `redirect` | 303 リダイレクト URL を返します (ローカルは更新されません) |
-| `auxiliary` | ローカルのみを更新します (リモートは読み取り専用) |
+| `inclusive` | ローカルとリモートの両方を更新 |
+| `exclusive` | リモートのみを更新 (ローカルは更新されない) |
+| `redirect` | 303 リダイレクト URL を返す (ローカルは更新されない) |
+| `auxiliary` | ローカルのみを更新 (リモートは読み取り専用) |
 
-### エラー処理
+### エラーハンドリング
 
 | シナリオ | 動作 |
 |----------|----------|
-| プロバイダー接続失敗 | 警告をログに記録し、ローカル結果のみを返します |
-| プロバイダータイムアウト | 警告をログに記録し、ローカル結果のみを返します |
-| 排他モードですべてのプロバイダーが失敗 | 502 エラーを返します (オプション) |
+| プロバイダー接続失敗 | 警告をログに記録し、ローカル結果のみを返す |
+| プロバイダータイムアウト | 警告をログに記録し、ローカル結果のみを返す |
+| exclusive モードで全プロバイダーが失敗 | 502 エラーを返す (オプション) |
 
 ---
 
 ## エンティティタイプ
 
-### タイプ一覧
+### タイプ一覧の取得
 
 ```http
 GET /v2/types
@@ -967,8 +965,8 @@ GET /v2/types
 
 | パラメータ | 説明 |
 |-----------|-------------|
-| `options=count` | エンティティ数を含めます |
-| `options=values` | 属性の詳細を含めます |
+| `options=count` | エンティティ数を含める |
+| `options=values` | 属性の詳細を含める |
 
 **レスポンス例**
 
@@ -1006,37 +1004,37 @@ GET /v2/types/{typeName}
 
 ---
 
-## HTTP キャッシュコントロール
+## HTTP キャッシュ制御
 
-GET エンドポイントは、エンドポイントのクラスごとにキャッシュ関連のヘッダーを返します:
+GET エンドポイントは、エンドポイントクラスごとにキャッシュ関連のヘッダーを返します:
 
-### データエンドポイント (エンティティ、サブスクリプション、登録) — 完全な RFC 7232 + RFC 7234 サポート
+### データエンドポイント(エンティティ、サブスクリプション、登録) — 完全な RFC 7232 + RFC 7234 サポート
 
 | ヘッダー | 値 | 目的 |
 |--------|-------|---------|
-| `ETag` | `W/"..."` | 弱いバリデーター。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
+| `ETag` | `W/"..."` | 弱い検証子。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` と総数およびスコープを混合したストリーミングダイジェスト。単一: `modifiedAt` とスコープを混合したハッシュ。 |
 | `Last-Modified` | RFC 1123 HTTP-date | 結果セット内の最新の `modifiedAt` のタイムスタンプ。 |
-| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュ向けのテナント + 認証 + コンテンツネゴシエーション分離。 |
+| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロックし、`no-cache` はプライベートキャッシュからの再検証を強制します。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュのためのテナント + 認証 + コンテンツネゴシエーションの分離。 |
 
 条件付きリクエストがサポートされています:
 
 | リクエストヘッダー | 動作 |
 |----------------|----------|
-| `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified` (空のボディ) を返します。 |
+| `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified`(空のボディ)を返します。 |
 | `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。 |
-| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします。 |
+| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` に上書きします。 |
 
-### メタエンドポイント (タイプ) — Cache-Control + Vary のみ (ETag なし / 304 なし)
+### メタエンドポイント(タイプ) — Cache-Control + Vary のみ(ETag / 304 なし)
 
 | ヘッダー | 値 | 目的 |
 |--------|-------|---------|
 | `Cache-Control` | `max-age=60, stale-while-revalidate=120` | バックグラウンド再検証を伴う短期キャッシング。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証分離。 |
+| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証の分離。 |
 
-メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしていません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
+メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
 
-完全なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
+完全なセマンティクスについては、[API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
 
 ---
 
@@ -1045,21 +1043,21 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 | ステータスコード | エラーコード | 説明 |
 |-------------|------------|-------------|
 | 400 | BadRequest | 無効なリクエストパラメータまたはボディ |
-| 400 | InvalidModification | 無効な属性変更 (例: id や type の変更) |
+| 400 | InvalidModification | 無効な属性変更(例: id または type の変更) |
 | 401 | Unauthorized | 認証が必要、またはトークンが無効 |
 | 403 | Forbidden | 権限不足 |
 | 404 | NotFound | エンティティ、サブスクリプションなどが見つかりません |
 | 405 | MethodNotAllowed | HTTP メソッドが許可されていません |
-| 409 | AlreadyExists | エンティティが既に存在します (POST 作成時) |
-| 409 | TooManyResults | 複数のエンティティが一致しました (type が指定されていない場合) |
+| 409 | AlreadyExists | エンティティが既に存在します(POST 作成時) |
+| 409 | TooManyResults | 複数のエンティティが一致しました(type が指定されていない場合) |
 | 411 | ContentLengthRequired | Content-Length ヘッダーが必要です |
 | 413 | RequestEntityTooLarge | リクエストボディが大きすぎます |
 | 415 | UnsupportedMediaType | サポートされていない Content-Type |
-| 422 | Unprocessable | エンティティフォーマットが無効です |
+| 422 | Unprocessable | エンティティ形式が無効です |
 | 429 | TooManyRequests | レート制限を超過しました |
 | 500 | InternalError | 内部サーバーエラー |
 
-**エラーレスポンスフォーマット**
+**エラーレスポンス形式**
 
 ```json
 {
@@ -1072,13 +1070,13 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 
 ## エンドポイントリファレンス
 
-FIWARE NGSIv2 互換の Context Broker API です。
+FIWARE NGSIv2 互換の Context Broker API。
 
 ### 共通仕様
 
 - **Content-Type**: `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
 - **テナント分離**: `Fiware-Service` ヘッダーによるテナント分離
-- **ページネーション**: `limit`/`offset` パラメータを使用。総数を取得するには `options=count` を使用
+- **ページネーション**: `limit`/`offset` パラメータ; 総数を取得するには `options=count` を使用
 
 ### エンティティ操作
 
@@ -1088,7 +1086,7 @@ FIWARE NGSIv2 互換の Context Broker API です。
 | `/v2/entities` | POST | エンティティの作成 | 201 | 400, 401, 409, 415 | - |
 | `/v2/entities/{entityId}` | GET | エンティティの取得 | 200 | 400, 401, 404 | - |
 | `/v2/entities/{entityId}` | DELETE | エンティティの削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | GET | 属性のみを取得 (id/type フィールドなし) | 200 | 400, 401, 404 | - |
+| `/v2/entities/{entityId}/attrs` | GET | 属性のみを取得 (id/type フィールドを除く) | 200 | 400, 401, 404 | - |
 | `/v2/entities/{entityId}/attrs` | PATCH | 属性の更新 | 204 | 400, 401, 404, 415 | - |
 | `/v2/entities/{entityId}/attrs` | POST | 属性の追加 | 204 | 400, 401, 404, 415 | - |
 | `/v2/entities/{entityId}/attrs` | PUT | 属性の置換 | 204 | 400, 401, 404, 415 | - |
@@ -1103,7 +1101,7 @@ FIWARE NGSIv2 互換の Context Broker API です。
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
 | `/v2/types` | GET | タイプ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/types/{typeName}` | GET | タイプ詳細の取得 | 200 | 401, 404 | - |
+| `/v2/types/{typeName}` | GET | タイプの詳細を取得 | 200 | 401, 404 | - |
 
 ### サブスクリプション操作
 
@@ -1115,7 +1113,7 @@ FIWARE NGSIv2 互換の Context Broker API です。
 | `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプションの更新 | 204 | 400, 401, 404, 415 | - |
 | `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプションの削除 | 204 | 401, 404 | - |
 
-### 登録操作(フェデレーション)
+### 登録操作 (フェデレーション)
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
@@ -1127,10 +1125,10 @@ FIWARE NGSIv2 互換の Context Broker API です。
 
 ### バッチ操作
 
-> **注意**: バッチ操作(クエリを除く)は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています(デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
+> **注意**: バッチ操作 (クエリを除く) は、リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています (デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
 
 | エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
 |----------|--------|-------------|---------|-------|------------|
-| `/v2/op/update` | POST | バッチ更新(最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
+| `/v2/op/update` | POST | バッチ更新 (最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
 | `/v2/op/query` | POST | バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
 | `/v2/op/notify` | POST | 通知の受信 | 200 | 400, 401, 415 | - |

--- a/docs/ja/changelog.md
+++ b/docs/ja/changelog.md
@@ -10,7 +10,7 @@ outline: deep
 このフォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に基づいており、
 このプロジェクトは [Semantic Versioning](https://semver.org/lang/ja/) に準拠しています。
 
-## [Unreleased]
+## [Unreleased]## [0.8.0] — 2026-05-05
 
 ### 2026-05-05
 - **修正**: SDK の `db.request()` が空ボディ + JSON Content-Type のレスポンスで `SyntaxError: Unexpected end of JSON input` を投げて落ちる問題 (issue #1145) (#1146)
@@ -49,8 +49,7 @@ outline: deep
 - 🚨 **破壊的変更 (軽微)**: SDK の URL クエリ文字列のエンコーディングが微妙に変わる (#1149)
   - 旧: `encodeURIComponent` でフィールドごとに直列化
   - 新: `URLSearchParams` ベースに refactor (DRY 化のため)
-  - 影響を受ける文字: 半角スペース `%20` → `+` / `'` 素通し → `%27` / `!` `*` `(` `)` `~` 素通し → `%21` `%2A` `%28` `%29` `%7E`
-  - サーバ側 (GeonicDB 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
+  - 影響を受ける文字: 半角スペース `%20` → `+` / `'` 素通し → `%27` / `!` `*` `(` `)` `~` 素通し → `%21` `%2A` `%28` `%29` `%7E`  - サーバ側 (GeonicDB 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
   - 公開メソッドのシグネチャは追加のみで完全後方互換 (新パラメータはすべて optional)
 - **改善**: SDK のクエリパラメータ表面を NGSI-LD §5.7.2 (Query Entities) に揃えて拡充 (issue #1132) (#1149)
   - 背景: `db.getEntities()` 等は `type / limit / offset / q` の 4 パラメータしか URL に乗せておらず、サーバが実装している `scopeQ` / `georel` / `geometry` / `coordinates` / `attrs` / `pick` / `omit` / `lang` / `orderBy` / `count` 等を SDK 経由で使えなかった。実アプリで scope に基づくフィルタが必要になり (geonicdb-gis 関連)、SDK を諦めて `db.request()` で素のパスを組み立てる回避が必要だった
@@ -60,13 +59,13 @@ outline: deep
     - **`src/sdk/websocket.ts`**: `subscribe(options)` が `scopeQ` を受け、サブスクリプションメッセージに添える (サーバ側未対応バージョンでは無視される)
     - **`src/sdk/README.md`**: `getEntities()` の例にコメント形式で全パラメータを列挙
   - 後方互換: 既存呼び出し (`{ type, limit, offset, q }` のみ) は完全に動作。新パラメータは optional 追加
-  - 追加: `tests/unit/sdk/index.test.ts` に regression テスト 3 件
+  - 追加: __INLINE
 
 ## [0.7.1] — 2026-05-02
 
 ### 2026-05-02
 - **修正**: SDK 公開パッケージの d.ts root が strict tsconfig で named import を解決できない問題 (issue #1127)
-  - 背景: PR #1124 (#1118 の修正) で `geonicdb.d.ts` を `export * from './index'` の wildcard re-export に変更したが、`src/sdk/package.json` の `files: ["geonicdb.*"]` は **意図的な single-file 配信** (#877) のため `./index.d.ts` 等の per-file d.ts は npm パッケージに含まれない。strict tsconfig (`verbatimModuleSyntax`、`strict` 等) の consumer から見ると wildcard が空に解決され、`AuthorizationError` を含む全 named export が消えていた (locus サンプル開発で `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` がモジュール解決エラーになり発覚)
+  - 背景: PR #1124 (#1118 の修正) で `geonicdb.d.ts` を `export * from './index'` の wildcard re-export に変更したが、`src/sdk/package.json` の `files: ["geonicdb.*"]` は **意図的な single-file 配信** (#877) のため `./index.d.ts` 等の per-file d.ts は npm パッケージに含まれない。strict tsconfig (`verbatimModuleSyntax`, `strict` 等) の consumer から見ると wildcard が空に解決され、`AuthorizationError` を含む全 named export が消えていた (locus サンプル開発で `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` がモジュール解決エラーになり発覚)
   - 修正: `scripts/build-sdk.ts` の d.ts 生成を hardcoded export 列挙形式に戻した。ただし TypeScript AST (`typescript` の `createSourceFile`) で `src/sdk/index.ts` を走査して export 一覧を **build 時に自動収集** するため、新規 export 追加時に build-sdk.ts を後追い修正する必要なし (drift 自動防止)
   - **検証強化** (回帰防止): 既存の `dist/sdk/` 直読みではなく、`npm pack` の tarball を抽出した上で
     - 公開ファイルから `geonicdb.d.ts` / `geonicdb.{cjs,mjs,iife.js}` が含まれていることを検証
@@ -79,7 +78,7 @@ outline: deep
 
 ### 2026-05-02
 - **改善**: ReactiveCore Rules の SLO 超過に対する協調キャンセルを実装 (issue #1122) (#1123)
-  - 背景: PR #1121 で導入した `RuleProcessorFunction` の `Promise.race` ベースの soft timeout は、wait を打ち切るだけで `ruleEngine.processEntityChange()` の裏での実行は継続していた。Lambda hard timeout (30s) で最終的に止まるが、SLO (`MAX_RULE_EXECUTION_TIME_MS = 5s`) を超えた処理が走り続け、意図しない entity 作成 / webhook 発火を起こし得た (CodeRabbit 指摘)
+  - 背景: PR #1121 で導入した `RuleProcessorFunction` の `Promise.race` ベースの soft timeout は、wait を打ち切るだけで `ruleEngine.processEntityChange()` の裏での実行は継続していた。Lambda hard timeout (30s) で最終的に止まるが、SLO (`MAX_RULE_EXECUTION_TIME_MS = 5s`) を超えた処理が走り続け、unintended な entity 作成 / webhook 発火を起こし得た (CodeRabbit 指摘)
   - 対応: `RuleEngineService.processEntityChange(event, signal?)` に optional `AbortSignal` を追加。ルール評価ループ・アクション実行ループの境界で `signal.throwIfAborted()` をチェックし、新しいルール / アクションの開始を阻止する。`executeWebhookAction` は `AbortSignal.any([外部 signal, 内部 timeout signal])` で外部 signal と既存の内部 timeout を合成し、HTTP fetch も中断するようにした
   - `handlers/rules/processor.ts` で `AbortController` を作成し、SLO 超過で `controller.abort()` を呼ぶ。span 上は abort されたかを区別して ERROR を記録 (`aborted` フラグを log に出す)
   - 既存の `entity.service` / `temporal.service` の各メソッドへの signal threading は影響範囲が広いため別 issue に切り出し、本対応では「ループ境界で次の処理を始めない」までを保証する。in-flight の DB 操作は完走させる
@@ -108,11 +107,7 @@ outline: deep
     - `tests/e2e/features/auth/rules-auto-fire.feature` で「entity 作成 API のみで Rule action が自動実行される」シナリオを 2 つ追加 (`triggerRuleExecution` を介さない再現テスト)
     - `tests/unit/infrastructure/sam-template.test.ts` で `infrastructure/template.yaml` の最小構造を検証 (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction が EventBridgeRule で 3 種の detail-type を listen していることを機械的に確認)
     - `tests/unit/handlers/rules/processor.test.ts` で新規 handler 単体の挙動 (3 種イベント委譲・secondary region スキップ・エラー握り潰し・タイムアウト) を検証
-  - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
-
-## [0.6.0] — 2026-05-01
-
-### 2026-05-01
+  - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`## [0.6.0] — 2026-05-01### 2026-05-01
 - **認可**: WebSocket 配信時の XACML AuthzRequest に `entityOwner` / `entityId` を inject (issue #1107) (#1116)
   - `src/handlers/websocket/broadcaster.ts` の `filterByAuthz` と `src/core/streaming/local-ws-server.ts` の `broadcastEventAsync` を改修。各コネクションに対する `authorizeWs()` 呼び出しに、配信対象 entity の `entityOwner` (createdBy) / `entityId` / `entityType` を渡す。これまで `entityType` のみだったため、「**自分が所有する entity の更新だけ受信する**」per-user 通知フィルタが XACML カスタムポリシーで書けなかった
   - これに伴い `EntityChangeEvent.entity` に optional な `owner?: string` を追加。`entity.service.ts` の publish 経路 (CREATE/UPDATE/DELETE 各種) で entity の `createdBy` を transparent に伝播する。`InternalEntity.createdBy` も追加 (内部用; NGSI トランスフォーマでは出力されない)
@@ -221,8 +216,8 @@ outline: deep
 
 ### 2026-04-28
 - **CORS 修正**: `Access-Control-Allow-Headers` に `If-None-Match` / `If-Modified-Since` を追加 (#1065)
-  - 旧設定では cross-origin リクエストにこれら 2 ヘッダーが allow されていなかったため、ブラウザの HTTP cache 自動再検証と SDK の `_cachedRequest` が CORS preflight (OPTIONS) で reject され、INM 付き GET を送ることができなかった (#1065)
-  - 結果として PR #1060 (SDK invalidation 削除) / #1062 (CORS expose ETag) / #1063 (Cache-Control: no-cache strip) という 3 段の修正が揃っていても、INM そのものがブラウザから出ないため 304 経路全体が機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが効かない現象の最終真因) (#1065)
+  - 旧設定では cross-origin リクエストにこれら 2 ヘッダーが allow されていなかったため、ブラウザの HTTP cache auto-revalidation と SDK の `_cachedRequest` が CORS preflight (OPTIONS) で reject され、INM 付き GET を送ることができなかった (#1065)
+  - 結果として PR #1060 (SDK invalidation 削除) / #1062 (CORS expose ETag) / #1063 (Cache-Control: no-cache strip) という 3 段の修正が揃っていても、INM そのものがブラウザから出ないため 304 経路全体が機能していなかった (incident 2026-04-28: pulse で SDK cache が効かない現象の最終真因) (#1065)
   - 修正: `src/config/defaults.ts` に `CORS_ALLOW_HEADERS` 定数を新設し `If-None-Match` / `If-Modified-Since` を含めた完全な allow-list を集約。`cors.middleware.ts` と `infrastructure/template.yaml` (Cors.AllowHeaders / GatewayResponses) は同定数に同期 (#1065)
   - 検証方法: `curl -X OPTIONS -H 'Access-Control-Request-Headers: if-none-match' <endpoint>/ngsi-ld/v1/entities` で `If-None-Match` が allow-headers に含まれることを確認 (#1065)
   - テスト: cors.middleware.test に `If-None-Match` / `If-Modified-Since` の allow ケースを追加。cors-comprehensive.feature に `@issue-1065` シナリオ 2 件追加 (#1065)
@@ -230,43 +225,43 @@ outline: deep
 - **デプロイ可視化**: `/version` エンドポイントの `git_hash` フィールドにコミット SHA を埋め込み (#1064)
   - `infrastructure/template.yaml` に `GitHash` パラメータを追加し、Lambda 環境変数 `GIT_HASH` として注入 (#1064)
   - `deploy-env.yml` で `GitHash=${{ github.sha }}` を SAM パラメータに渡す (staging / prod 両経路対応) (#1064)
-  - 用途: staging / prod でデプロイ済みのコミットを `curl /version` で即時確認できるようにする。デプロイ問題の切り分けが従来 CloudFormation イベントログまで遡らないと判明しなかったが、これで一発で分かる (#1064)
+  - 用途: staging / prod でデプロイ済みのコミットを `curl /version` で即時確認できるようにする。デプロイ問題の切り分けが従来 CloudFormation event log まで遡らないと判明しなかったが、これで一発で分かる (#1064)
 
 - **条件付きリクエスト修正**: `Cache-Control: no-cache` リクエストヘッダーを INM 評価から除外 (#1063)
   - 旧挙動: `fresh` パッケージが RFC 2616 §14.9.4 に従いリクエストの `Cache-Control: no-cache` を "force reload" として扱い、`If-None-Match` 一致でも 304 を返さず常に 200 + body を返却していた (#1063)
-  - ブラウザは特定のコンテキスト (ハードリロード後の継続フェッチ等) で `Cache-Control: no-cache` を fetch に自動付与するため、SDK が明示的に `If-None-Match` を送っていてもサーバが 304 を返さなくなり、SDK の帯域節約が常に機能しない問題が発生 (incident 2026-04-28: pulse で SDK キャッシュが効いているように見えて毎回 200 が返る現象の真因) (#1063)
+  - ブラウザは特定の context (ハードリロード後の継続フェッチ等) で `Cache-Control: no-cache` を fetch に自動付与するため、SDK が明示的に `If-None-Match` を送っていてもサーバが 304 を返さなくなり、SDK の帯域節約が常に死ぬ問題が発生 (incident 2026-04-28: pulse で SDK キャッシュが効いているように見えて毎回 200 が返る現象の真因) (#1063)
   - 修正: `evaluateConditionalRequest` の `normalizeRequestHeaders` でリクエストヘッダーから `cache-control` を除外。SDK の明示的な `If-None-Match` 送信 = 「同じなら 304 で OK」という意思表示なので、ブラウザ自動付与の `Cache-Control: no-cache` で 304 を抑制しないのが正しい (#1063)
-  - `Cache-Control: no-store` (CDN バイパス意図) は引き続き `honorClientNoStore` で適切に扱う (本修正は INM 評価のみ影響) (#1063)
-  - テスト: `evaluateConditionalRequest` ユニットテストに Cache-Control: no-cache + INM / + IMS の 2 ケース追加。`http-cache-control.feature` に NGSIv2 単一エンティティ / NGSI-LD リストの 2 シナリオ追加 (#1063)
+  - `Cache-Control: no-store` (CDN bypass 意図) は引き続き `honorClientNoStore` で適切に扱う (本修正は INM 評価のみ影響) (#1063)
+  - テスト: `evaluateConditionalRequest` unit test に Cache-Control: no-cache + INM / + IMS の 2 ケース追加。`http-cache-control.feature` に NGSIv2 単一 entity / NGSI-LD list の 2 シナリオ追加 (#1063)
 
 - **CORS 修正**: `Access-Control-Expose-Headers` に複数のレスポンスヘッダーを追加 (#1062)
-  - **ETag / Vary**: 旧設定では `ETag` が CORS で隠され、ブラウザ JavaScript から `res.headers.get('etag')` が `null` を返していたため、SDK がキャッシュエントリを作れず `If-None-Match` も送れず、304 帯域節約パスが完全に機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが一切効かなかった真因) (#1062)
-  - **Content-Crs**: NGSI-LD / NGSIv2 の geo レスポンスで CRS を通知するヘッダー。ブラウザクライアントが座標系を判別するために必要 (#1062)
+  - **ETag / Vary**: 旧設定では `ETag` が CORS で隠され、ブラウザ JS から `res.headers.get('etag')` が `null` を返していたため、SDK がキャッシュエントリを作れず `If-None-Match` も送れず、304 帯域節約パスが完全に機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが一切効かなかった真因) (#1062)
+  - **Content-Crs**: NGSI-LD / NGSIv2 の geo response で CRS を通知するヘッダー。ブラウザクライアントが座標系を判別するために必要 (#1062)
   - **Fiware-Next-Token**: NGSIv2 ページネーション継続トークン。クライアントが次ページをリクエストするために必要 (#1062)
-  - **NGSILD-Warning**: NGSI-LD federation 警告。クライアントに警告を通知するために必要 (#1062)
-  - **Retry-After**: 429 rate limit / 503 retry-after 案内。クライアントがリトライ戦略を決めるために必要 (#1062)
+  - **NGSILD-Warning**: NGSI-LD federation warning。クライアントに警告を通知するために必要 (#1062)
+  - **Retry-After**: 429 rate limit / 503 retry-after 案内。クライアントが retry 戦略を決めるために必要 (#1062)
   - `Cache-Control` / `Last-Modified` / `Content-Type` 等は CORS-safelisted なので expose 不要 (#1062)
-  - 漏れ検出: 全エンドポイントのレスポンスヘッダーを grep して CORS expose リストと突合し、不足している 4 件 (Content-Crs / Fiware-Next-Token / NGSILD-Warning / Retry-After) を発見・追加 (#1062)
+  - 漏れ検出: 全エンドポイント response header を grep して CORS expose リストと突合し、missing 4 件 (Content-Crs / Fiware-Next-Token / NGSILD-Warning / Retry-After) を発見・追加 (#1062)
   - 設定値は `src/config/defaults.ts` の `CORS_EXPOSE_HEADERS` (`as const` 配列) に集約 (#1062)
 
 - **セキュリティ**: Dependabot アラート 13 件を一括解消 (#1061)
-  - 直接依存 (overrides 経由): `hono` ^4.12.14, `@hono/node-server` ^1.19.13 — JSX SSR HTML インジェクション / cookie 名検証 / IPv4-mapped IPv6 / serveStatic / toSSG パストラバーサルを解消 (#1061)
-  - 間接依存 (overrides 追加): `protobufjs@<8` ^7.5.5 (任意コード実行), `basic-ftp` ^5.3.1 (CRLF インジェクション / DoS), `follow-redirects` ^1.16.0 (Authorization ヘッダーリーク), `uuid` ^14.0.0 (バッファ境界) (#1061)
+  - 直接依存 (overrides 経由): `hono` ^4.12.14, `@hono/node-server` ^1.19.13 — JSX SSR HTML injection / cookie name 検証 / IPv4-mapped IPv6 / serveStatic / toSSG path traversal を解消 (#1061)
+  - 間接依存 (overrides 追加): `protobufjs@<8` ^7.5.5 (任意コード実行), `basic-ftp` ^5.3.1 (CRLF injection / DoS), `follow-redirects` ^1.16.0 (Authorization ヘッダーリーク), `uuid` ^14.0.0 (バッファ境界) (#1061)
   - `npm audit` で 0 vulnerabilities を確認 (#1061)
 
-- **SDK パフォーマンス修正**: WebSocket エンティティイベントでの自動キャッシュ無効化を削除 (#1060)
-  - 旧実装: `entityCreated` / `entityUpdated` / `entityDeleted` 受信時に SDK が `_invalidateCacheForEntityEvent()` で全エンティティキャッシュエントリを `deleteWhere` で削除していた (#1060)
-  - 削除すると ETag も失われ、次回読み取りで `If-None-Match` が送られず、サーバは毎回 full `200` body を返却 → 304 帯域節約パスが完全に機能していなかった (#1060)
-  - data エンドポイントは `Cache-Control: private, no-cache` で毎回再検証されるため、キャッシュを残しても安全 (サーバ側 ETag マッチで 304 / 200 が自動的に振り分けられる) (#1060)
-  - 結果: pulse 等のリアルタイム監視アプリで WebSocket 受信中にキャッシュが効くようになり、未変更データの再取得が 304 で済むようになる (#1060)
+- **SDK パフォーマンス修正**: WebSocket entity events での自動キャッシュ無効化を削除 (#1060)
+  - 旧実装: `entityCreated` / `entityUpdated` / `entityDeleted` 受信時に SDK が `_invalidateCacheForEntityEvent()` で全 entities cache エントリを `deleteWhere` で削除していた (#1060)
+  - 削除すると ETag も失われ、次回読み取りで `If-None-Match` が送られず、サーバは毎回 full `200` body を返却 → 304 帯域節約パスが完全に死んでいた (#1060)
+  - data エンドポイントは `Cache-Control: private, no-cache` で毎回 revalidation されるため、cache を残しても安全 (server 側 ETag マッチで 304 / 200 が自動的に振り分けられる) (#1060)
+  - 結果: pulse 等のリアルタイム監視アプリで WebSocket 受信中にキャッシュが効くようになり、unchanged data の再取得が 304 で済むようになる (#1060)
   - 明示的に全クリアしたい場合は `clearCache()` を呼ぶ (公開 API なので未変更)。`clearCache()` で `cacheInvalidated` イベントが発火するように修正 — WebSocket 経路を削除した結果、このイベントが発火しなくなる退行を回避 (#1060)
 
 - **セキュリティ強化**: Security Audit Group 3 — 公開 vs 認証境界の網羅検証 (#1057)
   - **#1053: 公開メタエンドポイントに STATIC ポリシーを適用** — `/llms.txt`, `/api.json`, `/openapi.json`, `/tools.json`, `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json` の 6 エンドポイントが `Cache-Control` を返していなかった (CDN がキャッシュ判断できず、コスト・レイテンシが悪化)。`applyCachePolicy('static')` を適用して `Cache-Control: public, max-age=3600` を返すよう修正。ただし `/openapi.json` は tenant 依存の `CustomDataModel_*` を埋め込むケースがあるため、注入された場合のみ `meta` ポリシーへフォールバック (#1057)
   - **#1053: STATIC ポリシーの Vary を最小化** — STATIC は cross-tenant で共有可能なため、`Vary` を `Accept` のみに制限。`Fiware-Service` / `Authorization` / `X-Api-Key` を含めると CDN がテナント / ユーザ毎にキャッシュ分離してしまい、STATIC の意義 (CDN 広域共有) が損なわれる (#1057)
-  - **#1053: lint テスト追加** — `meta.controller.test.ts` に「Cache-Control policy assignment lint」を新設。各公開エンドポイントが `public, max-age=3600` を返し、`private` / `no-cache` を含まないこと、`Vary` がテナント / 認証次元を含まないこと、`/openapi.json` の tenant スキーマありケースで `meta` フォールバックが効くことを 12 ケースで検証 (#1057)
-  - **#1048: Vary 網羅性 audit + 文書化** — 現状の `Vary` (`Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`) が網羅的であることを確認。`DPoP` (リクエスト毎)、`Accept-Language` (NGSI で使われない)、`Origin`、`X-Forwarded-For` (認証段階で評価) を意図的に除外することを `docs/SECURITY.md` に明記 (#1057)
-  - **#1052: DPoP / DPoP-Nonce × cache 検証 + 文書化** — `DPoP-Nonce` が 304 パススルーホワイトリストに既に含まれていることをユニットテストで固定。DPoP 認証失敗が `evaluateConditionalRequest` より前に評価される invariant を `docs/AUTH.md` / `docs/SECURITY.md` に明記 (#1057)
+  - **#1053: lint test 追加** — `meta.controller.test.ts` に「Cache-Control policy assignment lint」を新設。各公開エンドポイントが `public, max-age=3600` を返し、`private` / `no-cache` を含まないこと、`Vary` がテナント / 認証次元を含まないこと、`/openapi.json` の tenant スキーマありケースで `meta` フォールバックが効くことを 12 ケースで検証 (#1057)
+  - **#1048: Vary 網羅性 audit + 文書化** — 現状の `Vary` (`Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`) が網羅的であることを確認。`DPoP` (per-request)、`Accept-Language` (NGSI で使われない)、`Origin`、`X-Forwarded-For` (auth 段階で評価) を意図的に除外することを `docs/SECURITY.md` に明記 (#1057)
+  - **#1052: DPoP / DPoP-Nonce × cache 検証 + 文書化** — `DPoP-Nonce` が 304 passthrough whitelist に既に含まれていることを unit test で固定。DPoP 認証失敗が `evaluateConditionalRequest` より前に評価される invariant を `docs/AUTH.md` / `docs/SECURITY.md` に明記 (#1057)
   - **ドキュメント**: `docs/SECURITY.md` に「Vary Header Coverage Audit」「DPoP / DPoP-Nonce & Cache Integrity」「Public vs Authenticated Endpoint Cache Policy Matrix」3 セクション追加。`docs/AUTH.md` に「DPoP & HTTP Cache Interaction」サブセクション追加 (#1057)
 
 ### 2026-04-28
@@ -281,7 +276,7 @@ outline: deep
   - **#1047: 共有キャッシュ汚染防止** — data エンドポイントの `Cache-Control` を `no-cache` から `private, no-cache` に変更。RFC 7234 §5.2.2.6 の `private` で CloudFront / 中間プロキシ / ISP プロキシでの保存を禁止し、ブラウザ等の private cache のみを許容。`Authorization` 付きレスポンスがブラウザ disk cache に乗らない問題 (Chrome/Safari の挙動) も同時に解消 (#1055)
   - **#1051: テナント間 ETag 衝突防止** — `deriveEtagScope(event)` の seed に `Fiware-Service` + `Fiware-ServicePath` を追加。Vary が壊れた中間キャッシュ越しでも ETag 値そのものがテナント / サブテナント間で必ず異なることを保証。`Authorization` / `X-Api-Key` は seed に含めない (同テナント内の別ユーザは 304 で帯域節約できるべきで、テナント seed が認可境界として十分) (#1055)
   - **テスト** (#1055): cache-control middleware unit test に scope 検証 4 ケース追加 (cross-tenant / cross-servicePath / case-insensitive header lookup)。`http-cache-control.feature` に `@issue-1047` シナリオ 3 件、`@issue-1051` シナリオ 3 件追加
-  - **ドキュメント** (#1055): `docs/API.md`, `docs/API_NGSIV2.md`, `docs/API_NGSILD.md`, `docs/INSTRUCTION.md`, `docs/SECURITY.md` に `private, no-cache` ポリシーと tenant-scoped ETag を反映
+  - **ドキュメント** (#1055): `docs/API.md`、`docs/API_NGSIV2.md`、`docs/API_NGSILD.md`、`docs/INSTRUCTION.md`、`docs/SECURITY.md` に `private, no-cache` ポリシーと tenant-scoped ETag を反映
 
 ### 2026-04-27
 - **セキュリティ / バグ修正**: HTTP キャッシュコントロール監査で検出した 4 件のバグを修正 (#1054)
@@ -295,7 +290,7 @@ outline: deep
     - `handlers/api/index.ts` — HEAD リクエストを内部で GET にフォールバックし、`addCorsHeaders` ラッパーで最終 body を抑止 (成功・エラー両経路)
     - `temporal.controller.ts` の GET 4 経路に `applyCachePolicy('data')` を適用
     - `local-server.ts` — Express の自動 ETag 生成を `app.set('etag', false)` で無効化。ローカル開発でも本番 (API Gateway + Lambda) と同じ挙動を再現
-    - **追加カバレッジ**: NGSIv2 / NGSI-LD の attribute-level GET エンドポイント (`/v2/entities/{id}/attrs`, `/v2/entities/{id}/attrs/{name}`, `/v2/entities/{id}/attrs/{name}/value`, `/ngsi-ld/v1/entities/{id}/attrs/{name}`) も `applyCacheHeaders` 経由で ETag/Last-Modified/Cache-Control/Vary を返すよう追加。Express auto-ETag 無効化に伴うキャッシュ無し状態を回避
+    - **追加カバレッジ**: NGSIv2 / NGSI-LD の attribute-level GET エンドポイント (`/v2/entities/{id}/attrs`、`/v2/entities/{id}/attrs/{name}`、`/v2/entities/{id}/attrs/{name}/value`、`/ngsi-ld/v1/entities/{id}/attrs/{name}`) も `applyCacheHeaders` 経由で ETag/Last-Modified/Cache-Control/Vary を返すよう追加。Express auto-ETag 無効化に伴うキャッシュ無し状態を回避
   - **テスト** (#1054): cache-control middleware unit test に scope 検証 11 ケース追加。`http-cache-control.feature` に B-1 / B-2 / B-3 / B-4 シナリオ 7 件追加。`head-requests.feature` を 200 期待形に書き換え (HEAD が GET 等価で動作することを検証)
   - **ドキュメント** (#1054): `docs/API.md` に Temporal クラス追加、ETag scope (path + Accept) の説明追加、HEAD サポート明記、attribute-level エンドポイント追加
 
@@ -331,21 +326,21 @@ outline: deep
 - **Feature**: HTTP キャッシュコントロール Phase 1 — GET エンドポイントに `ETag` / `Last-Modified` を導入し、`If-None-Match` / `If-Modified-Since` による条件付きリクエスト (304 Not Modified) をサポート (#1026)
   - 対象: `/v2/entities`, `/v2/subscriptions`, `/v2/registrations`, `/ngsi-ld/v1/entities`, `/ngsi-ld/v1/subscriptions`, `/ngsi-ld/v1/csourceRegistrations`, `/ngsi-ld/v1/csourceSubscriptions` の一覧 / 単一取得 (#1026)
   - リスト用 ETag は各要素の `id + modifiedAt` のストリーミングハッシュ + 総件数のダイジェスト (RFC 7232 §2.3.2 weak validator として正確)、単一用 ETag は `modifiedAt` のハッシュ (#1026)
-  - `fresh` モジュールで RFC 7232 準拠の評価 (弱い ETag、ワイルドカード、HTTP-date) (#1026)
+  - `fresh` モジュールで RFC 7232 準拠の評価(弱い ETag、ワイルドカード、HTTP-date)(#1026)
   - 304 レスポンスは ETag / Last-Modified / Cache-Control / Vary / CORS / 相関 ID / トレースを保持 (#1026)
 - **Feature**: A2A (Agent-to-Agent) プロトコル Phase 1 対応 (#1025)
-  - `GET /.well-known/agent-card.json` — Agent Card 配信 (5 スキル: entities, batch, temporal, config, admin) (#1025)
+  - `GET /.well-known/agent-card.json` — Agent Card 配信(5 スキル: entities, batch, temporal, config, admin)(#1025)
   - `POST /a2a` — JSON-RPC 2.0 エンドポイント。`message/send`, `tasks/get`, `tasks/list`, `tasks/cancel` メソッドに対応 (#1025)
-  - MongoDB `a2aTasks` コレクションによる Task 状態管理 (ライフサイクル: submitted → working → completed/failed/canceled、TTL 30 日) (#1025)
+  - MongoDB `a2aTasks` コレクションによる Task 状態管理(ライフサイクル: submitted → working → completed/failed/canceled、TTL 30 日)(#1025)
   - 既存 MCP ツール 5 つを A2A スキルにマッピング。サービス層を直接呼び出し (#1025)
-  - `@a2a-js/sdk` v0.3.13 を活用 (`JsonRpcTransportHandler` + `DefaultRequestHandler`) (#1025)
+  - `@a2a-js/sdk` v0.3.13 を活用(`JsonRpcTransportHandler` + `DefaultRequestHandler`)(#1025)
 
 ## [0.3.0] — 2026-04-24
 
 ### 2026-04-24
-- **Feature**: カスタムデータモデルに `additionalProperties` フィールドを追加。`false` 指定でモデル未定義の属性を拒否する厳格モードを有効化。デフォルトは `true` (NGSI-LD の自然な挙動を維持) (#1007)
+- **Feature**: カスタムデータモデルに `additionalProperties` フィールドを追加。`false` 指定でモデル未定義の属性を拒否する厳格モードを有効化。デフォルトは `true`(NGSI-LD の自然な挙動を維持)(#1007)
 - **Feature**: SDK に型付きエラークラスを導入。`GeonicDBError` 基底クラスと `AuthenticationError`, `AuthorizationError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `NetworkError` を追加。`instanceof` でエラー種別を判定可能に (#1008)
-- **Feature**: SDK WebSocket イベント (`entityCreated`/`entityUpdated`/`entityDeleted`) に `entity` フィールドを追加。`id` + `type` + `data` から構築した完全な NGSI-LD エンティティオブジェクトを直接取得可能に (#1009)
+- **Feature**: SDK WebSocket イベント(`entityCreated`/`entityUpdated`/`entityDeleted`)に `entity` フィールドを追加。`id` + `type` + `data` から構築した完全な NGSI-LD エンティティオブジェクトを直接取得可能に (#1009)
 - **Feature**: SDK に `debug` オプションを追加。有効時に HTTP リクエスト/レスポンス、WebSocket 接続・イベント、トークンリフレッシュをコンソールにログ出力 (#1010)
 
 ### 2026-04-23
@@ -355,8 +350,8 @@ outline: deep
   - servicePath ↔ scope の自動マッピング（NGSIv2 `/sensors` → NGSI-LD `["/sensors"]`）
   - `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` テンプレート変数を追加
   - Change Stream ハンドラが EntityDocument の `protocol` / `scope` をルールエンジンに伝播するよう修正
-- **Improve**: WAF カスタムルール（RateLimitPerIP、SizeRestrictionBody10MB）にカスタムレスポンスを追加。アプリケーション互換の JSON エラーボディと適切な HTTP ステータスコード（429/413）を返すように改善 (#986)
-- **Feature**: WAF ロギング設定を追加。BLOCK/COUNT アクションのみ記録し、マネージドルールのブロック原因をトレース可能に (#986)
+- **Improve**: WAF カスタムルール（RateLimitPerIP、SizeRestrictionBody10MB）にカスタムレスポンスを追加。アプリケーション互換の JSON エラーボディと適切な HTTP ステータスコード（429 / 413）を返すように改善 (#986)
+- **Feature**: WAF ロギング設定を追加。BLOCK / COUNT アクションのみ記録し、マネージドルールのブロック原因をトレース可能に (#986)
 
 ### 2026-04-21
 - **Fix**: WAF `SizeRestrictionBody10MB` ルールの `OversizeHandling: MATCH` により 8 KB 超のリクエストが全て 403 Forbidden になる問題を修正 (#983)
@@ -379,7 +374,7 @@ outline: deep
 - **Feature**: MCP ツールの NGSI-LD クエリパラメータを大幅拡張 (#898)
   - `entities` ツール: `idList`、`idPattern`、`orderBy`、`orderDirection`、`sysAttrs`、`pick`、`omit`、`scopeQ`、`lang`、`geoproperty`、`spatialId`、`spatialIdDepth` を追加
   - `batch` ツールの `query` アクション: `orderBy`、`orderDirection`、`sysAttrs` を追加
-  - `entityToKeyValues` に `sysAttrs`（`createdAt`/`modifiedAt` 出力）と `distance` 出力を追加
+  - `entityToKeyValues` に `sysAttrs`（`createdAt` / `modifiedAt` 出力）と `distance` 出力を追加
   - `orderBy` の `!` プレフィックスによる降順指定をサポート
   - CSV パラメータの空要素フィルタリングを追加
   - MCP ツールを NGSI-LD に統一（NGSIv2 固有パラメータ `mq`、`typePattern` を削除）
@@ -415,7 +410,7 @@ outline: deep
   - `request(method, path, body)`: 認証付き汎用 API リクエスト (#830)
   - `reconnect()`: WebSocket 強制再接続 (#830)
   - `isConnected()`: WebSocket 接続状態の確認 (#830)
-  - WebSocket ライフサイクルイベント追加: `connected`, `disconnected`, `reconnecting` (#830)
+  - WebSocket ライフサイクルイベント追加: `connected`、 `disconnected`、 `reconnecting` (#830)
   - SDK ファイル冒頭に JSDoc 型定義を埋め込み — AI コーディングアシスタントが自動的に全 API を把握可能 (#830)
 
 ### 2026-04-01
@@ -432,13 +427,13 @@ outline: deep
   - `handlers/api/index.ts` で `resolveJwtSecret()` と `getMongoClient()` を `Promise.all` で並列実行
   - Secrets Manager 解決（〜100-500ms）と MongoDB 接続確立（〜500-1000ms）を直列から並列に変更
 - **Security**: `updatePolicy` の TOCTOU 競合状態を Optimistic Locking で修正 (#784) (#793)
-  - `Policy`/`PolicyDocument`/`PolicyPublic` に `version: number` フィールドを追加
+  - `Policy`、 `PolicyDocument`、 `PolicyPublic` に `version: number` フィールドを追加
   - `PolicyRepository.updatePolicy()` にバージョンフィルタ（`findOneAndUpdate` で `version` 一致確認）を追加
   - バージョン不一致時に `ConflictError` (409) を返す
   - 既存ドキュメント（`version` フィールドなし）は `version: 0` として移行互換対応
 - **Security**: `permit-overrides` 結合アルゴリズムを `super_admin` 以外に禁止（defense in depth） (#785) (#793)
   - `validateCombiningAlgorithm()` に `actorRole` パラメータを追加
-  - `tenant_admin`/`user` が `permit-overrides` を指定した場合 `ForbiddenError` (403) を返す
+  - `tenant_admin`、 `user` が `permit-overrides` を指定した場合 `ForbiddenError` (403) を返す
   - 更新時に `ruleCombiningAlgorithm` を指定しない場合も既存値（有効アルゴリズム）を検証
 
 ### 2026-03-24
@@ -636,10 +631,10 @@ outline: deep
 - **Feat**: Crypto-Shredding と削除完了レポート生成 (#554)
   - `DELETE /admin/tenants/{tenantId}?shred=true` で暗号化テナントの Crypto-Shredding を実行
   - KMS CMK の DisableKey → ScheduleKeyDeletion → 全テナントデータ物理削除 → テナント論理削除
-  - 削除完了レポート自動生成 (ISMAP/ISO 27001/NIST SP 800-88 準拠)
+  - 削除完了レポート自動生成（ISMAP/ISO 27001/NIST SP 800-88 準拠）
   - `GET /admin/tenants/{tenantId}/deletion-report` でレポート取得
-  - CloudTrail 監査イベント取得 (best-effort)
-  - テナント論理削除 (`status: 'deleted'`) とクエリからの自動除外
+  - CloudTrail 監査イベント取得（best-effort）
+  - テナント論理削除（`status: 'deleted'`）とクエリからの自動除外
 - **Infra**: 単一リージョン Staging デプロイ対応 (#571)
   - `HasSecondaryRegion` 条件追加: `SecondaryRegion=""` 時に `AWS::DynamoDB::Table` を使用
   - 3 テーブル (DeploymentsTable, TokenInvalidationTable, UsageStatisticsTable) の単一リージョン版を追加
@@ -649,14 +644,14 @@ outline: deep
 - **CI**: `ci.yml` に `workflow_call` トリガー追加 (#573)
   - CD ワークフロー (`deploy.yml`) から CI パイプラインを再利用可能に
 - **CI**: CD パイプライン `deploy.yml` 新規作成 (#574, #575)
-  - Staging: `main` マージで自動デプロイ (OIDC 認証、ヘルスチェック、デプロイ記録)
-  - Production: `v*.*.*` タグで手動承認付きマルチリージョンデプロイ (Primary → Secondary → Route53)
-  - `ci.yml` から `push: [main]` トリガーを削除 (`deploy.yml` 経由の `workflow_call` に統合)
+  - Staging: `main` マージで自動デプロイ（OIDC 認証、ヘルスチェック、デプロイ記録）
+  - Production: `v*.*.*` タグで手動承認付きマルチリージョンデプロイ（Primary → Secondary → Route53）
+  - `ci.yml` から `push: [main]` トリガーを削除（`deploy.yml` 経由の `workflow_call` に統合）
 
 ### 2026-02-27
 - **Perf**: KMS Decrypt DEK キャッシュと並列数制限の導入 (#578)
   - 復号済み DEK をキャッシュし、同一エンベロープの繰り返し KMS DecryptCommand 呼び出しを排除
-  - `ConcurrencyLimiter` により KMS API 並列呼び出しを制限 (デフォルト: 10)
+  - `ConcurrencyLimiter` により KMS API 並列呼び出しを制限（デフォルト: 10）
   - `entity.repository.ts`, `temporal.repository.ts`, `snapshot.repository.ts` のバッチ復号に適用
 - **Feat**: 暗号化テナントでの時系列集計リクエストにランタイムチェックを追加 (#579)
   - `aggrMethod` パラメータ指定時に暗号化テナントを検出して 400 Bad Request を返却
@@ -664,14 +659,14 @@ outline: deep
 - **BREAKING**: エンティティ ID の一意制約をテナントスコープ内で `entityId` 単独に変更 (#580)
   - インデックスを `(tenant, servicePath, entityId, entityType)` → `(tenant, servicePath, entityId)` に変更
   - 同一 ID で異なる type のエンティティ作成は `409 AlreadyExists` を返却
-  - バッチ Upsert は `entityId` のみでマッチ (type の上書きが可能)
+  - バッチ Upsert は `entityId` のみでマッチ（type の上書きが可能）
   - NGSIv2 の `?type=` パラメータによる type disambiguation を廃止
-  - NGSI-LD の ID 一意セマンティクスと統一 (GeonicDB 独自拡張)
+  - NGSI-LD の ID 一意セマンティクスと統一（GeonicDB 独自拡張）
 - **Feat**: テナント単位 KMS CMK 導入と Envelope Encryption の実装 (#553)
-  - テナント作成時に AWS KMS CMK を自動生成 (`encryptionEnabled: true` 設定時)
+  - テナント作成時に AWS KMS CMK を自動生成（`encryptionEnabled: true` 設定時）
   - エンティティ `attributes` フィールドを AES-256-GCM Envelope Encryption で暗号化
-  - データキーキャッシュ (TTL/カウント/バイト制限) による KMS API 呼び出し最適化
-  - テナント削除時の KMS 鍵無効化・削除スケジュール (Crypto-Shredding 対応)
+  - データキーキャッシュ（TTL/カウント/バイト制限）による KMS API 呼び出し最適化
+  - テナント削除時の KMS 鍵無効化・削除スケジュール（Crypto-Shredding 対応）
   - 暗号化/非暗号化テナントの後方互換共存
   - Temporal/Snapshot リポジトリの暗号化統合
   - SAM テンプレート: KMS IAM ポリシー、DynamoDB SSE 設定、`EncryptionEnabled` パラメータ追加
@@ -758,16 +753,16 @@ outline: deep
 - **Fix**: E2E テストで見逃された仕様準拠バグ 10 件を修正 (#520)
   - **[BREAKING]** NGSIv2 `Fiware-Total-Count` ヘッダーが `options=count` 指定時のみ返されるよう修正(仕様: NGSIv2 spec "Pagination" section)(#520)
   - **[BREAKING]** NGSI-LD `NGSILD-Results-Count` ヘッダーが `count=true` 指定時のみ返されるよう修正(仕様: ETSI GS CIM 009)(#520)
-  - NGSIv2 `POST /v2/op/query` に `options=values`/`options=unique` サポートを追加(仕様: NGSIv2 spec "Representation Formats")(#520)
+  - NGSIv2 `POST /v2/op/query` に `options=values` / `options=unique` サポートを追加(仕様: NGSIv2 spec "Representation Formats")(#520)
   - NGSIv2 `POST /v2/op/query` に `orderBy` サポートを追加(仕様: NGSIv2 spec "Ordering Results")(#520)
   - NGSIv2 `POST /v2/op/query` に `expression.mq` サポートを追加(仕様: NGSIv2 spec "Batch Operations")(#520)
   - NGSIv2 `POST /v2/op/notify` を Zod スキーマバリデーションに移行(`Ngsiv2NotifySchema` 適用)(#520)
   - NGSIv2 `GET /v2/types?options=values` がタイプ名文字列配列を返すよう修正(仕様: NGSIv2 spec "Entity Types")(#520)
   - NGSI-LD temporal controller の `AlreadyExistsError` → `AlreadyExistsLdError` に修正(仕様: ETSI GS CIM 009 §5.5.1)(#520)
-  - NGSI-LD コントローラーのエラータイプを ETSI 仕様に準拠: JSON パースエラーは `InvalidRequest`、データバリデーションエラーは `BadRequestData`(仕様: ETSI GS CIM 009 §5.5.1, Orion-LD/Stellio 互換)(#520)
+  - NGSI-LD コントローラーのエラータイプを ETSI 仕様に準拠: JSON パースエラーは `InvalidRequest`、データバリデーションエラーは `BadRequestData`(仕様: ETSI GS CIM 009 §5.5.1、Orion-LD/Stellio 互換)(#520)
   - NGSI-LD batch 207 レスポンスの Content-Type を `application/json` に修正(仕様: ETSI GS CIM 009 §5.6.7/5.6.8)(#520)
 
-- **Fix**: ReactiveCore Rules の条件評価でエンティティレベルフィールド(`id`, `type`)を `attributeName` に指定できるよう修正(Issue #513)(#516)
+- **Fix**: ReactiveCore Rules の条件評価でエンティティレベルフィールド(`id`、`type`)を `attributeName` に指定できるよう修正(Issue #513)(#516)
   - `value` 条件と `pattern` 条件で `attributeName: "id"` / `"type"` をサポート (#516)
   - PATCH 後にルールアクションが実行されない問題を解消 (#516)
 - **Security**: OWASP API Security 一括修正 — 8 件のセキュリティ指摘対応 (#515)
@@ -775,7 +770,7 @@ outline: deep
   - MCP ツールの OAuth スコープ検証・XACML 認可バイパスを修正 — `requireMcpScope` 追加、エンドポイントをレート制限後に移動 (#515)
   - OAuth token エンドポイントにブルートフォース保護を追加 — `LoginProtectionService` を `clientId` ベースで適用 (#515)
   - CSource 通知・Rule Webhook・Registration に DNS Rebinding 対策(`validateResolvedDns`)追加 (#515)
-  - `/admin/cadde`, `/admin/metrics`, `/rules`, `/custom-data-models` に OAuth スコープ要求を追加 (#515)
+  - `/admin/cadde`、`/admin/metrics`、`/rules`、`/custom-data-models` に OAuth スコープ要求を追加 (#515)
   - PasswordSchema を `PASSWORD_POLICY.MIN_LENGTH` に統一、`SUPER_ADMIN_PASSWORD` 最低長チェック追加、WebSocket メッセージにトークン再検証追加 (#515)
   - クエリパラメータにリソース制限追加 — ID リスト 100 件、ポリゴン頂点 1000、クエリ条件 50 上限 (#515)
   - Temporal/Federation の正規表現パターンに ReDoS 対策(`validateRegexPattern`)追加 (#515)
@@ -809,12 +804,12 @@ outline: deep
   - `NODE_ENV=production` 時はエラーログからスタックトレースを除外
   - クライアントレスポンスには内部情報を含めない（既存動作を維持）
 - **Security**: OWASP API Security Top 10:2023 監査指摘 MEDIUM 7 件を修正 (#475, #476, #477, #478, #479, #481, #482)
-  - Policy/PolicySet のテナントスコープチェック追加（BOLA 対策, #475）
-  - ストレージクォータを作成時に強制（エンティティ/サブスクリプション/レジストレーション, #476）
+  - Policy/PolicySet のテナントスコープチェック追加（BOLA 対策、#475）
+  - ストレージクォータを作成時に強制（エンティティ/サブスクリプション/レジストレーション、#476）
   - リクエストボディサイズのプラン別制限を強制（#477）
-  - `/admin/oauth-clients` に `requireScope('admin:oauth-clients')` を適用（BFLA 対策, #478）
+  - `/admin/oauth-clients` に `requireScope('admin:oauth-clients')` を適用（BFLA 対策、#478）
   - Webhook URL テンプレート置換後の SSRF 検証を追加（#479）
-  - `/statistics`, `/cache/statistics`, `/metrics` エンドポイントを認証必須化（#481）
+  - `/statistics`、`/cache/statistics`、`/metrics` エンドポイントを認証必須化（#481）
   - `/oauth/token` を API Gateway Event に登録（#482）
 - **Security**: OWASP API Security Top 10:2023 監査指摘の MEDIUM 4 件を修正 (#474)
   - JWT 署名検証に `timingSafeEqual` を使用（タイミング攻撃防止）
@@ -849,7 +844,7 @@ outline: deep
   - リフレッシュトークンの無効化チェック追加
 - **Security**: OWASP API2:2023 (Broken Authentication) 対応のブルートフォース保護機能を追加 (#459)
   - メールアドレスベースのログイン試行回数追跡
-  - プログレッシブ遅延（2 回目以降: 2 秒→4 秒→8 秒）
+  - プログレッシブ遅延（2 回目以降: 2 秒→ 4 秒→ 8 秒）
   - 自動アカウントロック（5 回失敗後、60 秒間ロック）
   - ロック中は正しいパスワードでもログイン不可
   - ログイン成功時にカウンターを自動リセット
@@ -880,10 +875,9 @@ outline: deep
   - `--proxy` オプションで非マッチ URL をアプリ側 dev server に透過転送（URL 重複時は GeonicDB 優先）
   - `--silent` オプションでコンソール出力抑制
 - **Build**: `tsc-alias` 導入でビルド時にパスエイリアスを相対パスに解決 (#453)
-- **Package**: `bin`、`types`、`files`、`peerDependencies` 設定で npm パッケージに対応 (#453)
+- **Package**: npm パッケージ対応を `bin`、`types`、`files`、`peerDependencies` 設定で追加 (#453)# 2026-02-15
 
-### 2026-02-15
-- **Documentation**: `docs/INSTRUCTION.md` のカスタムデータモデルセクション（14.9）を大幅に拡充 (#445)
+- **ドキュメント**: `docs/INSTRUCTION.md` のカスタムデータモデルセクション（14.9）を大幅に拡充 (#445)
   - `isActive` フラグの詳細な説明を追加（バリデーション、OpenAPI、一覧取得への影響）
   - Smart Data Models との違いを明記（用途、バリデーション、管理方法の比較表）
   - バリデーションの詳細とタイミングを追加（部分バリデーション、required チェック、エラー形式）
@@ -891,70 +885,70 @@ outline: deep
   - 制限事項とベストプラクティスを追加（ReDoS 対策、推奨値、段階的ロールアウト）
   - エラーハンドリングの詳細を追加（ステータスコード、409 Conflict、エラーメッセージの読み方）
 - **API**: `/admin/cadde` エンドポイント追加（GET/PUT/DELETE）(#439)
-- **Backend**: CADDE 設定を MongoDB 管理に移行、環境変数を廃止 (#439)
+- **バックエンド**: CADDE 設定を MongoDB 管理に移行、環境変数を廃止 (#439)
 - **MCP**: CADDE 設定を config tools に追加 (#439)
-- **Critical**: OpenAPI/メタ情報の完全欠落を修正 (#418)
+- **クリティカル**: OpenAPI/メタ情報の完全欠落を修正 (#418)
   - Snapshots API（7 エンドポイント）を `meta.controller.ts` に追加
   - Quotas/Usage API（3 エンドポイント）を `meta.controller.ts` に追加
   - API ドキュメント・OpenAPI 仕様・AI Tools ドキュメントに反映
-- **Documentation**: NGSIv2 ドキュメント拡充（`docs/API_NGSIV2.md`）(#418)
+- **ドキュメント**: NGSIv2 ドキュメント拡充（`docs/API_NGSIV2.md`）(#418)
   - `id`、`typePattern`、`options=upsert/append/keyValues` パラメータ追加
   - HTTP エラー 411/413/422 のドキュメント追加
   - `orderBy`/`metadata` の仕様差異を「GeonicDB 独自拡張」として明記
-- **Documentation**: NGSI-LD ドキュメント拡充（`docs/API_NGSILD.md`）(#418)
+- **ドキュメント**: NGSI-LD ドキュメント拡充（`docs/API_NGSILD.md`）(#418)
   - Multi-Attribute（datasetId）の全操作詳述（CREATE/UPDATE/RETRIEVE/DELETE）
   - Temporal API `lastN` パラメータ追加
   - `id` 複数指定、`NGSILD-EntityMap` ヘッダー追加
   - `NGSILD-Results-Count` ヘッダーの記述修正（「常に返却」）
-- **Documentation**: REACTIVCORE_RULES.md チュートリアル修正 (#418)
+- **ドキュメント**: REACTIVCORE_RULES.md チュートリアル修正 (#418)
   - 古い構文（`trigger`/`action`）を正しい構文（`conditions`/`actions`）に修正
-- **Testing**: instruction.feature 拡充（31 → 46 シナリオ）(#418)
+- **テスト**: instruction.feature 拡充（31 → 46 シナリオ）(#418)
   - セクション 10（時系列データ管理）のテストシナリオ追加
   - セクション 5.4（NGSIv2 属性操作）のテストシナリオ追加
   - セクション 9.3（バッチ全アクション）のテストシナリオ追加
   - セクション 3.7（NGSI-LD q パラメータ検索）のテストシナリオ追加
   - INSTRUCTION.md との整合性を 60% から大幅に向上
-- **Testing**: spec-compliance.feature 拡充 (#418)
+- **テスト**: spec-compliance.feature 拡充 (#418)
   - NGSIv2: 4 シナリオ追加（orderBy、Subscription throttling、Batch appendStrict）
   - NGSI-LD: 8 シナリオ追加（Multi-Attribute CRUD、Subscription/Registration PATCH、lastN）
-- **Bug Fix**: `api.json` temporal section のメソッド不整合修正 (#418)
+- **バグ修正**: `api.json` temporal section のメソッド不整合修正 (#418)
   - `/temporal/entities/{entityId}` に PATCH メソッド追加
   - `/temporal/.../attrs/{attrName}/{instanceId}` に DELETE メソッド追加
-- **Bug Fix**: OpenAPI spec 修正 (#418)
+- **バグ修正**: OpenAPI spec 修正 (#418)
   - temporal attribute instance の DELETE operation 追加
   - 未定義タグ 4 件追加（NGSI-LD Attributes、Info、JSON-LD Context Management、Rules）
-- **Bug Fix**: コメント・パス参照修正 (#418)
+- **バグ修正**: コメント・パス参照修正 (#418)
   - `rules.feature`: `docs/RULES.md` → `docs/REACTIVCORE_RULES.md`  - `instruction.feature`: セクション番号ずれ修正
-- **Bug Fix**: NGSIv2 appendStrict 仕様準拠修正 (#418)
+- **バグ修正**: NGSIv2 appendStrict 仕様準拠修正 (#418)
   - 既存属性を含む場合に 422 Unprocessable を返すように修正（仕様準拠）
   - 従来は既存属性を黙って上書きする仕様違反の動作だった
   - バッチ操作の全件失敗時に 422 を返すように修正
   - 仕様違反のテストを削除、仕様準拠のテストを追加
-- **Bug Fix**: Change Stream の watch オプションに `fullDocument: 'updateLookup'` を追加 (#442)
+- **バグ修正**: Change Stream の watch オプションに `fullDocument: 'updateLookup'` を追加 (#442)
 - update 操作時に `fullDocument: null` となりルールエンジンが発火しなかった問題を修正
-  - `src/local-server.ts`（ローカル開発サーバー）と `src/handlers/streams/change-stream.ts`（Lambda ハンドラー）の両方を修正
+  - `src/local-server.ts` (ローカル開発サーバー) と `src/handlers/streams/change-stream.ts` (Lambda ハンドラー) の両方を修正
   - ユニットテストに `fullDocument: 'updateLookup'` オプションの検証を追加
 - **Testing**: ユニットテストカバレッジを大幅に向上 (#440)
-  - Lines: 90.97% → 99.08%（+8.11 ポイント）
-  - Statements: 90.68% → 98.84%（+8.16 ポイント）
-  - Branches: 84.05% → 93.99%（+9.94 ポイント）
-  - Functions: 91.75% → 96.88%（+5.13 ポイント）
-  - テスト数: 6015 件（200 スイート）
+  - Lines: 90.97% → 99.08% (+8.11 ポイント)
+  - Statements: 90.68% → 98.84% (+8.16 ポイント)
+  - Branches: 84.05% → 93.99% (+9.94 ポイント)
+  - Functions: 91.75% → 96.88% (+5.13 ポイント)
+  - テスト数: 6015 件 (200 スイート)
 - **Testing**: 新規テストファイル追加 (#440)
-  - Admin API: tenants、policies、metrics、users、oauth-clients コントローラーテスト、routes テスト
-  - MCP: entity.tools、batch.tools、config.tools、admin.tools テスト拡充
-  - NGSI-LD: tiles、attributes、types、entity-maps、snapshots コントローラーテスト拡充
+  - Admin API: tenants, policies, metrics, users, oauth-clients コントローラーテスト、routes テスト
+  - MCP: entity.tools, batch.tools, config.tools, admin.tools テスト拡充
+  - NGSI-LD: tiles, attributes, types, entity-maps, snapshots コントローラーテスト拡充
   - NGSIv2: tiles コントローラーテスト、entities.controller 追加カバレッジ
-  - Core: rules、subscriptions、custom-data-models、auth、geo、temporal サービステスト拡充
-  - Handlers: matcher、notifier テスト拡充
-  - Infrastructure: template-parser、mqtt client、audit logger テスト拡充
+  - Core: rules, subscriptions, custom-data-models, auth, geo, temporal サービステスト拡充
+  - Handlers: matcher, notifier テスト拡充
+  - Infrastructure: template-parser, mqtt client, audit logger テスト拡充
 - **Documentation**: CLAUDE.md にカバレッジ検証の必須チェックリストを追加 (#440)
   - Pre-Push Verification セクション追加
   - Documentation Update Checklist にカバレッジ検証を追加
   - Endpoint Implementation Checklist にカバレッジ確認ステップを追加
 - **依存関係**: `eslint` を 9.39.2 → 10.0.0 にメジャーアップグレード (#438)
-- **依存関係**: `typescript-eslint` を 8.55.0 → 8.55.1-alpha.4 に更新（ESLint 10 対応 canary 版）(#438)
-- **依存関係**: `@typescript-eslint/eslint-plugin`、`@typescript-eslint/parser` を直接依存から削除（`typescript-eslint` ラッパーに統合）(#438)
+- **依存関係**: `typescript-eslint` を 8.55.0 → 8.55.1-alpha.4 に更新 (ESLint 10 対応 canary 版) (#438)
+- **依存関係**: `@typescript-eslint/eslint-plugin`、`@typescript-eslint/parser` を直接依存から削除 (`typescript-eslint` ラッパーに統合) (#438)
 
 ### 2026-02-14
 - **Infrastructure**: Lambda Runtime を `nodejs20.x` → `nodejs24.x` に更新（Node.js 24 LTS に統一）(#437)
@@ -1000,39 +994,39 @@ outline: deep
 - **Documentation**: `docs/REACTIVCORE_RULES.md` に CEL 式条件の仕様・使用例を追加 (#387)
 
 ### 2026-02-13
-- **Documentation**: ReactiveCore Rules に不快指数（DI）による熱中症アラート通知の使用例を追加しました (#419)
+- **Documentation**: ReactiveCore Rules に不快指数（DI）による熱中症アラート通知の使用例を追加 (#419)
   - `docs/REACTIVCORE_RULES.md` — 例6: CEL 式による不快指数計算、sendNotification/Webhook アクション
-  - `docs/INSTRUCTION.md` — セクション13.7 例4: ステップバイステップの導入手順
-- **Testing**: 不快指数アラートの E2E テストシナリオを 7 件追加しました（`@rules-discomfort-index` タグ）(#419)
+  - `docs/INSTRUCTION.md` — セクション 13.7 例4: ステップバイステップの導入手順
+- **Testing**: 不快指数アラートの E2E テストシナリオを 7 件追加（`@rules-discomfort-index` タグ）(#419)
   - WARNING（DI > 75）/DANGER（DI > 80）レベルのルール実行テスト
   - 閾値以下でのルール非トリガー確認
   - 優先度制御と範囲条件（75 < DI <= 80）の動作確認
   - sendNotification/webhook アクションの構成検証
-- **Added**: CADDE コネクタ v4 API エンドポイントを追加しました (#409)
+- **Added**: CADDE コネクタ v4 API エンドポイントを追加 (#409)
   - `GET /cadde/api/v4/catalog` — カタログ検索（横断検索/詳細検索）
   - `GET /cadde/api/v4/entities` — NGSI データ交換（NGSIv2/NGSI-LD 形式対応）
 - **Added**: カタログ横断検索（`x-cadde-search: meta`）— キーワードフィルタ付き CKAN 形式レスポンス (#409)
 - **Added**: カタログ詳細検索（`x-cadde-search: detail`）— データセット個別取得 (#409)
-- **Added**: CADDE 固有メタデータフィールド（`caddec_dataset_id_for_detail`、`caddec_provider_id`、`caddec_resource_type`）を追加しました (#409)
-- **Added**: `x-cadde-resource-url` からクエリパラメータ解析によるエンティティ取得機能を追加しました (#409)
-- **Added**: `x-cadde-resource-api-type` による NGSIv2/NGSI-LD レスポンス形式切替機能を追加しました (#409)
-- **Added**: CADDE v4 エンドポイントの来歴ヘッダー（provenance headers）付与機能を追加しました (#409)
-- **Added**: CADDE エラーレスポンス形式（`{ detail, status }`）を追加しました (#409)
-- **Added**: `x-cadde-search` ヘッダー定数を `CADDE_HEADERS` に追加しました (#409)
-- **Infrastructure**: SAM テンプレートに CADDE v4 API ルートを追加しました (#409)
-- **OpenAPI**: `/openapi.json` に Rule Engine の詳細スキーマを追加しました (#410)
+- **Added**: CADDE 固有メタデータフィールド（`caddec_dataset_id_for_detail`、`caddec_provider_id`、`caddec_resource_type`）(#409)
+- **Added**: `x-cadde-resource-url` からクエリパラメータ解析によるエンティティ取得 (#409)
+- **Added**: `x-cadde-resource-api-type` による NGSIv2/NGSI-LD レスポンス形式切替 (#409)
+- **Added**: CADDE v4 エンドポイントの来歴ヘッダー（provenance headers）付与 (#409)
+- **Added**: CADDE エラーレスポンス形式（`{ detail, status }`）(#409)
+- **Added**: `x-cadde-search` ヘッダー定数を `CADDE_HEADERS` に追加 (#409)
+- **Infrastructure**: SAM テンプレートに CADDE v4 API ルートを追加 (#409)
+- **OpenAPI**: `/openapi.json` に Rule Engine の詳細スキーマを追加 (#410)
   - `RulePublic`、`CreateRuleInput`、`UpdateRuleInput` スキーマを追加
   - `RuleCondition`（8 種類の条件型）、`RuleAction`（5 種類のアクション型）スキーマを追加
   - `/rules` 系エンドポイントの定義を `$ref` によるスキーマ参照に更新
-- **BREAKING CHANGE**: カスタムデータモデル管理エンドポイントを `/admin/data-models` から `/custom-data-models` に変更しました (#376)
+- **BREAKING CHANGE**: カスタムデータモデル管理エンドポイントを `/admin/data-models` から `/custom-data-models` に変更 (#376)
   - テナント固有のリソースのため Admin API から独立した API として再編成
-  - ルートパスの変更に伴い、エンドポイントは `/custom-data-models` および `/custom-data-models/:type` になりました
-- **BREAKING CHANGE**: Phase 2 の自動生成機能（`POST /admin/data-models/generate`）を削除しました (#376)
-  - AI ツールを使った生成機能は Phase 3 で再設計予定です
+  - ルートパスの変更に伴い、エンドポイントは `/custom-data-models` および `/custom-data-models/:type` に
+- **BREAKING CHANGE**: Phase 2 の自動生成機能（`POST /admin/data-models/generate`）を削除 (#376)
+  - AI ツールを使った生成機能は Phase 3 で再設計予定
 - **Changed**: 認証・認可の変更 (#376)
   - `requireAdminAuth()` から `requireAuth()` + XACML ポリシーベース認可に変更
   - `tenant_admin` および `user` ロールもテナント内のカスタムデータモデルを管理可能（ポリシー設定による）
-- **Added**: カスタムデータモデル管理機能 Phase 1 を追加しました (#376)
+- **Added**: カスタムデータモデル管理機能 Phase 1 (#376)
   - `GET /custom-data-models` - データモデル一覧取得
   - `POST /custom-data-models` - データモデル作成
   - `GET /custom-data-models/:type` - データモデル取得
@@ -1041,30 +1035,29 @@ outline: deep
   - テナントごとに独自のデータモデルを定義可能
   - Version 管理機能（作成時 = 1、更新時に自動インクリメント）
   - 19 種類の既存 Smart Data Models に加えて、カスタムデータモデルをサポート
-- **Added**: ExtendedPropertyDetail 型定義を追加しました - PropertyDetail を拡張し defaultValue、validation、indexed をサポート (#376)
-- **Added**: MCP ツールに custom data models 統合機能を追加しました (#376)
+- **Added**: ExtendedPropertyDetail 型定義 - PropertyDetail を拡張し defaultValue、validation、indexed をサポート (#376)
+- **Added**: MCP ツールに custom data models 統合 (#376)
   - `config` ツールの `data_models` リソースに新アクション追加
   - list、get、create、update、delete（認証必須）
   - Smart Data Models（カタログ）とカスタムデータモデル（テナント固有）を統合検索
-- **Added**: Phase 3 - エンティティバリデーション・@context 解決拡張・JSON Schema 生成機能を追加しました (#376)
+- **Added**: Phase 3 - エンティティバリデーション・@context 解決拡張・JSON Schema 生成 (#376)
   - カスタムデータモデルに基づくエンティティの自動バリデーション（作成・更新時）
   - 型チェック（string、number、integer、boolean、array、object、GeoJSON）
 - バリデーションルール: minLength、maxLength、minimum、maximum、pattern、enum
-- 必須フィールド (`required`) チェック
-- NGSI-LD @context 解決をカスタムデータモデルの `contextUrl` に拡張
-- カスタムデータモデルから JSON Schema (Draft 2020-12) を自動生成
-- `jsonSchema` フィールドをカスタムデータモデルレスポンスに追加
+  - 必須フィールド（`required`）チェック
+  - NGSI-LD @context 解決をカスタムデータモデルの `contextUrl` に拡張
+  - カスタムデータモデルから JSON Schema (Draft 2020-12) を自動生成
+  - `jsonSchema` フィールドをカスタムデータモデルレスポンスに追加
 - **Added**: Phase 4 - エンティティテンプレート生成・OpenAPI 動的統合 (#376)
   - MCP `config` ツールに `generate_template` アクション追加 - カスタムデータモデルからエンティティテンプレートを自動生成
   - テンプレートは `defaultValue`、`example`、`valueType` に基づきプレースホルダ値を含む NGSI-LD 形式で生成
   - `contextUrl` が定義されている場合は `@context` も自動付与
   - OpenAPI 仕様 (`/openapi.json`) にカスタムデータモデルの JSON Schema を動的統合
   - 認証済みユーザーのテナントに紐づくアクティブなカスタムデータモデルが `components/schemas` に自動追加
-- **Tests**: E2E テスト 7 シナリオ追加 (CRUD、ページネーション、権限、テナント分離、バリデーション、フィルタリング、バージョニング) (#376)
+- **Tests**: E2E テスト 7 シナリオ追加（CRUD、ページネーション、権限、テナント分離、バリデーション、フィルタリング、バージョニング）(#376)
 
 ### 2026-02-11
-
-- **Documentation**: ドキュメントを 30 ファイルから 17 ファイルに統合 (43% 削減) (#405)
+- **Documentation**: ドキュメントを 30 ファイルから 17 ファイルに統合（43%削減）(#405)
   - PAGINATION.md、STATUS_CODES.md、DEPLOYMENT.md を DEVELOPMENT.md に統合
   - WEBAPP_INTEGRATION.md を EVENT_STREAMING.md に統合
   - CATALOG.md、TELEMETRY.md を INTEGRATIONS.md に統合
@@ -1073,35 +1066,29 @@ outline: deep
   - RULES.md を REACTIVCORE_RULES.md にリネーム
   - SUBSCRIPTIONS.md を新規作成 - HTTP/MQTT 通知の実践例を含む包括的ガイド
 - **BREAKING**: `AUTHZ_ENABLED` 環境変数を削除。XACML ポリシー評価は `AUTH_ENABLED=true` の場合に自動的に有効化されるよう変更 (#403)
-- **Changed**: `/rules` エンドポイントは `AUTH_ENABLED` 設定に関わらずアクセス可能に (`/v2/*` および `/ngsi-ld/*` エンドポイントと同様) (#403)
+- **Changed**: `/rules` エンドポイントは `AUTH_ENABLED` 設定に関わらずアクセス可能に（`/v2/*` および `/ngsi-ld/*` エンドポイントと同様）(#403)
 
 ### 2026-02-10
-
 - **MCP**: MCP ツール構造を再編成 - 8 ツールから 5 ツールに統合して保守性を向上 (#402)
-- `rules` と `contexts` (JSON-LD コンテキストと Smart Data Models) を新しい `config` ツールに移動 (#402)
+- `rules` と `contexts`（JSON-LD コンテキストと Smart Data Models）を新しい `config` ツールに移動 (#402)
 - `admin` ツールはユーザー、テナント、ポリシーの管理のみに集中 (#402)
 
 ### 2026-02-08
-
 - **BREAKING**: Rules API を `/admin/rules` から `/rules` に移動し、XACML ベースの認可を導入 (#401)
 - Rules エンドポイントはロールベース認証ではなく XACML ポリシーで保護されるようになり、きめ細かなアクセス制御が可能に (#401)
 
 ### 2026-02-07
-
-- **Documentation**: GeonicDB 取扱説明書 (docs/INSTRUCTION.md) を追加 (#400)
-- PDF 生成スクリプトを追加 (`npm run docs:pdf`) (#400)
-- INSTRUCTION.md の全サンプルを検証する E2E テスト (tests/e2e/features/common/instruction.feature) を追加 (#400)
+- **Documentation**: GeonicDB 取扱説明書（docs/INSTRUCTION.md）を追加 (#400)
+- PDF 生成スクリプトを追加（`npm run docs:pdf`）(#400)
+- INSTRUCTION.md の全サンプルを検証する E2E テスト（tests/e2e/features/common/instruction.feature）を追加 (#400)
 
 ### 2026-02-05
-
 - **Fixed**: ローカルサーバーの MongoDB シャットダウン時のエラーメッセージを抑制 (#394)
 
 ### 2026-02-04
-
 - **Changed**: バージョン番号を集約し、package.json からインポートするよう変更 (#393)
 
 ### 2026-02-03
-
 - **Added**: MCP (Model Context Protocol) サーバー統合 (#392)
   - AI 駆動型エンティティ管理のための 5 つの統合ツール
   - エンティティ CRUD 操作
@@ -1141,7 +1128,7 @@ outline: deep
 - **Fixed**: NGSI-LD スキーマ検証を強化 (#370)
 
 ### 2026-01-22
-- **Security**: エンティティ ID(256文字)、タイプ(256文字)、属性名(256文字)の長さ制限を追加 (#369)
+- **Security**: エンティティ ID（256 文字）、タイプ（256 文字）、属性名（256 文字）の長さ制限を追加 (#369)
 
 ### 2026-01-20
 - **Fixed**: NGSI-LD URI パターンの不整合を解決 (#364)
@@ -1154,7 +1141,7 @@ outline: deep
 
 ### 2026-01-16
 - **Added**: SaaS ローンチ向けの包括的なクォータシステム (#356)
-  - リクエストクォータ(レート制限、日次/月次制限)
+  - リクエストクォータ（レート制限、日次/月次制限)
   - ストレージクォータ(エンティティ/属性数)
   - DynamoDB によるリアルタイム監視
   - テナント固有のクォータ設定

--- a/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
+++ b/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
@@ -5,16 +5,16 @@ outline: deep
 ---
 # NGSIv2 / NGSI-LD プロトコル分離
 
-GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートしています。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルごとに分離されています** -- NGSIv2 で作成されたエンティティは NGSIv2 でのみアクセス可能で、NGSI-LD についても同様です。
+GeonicDB は、単一の Context Broker 内で NGSIv2 と NGSI-LD の両方の API をサポートしています。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルによって分離されています** -- NGSIv2 経由で作成されたエンティティは NGSIv2 経由でのみアクセス可能であり、NGSI-LD についても同様です。
 
 ## 目次
 
 - [概要](#概要)
 - [統一された内部形式](#統一された内部形式)
-- [プロトコルアイソレーション](#プロトコルアイソレーション)
+- [プロトコル分離](#プロトコル分離)
 - [属性タイプマッピングテーブル](#属性タイプマッピングテーブル)
 - [システム属性の違い](#システム属性の違い)
-- [出力フォーマットの違い](#出力フォーマットの違い)
+- [出力形式の違い](#出力形式の違い)
 - [共有機能](#共有機能)
 - [NGSI-LD 固有の機能](#ngsi-ld-固有の機能)
 - [エンティティ ID の考慮事項](#エンティティ-id-の考慮事項)
@@ -25,7 +25,7 @@ GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API 
 
 ## 概要
 
-GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートしています。各エンティティには、それを作成したプロトコルのタグが付けられ、2 つの API 間の厳格な分離が保証されます。
+GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートしています。各エンティティは、それを作成したプロトコルでタグ付けされ、2 つの API 間の厳格な分離が保証されます。
 
 ### アーキテクチャ
 
@@ -36,14 +36,14 @@ NGSI-LD API (/ngsi-ld/v1) ──> [protocol: 'ngsild'] ┘
 ```
 
 - 両方の API は同じ MongoDB ストレージと統一された内部形式を共有します
-- 各エンティティには作成時に設定される `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)があります
+- 各エンティティには、作成時に設定される `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)があります
 - クエリはプロトコルでフィルタリングされます: NGSIv2 API は `protocol: 'ngsiv2'` エンティティのみを返し、NGSI-LD API は `protocol: 'ngsild'` エンティティのみを返します
 - `protocol` フィールドを持たない既存のエンティティは `'ngsild'` として扱われます
 
 ### メリット
 
 - **プロトコル分離** - 明確な境界により、意図しないクロスプロトコルデータ漏洩を防ぎ、各 API が仕様に準拠したエンティティのみを返すことを保証します
-- **仕様準拠** - 各 API は独自の仕様内で厳密に動作し、形式変換によるエッジケースを回避します
+- **仕様準拠** - 各 API は厳密に独自の仕様内で動作し、形式変換によるエッジケースを回避します
 - **既存システムとの統合** - NGSIv2 と NGSI-LD のワークロードを干渉なく並行して実行できます
 - **API 選択の自由** - 各ユースケースに最適な API を選択できます。クロスプロトコルのニーズには Federation を使用します
 
@@ -51,7 +51,7 @@ NGSI-LD API (/ngsi-ld/v1) ──> [protocol: 'ngsild'] ┘
 
 ## 統一された内部形式
 
-GeonicDB は、両方の API からのデータを統一された内部形式に変換します。
+GeonicDB は両方の API からのデータを統一された内部形式に変換します。
 
 ### 内部エンティティ構造
 
@@ -108,28 +108,28 @@ interface EntityDocument {
 
 ---
 
-## プロトコルアイソレーション
+## プロトコル分離
 
-エンティティは、それらを作成したプロトコルによって分離されています。各エンティティには `protocol` フィールド (`'ngsiv2'` または `'ngsild'`) があり、どの API がそれにアクセスできるかを決定します。
+エンティティは、それを作成したプロトコルによって分離されます。各エンティティには `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)があり、どの API がアクセスできるかを決定します。
 
 ### ルール
 
 | 操作 | NGSIv2 エンティティ (`protocol: 'ngsiv2'`) | NGSI-LD エンティティ (`protocol: 'ngsild'`) |
 |-----------|--------------------------------------|---------------------------------------|
-| NGSIv2 GET/LIST | 可視 | 不可視 |
-| NGSIv2 UPDATE/DELETE | 許可 | 見つからない (404) |
-| NGSI-LD GET/LIST | 不可視 | 可視 |
-| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可 |
+| NGSIv2 GET/LIST | 表示される | 表示されない |
+| NGSIv2 UPDATE/DELETE | 許可される | 見つからない (404) |
+| NGSI-LD GET/LIST | 表示されない | 表示される |
+| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可される |
 
 ### レガシーエンティティ
 
-プロトコルアイソレーション導入以前に作成されたエンティティ (つまり、データベースに `protocol` フィールドがないもの) は `'ngsild'` として扱われます。これらは NGSI-LD API を介してのみアクセス可能です。
+プロトコル分離が導入される前に作成されたエンティティ(つまり、データベースに `protocol` フィールドがないもの)は、`'ngsild'` として扱われます。これらは NGSI-LD API 経由でのみアクセス可能です。
 
-### フェデレーション経由のクロスプロトコルアクセス
+### Federation によるプロトコル間アクセス
 
-直接的なクロスプロトコルアクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション** (Context Source Registration) を使用して、一方の GeonicDB インスタンスを他方のプロトコルのコンテキストプロバイダーとして登録してください。詳細は [フェデレーション](#federation) セクションを参照してください。
+直接的なプロトコル間アクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**Federation**(コンテキストソース登録)を使用して、ある GeonicDB インスタンスを他のプロトコルのコンテキストプロバイダーとして登録してください。詳細は [Federation](#federation) セクションを参照してください。
 
-### 例: プロトコルアイソレーションの動作
+### 例: プロトコル分離の動作
 
 ```bash
 # Create an entity via NGSIv2
@@ -149,21 +149,21 @@ curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001 -H "Fiware-S
 
 ---
 
-## 属性タイプマッピングテーブル
+## 属性タイプ対応表
 
 GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ、NGSI-LD タイプを変換します。
 
-### 基本データタイプ
+### 基本データ型
 
 | NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
 |-------------|---------------|--------------|-------------|
-| `Number` | `Number` | `Property` | 数値 (整数または小数) |
+| `Number` | `Number` | `Property` | 数値(整数または小数) |
 | `Text` / `String` | `String` | `Property` | 文字列 |
 | `Boolean` | `Boolean` | `Property` | 真偽値 |
 | `DateTime` | `DateTime` | `Property` または `TemporalProperty` | ISO 8601 日時文字列 |
 | `Null` | `Null` | `Property` | null 値 |
 
-### 構造化データタイプ
+### 構造化データ型
 
 | NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
 |-------------|---------------|--------------|-------------|
@@ -171,7 +171,7 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 | `Array` | `Array` | `Property` または `ListProperty` | JSON 配列 |
 | `StructuredValue` | `Object` | `Property` | 構造化データ |
 
-### 地理空間タイプ
+### 地理空間型
 
 | NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
 |-------------|---------------|--------------|-------------|
@@ -184,18 +184,18 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 | NGSI-LD タイプ | 内部タイプ | NGSIv2 変換 | 説明 |
 |--------------|---------------|-------------------|-------------|
-| `Relationship` | `Relationship` | `Relationship` (カスタムタイプ) | エンティティ参照 (`object` プロパティを含む) |
-| `LanguageProperty` | `LanguageProperty` | `StructuredValue` | 多言語文字列 (`languageMap` プロパティを含む) |
-| `JsonProperty` | `JsonProperty` | `Object` | JSON データ (`json` プロパティを含む) |
-| `VocabProperty` | `VocabProperty` | `Object` | ボキャブラリーデータ (`vocab` または `vocabMap` プロパティを含む) |
-| `ListProperty` | `ListProperty` | `Array` | 順序付き配列 (`valueList` プロパティを含む) |
-| `ListRelationship` | `ListRelationship` | `Array` | エンティティ参照の配列 (`objectList` プロパティを含む) |
+| `Relationship` | `Relationship` | `Relationship` (カスタムタイプ) | エンティティ参照(`object` プロパティを含む) |
+| `LanguageProperty` | `LanguageProperty` | `StructuredValue` | 多言語文字列(`languageMap` プロパティを含む) |
+| `JsonProperty` | `JsonProperty` | `Object` | JSON データ(`json` プロパティを含む) |
+| `VocabProperty` | `VocabProperty` | `Object` | 語彙データ(`vocab` または `vocabMap` プロパティを含む) |
+| `ListProperty` | `ListProperty` | `Array` | 順序付き配列(`valueList` プロパティを含む) |
+| `ListRelationship` | `ListRelationship` | `Array` | エンティティ参照の配列(`objectList` プロパティを含む) |
 
-### メタデータタイプマッピング
+### メタデータタイプ対応
 
 | NGSIv2 メタデータ名 | NGSI-LD プロパティ | 説明 |
 |----------------------|------------------|-------------|
-| `unit` (Text) | `unitCode` (string) | 単位 (例: "CEL"、"KMH") |
+| `unit` (Text) | `unitCode` (string) | 単位(例: "CEL"、"KMH") |
 | `observedAt` (DateTime) | `observedAt` (ISO 8601) | 観測タイムスタンプ |
 | `datasetId` (Text) | `datasetId` (URI) | データセット ID |
 
@@ -203,16 +203,16 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ## システム属性の違い
 
-エンティティメタデータ (作成および変更タイムスタンプ) は、API によって異なる名前を使用します。
+エンティティのメタデータ(作成および変更タイムスタンプ)は、API によって異なる名前を使用します。
 
 ### NGSIv2 システム属性
 
 | 属性名 | タイプ | 説明 |
 |----------------|------|-------------|
-| `dateCreated` | `DateTime` | エンティティ作成タイムスタンプ (ISO 8601) |
-| `dateModified` | `DateTime` | エンティティ最終変更タイムスタンプ (ISO 8601) |
+| `dateCreated` | `DateTime` | エンティティ作成タイムスタンプ(ISO 8601) |
+| `dateModified` | `DateTime` | エンティティ最終更新タイムスタンプ(ISO 8601) |
 
-**例 (NGSIv2 レスポンス、`options=dateCreated,dateModified` 使用時):**
+**例(NGSIv2 レスポンス、`options=dateCreated,dateModified` 使用時):**
 
 ```json
 {
@@ -238,11 +238,11 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 | 属性名 | タイプ | 説明 |
 |----------------|------|-------------|
 | `createdAt` | ISO 8601 文字列 | エンティティ作成タイムスタンプ |
-| `modifiedAt` | ISO 8601 文字列 | エンティティ最終変更タイムスタンプ |
+| `modifiedAt` | ISO 8601 文字列 | エンティティ最終更新タイムスタンプ |
 
-**注意:** `pick` パラメータを使用した場合、レスポンスには明示的にリクエストされた属性と、常に存在する `@context`、`id`、`type` が含まれます。ただし、`createdAt` と `modifiedAt` は `pick` を使用しても返されません。これらのシステム属性には `sysAttrs` オプションが必要です。
+**注意:** `pick` パラメータを使用する場合、レスポンスには明示的に要求された属性と、`@context`、`id`、`type` (常に存在)が含まれます。ただし、`createdAt` と `modifiedAt` は `pick` を使用しても返されません。これらのシステム属性には `sysAttrs` オプションが必要です。
 
-**例 (NGSI-LD レスポンス、システム属性は常に含まれる):**
+**例(NGSI-LD レスポンス、システム属性は常に含まれる):**
 
 ```json
 {
@@ -258,7 +258,7 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 }
 ```
 
-### 内部表現 (MongoDB)
+### 内部表現(MongoDB)
 
 ```typescript
 {
@@ -272,16 +272,16 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ---
 
-## 出力フォーマットの違い
+## 出力形式の違い
 
-各 API は複数のレスポンスフォーマットをサポートしています。
+各 API は複数のレスポンス形式をサポートしています。
 
-### NGSIv2 の出力フォーマット
+### NGSIv2 出力形式
 
-| フォーマット | options パラメータ | 説明 |
+| 形式 | options パラメータ | 説明 |
 |--------|-------------------|-------------|
-| **normalized** (デフォルト) | (なし) | タイプとメタデータを含む完全フォーマット |
-| **keyValues** | `options=keyValues` | キー・バリューペアのみ (メタデータなし) |
+| **normalized** (デフォルト) | (なし) | 型とメタデータを含む完全な形式 |
+| **keyValues** | `options=keyValues` | キーと値のペアのみ(メタデータなし) |
 | **values** | `options=values` | 属性値の配列のみ |
 
 **例:**
@@ -297,13 +297,13 @@ curl http://localhost:3000/v2/entities/Room1?options=keyValues
 curl 'http://localhost:3000/v2/entities?type=Room&options=values&attrs=temperature,humidity'
 ```
 
-### NGSI-LD の出力フォーマット
+### NGSI-LD 出力形式
 
-| フォーマット | Accept ヘッダー | 説明 |
+| 形式 | Accept ヘッダー | 説明 |
 |--------|---------------|-------------|
-| **normalized** (デフォルト) | `application/ld+json` | タイプとメタデータを含む完全フォーマット |
-| **concise** | `application/ld+json` + `options=concise` | 簡潔フォーマット (省略記法) |
-| **keyValues** | `application/ld+json` + `options=keyValues` | キー・バリューペアのみ |
+| **normalized** (デフォルト) | `application/ld+json` | 型とメタデータを含む完全な形式 |
+| **concise** | `application/ld+json` + `options=concise` | 簡潔な形式(省略記法) |
+| **keyValues** | `application/ld+json` + `options=keyValues` | キーと値のペアのみ |
 
 **例:**
 
@@ -332,7 +332,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1?options=k
 | **メタデータクエリ** | `mq` パラメータ | `q` パラメータ (メタデータもクエリ可能) | メタデータフィルタ |
 | **スコープクエリ** | `Fiware-ServicePath` ヘッダー (スコープから独立) | `scopeQ` パラメータ | スコープ階層フィルタ |
 
-**基本例:**
+**基本的な例:**
 
 ```bash
 # NGSIv2: Entities with temperature greater than 20
@@ -344,15 +344,15 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?type=Room&q=temperature>20'
 
 #### メタデータクエリ (mq) の詳細
 
-NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートしています。
+NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートします。
 
-**サポートされる演算子:**
+**サポートされている演算子:**
 
 | 演算子 | 説明 | 例 |
 |----------|-------------|---------|
 | `==` | 等しい | `mq=temperature.accuracy==0.95` |
 | `!=` | 等しくない | `mq=temperature.accuracy!=0` |
-| `>`、`<`、`>=`、`<=` | 比較演算子 | `mq=temperature.accuracy>0.9` |
+| `>`, `<`, `>=`, `<=` | 比較演算子 | `mq=temperature.accuracy>0.9` |
 | `~=` | パターンマッチ | `mq=temperature.unit~=Cel.*` |
 | `..` | 範囲 (両端を含む) | `mq=temperature.accuracy==0.9..1.0` |
 | `,` | リスト (OR) | `mq=temperature.unit==Celsius,Fahrenheit` |
@@ -377,15 +377,15 @@ curl 'http://localhost:3000/v2/entities?type=Room&mq=temperature.accuracy>0.9;te
 
 #### スコープクエリ (scopeQ) の詳細
 
-NGSI-LD の `scopeQ` パラメータは、エンティティのスコープ階層に対するクエリをサポートしています。
+NGSI-LD の `scopeQ` パラメータは、エンティティのスコープ階層に対するクエリをサポートします。
 
-**サポートされる演算子:**
+**サポートされている演算子:**
 
 | 演算子 | 説明 | 例 |
 |----------|-------------|---------|
 | `/path` | 完全一致 | `scopeQ=/Japan/Tokyo` |
 | `/path/+` | 1 階層下のみ | `scopeQ=/Japan/+` (例: Tokyo) |
-| `/path/#` | すべての子孫 | `scopeQ=/Japan/#` (例: Tokyo、Tokyo/Shibuya) |
+| `/path/#` | すべての子孫 | `scopeQ=/Japan/#` (例: Tokyo, Tokyo/Shibuya) |
 | `;` | AND 条件 (複数のスコープ) | `scopeQ=/Japan/Tokyo;/IoT` |
 
 **例:**
@@ -408,9 +408,9 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo;/IoT'
 
 | ジオクエリ演算子 | NGSIv2 | NGSI-LD | 説明 |
 |--------------------|--------|---------|-------------|
-| `near` | ✅ | ✅ | 指定された地点の近く |
+| `near` | ✅ | ✅ | 指定した地点の近く |
 | `coveredBy` | ✅ | ✅ | 領域内に完全に含まれる |
-| `within` | ✅ | ✅ | 領域と交差するか領域内に含まれる |
+| `within` | ✅ | ✅ | 領域と交差するか、領域内に含まれる |
 | `intersects` | ✅ | ✅ | 領域と交差する |
 | `disjoint` | ✅ | ✅ | 領域と交差しない |
 
@@ -428,31 +428,31 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 
 | ヘッダー | NGSIv2 | NGSI-LD | 説明 |
 |--------|--------|---------|-------------|
-| **合計数** | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数 |
-| **次のリンク** | `Link` (rel="next") | `Link` (rel="next") | 次のページへのリンク |
+| **総数** | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数 |
+| **次ページリンク** | `Link` (rel="next") | `Link` (rel="next") | 次のページへのリンク |
 
 詳細については、[ページネーション](/ja/api-reference/pagination)を参照してください。
 
 ### 4. サブスクリプション
 
-| 通知方法 | NGSIv2 | NGSI-LD | 説明 |
+| 通知方式 | NGSIv2 | NGSI-LD | 説明 |
 |--------------------|--------|---------|-------------|
 | **HTTP Webhook** | ✅ | ✅ | REST エンドポイントへの POST |
-| **MQTT** | ✅ | ✅ | MQTT ブローカーへの発行 (QoS 0/1/2、TLS) |
+| **MQTT** | ✅ | ✅ | MQTT ブローカーへの公開 (QoS 0/1/2, TLS) |
 | **WebSocket** | ✅ | ✅ | リアルタイムイベントストリーム |
 
 ### 5. フェデレーション (コンテキストソース登録)
 
 | 機能 | NGSIv2 | NGSI-LD | 説明 |
 |---------|--------|---------|-------------|
-| **登録 API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダー登録 |
+| **登録 API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダーの登録 |
 | **並列クエリ** | ✅ | ✅ | 複数のプロバイダーへの同時クエリ |
 | **結果のマージ** | ✅ | ✅ | ローカルとリモートの結果のマージ |
 | **ループ検出** | ✅ | ✅ | `Via` ヘッダーによるループ検出 |
 
 ---
 
-## NGSI-LD 固有の機能
+## NGSI-LD 専用機能
 
 以下の機能は NGSI-LD API でのみサポートされており、NGSIv2 API では直接利用できません。
 
@@ -473,7 +473,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 }
 ```
 
-> **注意:** プロトコル分離により、NGSI-LD エンティティ (Relationship 属性を含むもの) は NGSIv2 API 経由ではアクセスできません。
+> **注:** プロトコルの分離により、NGSI-LD エンティティ (Relationship 属性を持つものを含む) は NGSIv2 API 経由ではアクセスできません。
 
 ### 2. LanguageProperty (多言語プロパティ)
 
@@ -497,7 +497,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 
 **NGSI-LD で `lang=ja` を使用する場合:**
 
-`lang` クエリパラメータを使用すると、LanguageProperty は標準の Property に変換され、指定された言語の値が `value` フィールドに設定されます。
+`lang` クエリパラメータを使用すると、LanguageProperty は標準的な Property に変換され、指定された言語の値が `value` フィールドに設定されます。
 
 ```bash
 curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
@@ -515,11 +515,11 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
 }
 ```
 
-> **注意:** プロトコル分離により、NGSI-LD エンティティ (LanguageProperty 属性を含むもの) は NGSIv2 API 経由ではアクセスできません。
+> **注:** プロトコルの分離により、NGSI-LD エンティティ (LanguageProperty 属性を持つものを含む) は NGSIv2 API 経由ではアクセスできません。
 
 ### 3. Scope (スコープ階層)
 
-エンティティの論理階層を表します。
+エンティティの論理的な階層構造を表します。
 
 **NGSI-LD:**
 
@@ -531,7 +531,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
 }
 ```
 
-**Scope クエリ:**
+**スコープクエリ:**
 
 ```bash
 # All entities under /Japan/Tokyo
@@ -540,16 +540,16 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo'
 
 **NGSIv2 互換性:**
 
-- NGSIv2 は階層的なエンティティ管理のために `Fiware-ServicePath` ヘッダを使用します
-- `servicePath` は `?attrs=servicePath` 経由で組み込み属性として利用可能です
-- **servicePath と scope は独立した概念です (#964):** これらは自動的には同期されません
-  - NGSIv2 `Fiware-ServicePath` → DB に `servicePath` として保存されます (インフラレベルの分離)
-  - NGSI-LD `scope` → DB に `scope` として保存されます (ユーザ定義の論理階層)
-  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダを無視します
+- NGSIv2 は階層的なエンティティ管理に `Fiware-ServicePath` ヘッダーを使用します
+- `servicePath` は `?attrs=servicePath` 経由でビルトイン属性として利用可能です
+- **servicePath と scope は独立した概念です (#964):** これらは自動的に同期されません
+  - NGSIv2 `Fiware-ServicePath` → DB に `servicePath` として保存 (インフラストラクチャレベルの分離)
+  - NGSI-LD `scope` → DB に `scope` として保存 (ユーザー定義の論理階層)
+  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダーを無視します
 
 ### 4. 属性プロジェクション (pick / omit パラメータ)
 
-NGSI-LD では、`pick` と `omit` クエリパラメータを使用して、レスポンスに含まれる属性を制御できます。
+NGSI-LD では、`pick` と `omit` のクエリパラメータを使用して、レスポンスに含まれる属性を制御できます。
 
 #### pick パラメータ (属性選択)
 
@@ -611,14 +611,14 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?omit=locati
 
 **注意事項:**
 
-- `pick` と `omit` を同時に使用することはできません
+- `pick` と `omit` は同時に使用できません
 - `pick` を使用する場合: `@context`、`id`、`type`、および指定された属性のみが含まれます。`createdAt` と `modifiedAt` は含まれません。
-- `omit` を使用する場合: 指定されたもの以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様に基づく)
+- `omit` を使用する場合: 指定された属性以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様に準拠)
 
 **NGSIv2 互換性:**
 
-- NGSIv2 API では、`attrs` パラメータが同等の機能を提供します (選択のみ)
-- `omit` に相当する NGSIv2 の機能はありません
+- NGSIv2 API では、`attrs` パラメータが同等の機能を提供します (pick のみ)
+- `omit` に相当する NGSIv2 のパラメータはありません
 
 ```bash
 # Retrieve only temperature and humidity with NGSIv2 (equivalent to pick)
@@ -627,7 +627,7 @@ curl 'http://localhost:3000/v2/entities/urn:ngsi-ld:Room:001?attrs=temperature,h
 
 ### 5. @context (JSON-LD コンテキスト)
 
-NGSI-LD では、エンティティに `@context` を含めることで語彙を定義します。
+NGSI-LD では、エンティティに `@context` を含めることで、ボキャブラリを定義します。
 
 **NGSI-LD:**
 
@@ -646,34 +646,33 @@ NGSI-LD では、エンティティに `@context` を含めることで語彙を
 **NGSIv2 互換性:**
 
 - NGSIv2 には `@context` の概念がありません
-- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API によって返されません
+- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API では返されません
 
 ---
 
-## エンティティ ID の考慮事項
+## エンティティ ID に関する考慮事項
 
 ### エンティティ ID の一意性 (GeonicDB 拡張)
 
-> **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント (`Fiware-Service`) とServicePath (`Fiware-ServicePath`) のスコープ内で一意です。エンティティ `type` は一意性制約の一部では**ありません**。
+> **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント (`Fiware-Service`) とServicePath (`Fiware-ServicePath`) のスコープ内で一意です。エンティティ `type` は一意性制約の**一部ではありません**。
 
-これは、両方の API 間で ID のセマンティクスを統一するための意図的な設計上の決定です。
+これは、両方の API にわたって ID のセマンティクスを統一する意図的な設計決定です:
 
 - **NGSI-LD** はエンティティ ID を URI として扱い、本質的に一意です
-- **NGSIv2** (標準) は同じ ID を持つが異なるタイプのエンティティの共存を許可します — GeonicDB はこの動作を**サポートしていません**
+- **NGSIv2** (標準) は同じ ID で異なるタイプのエンティティが共存することを許可しますが、GeonicDB はこの動作を**サポートしていません**
 
 **影響:**
-
-- **直接作成** (`POST /v2/entities`, `POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID を持つエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
+- **直接作成** (`POST /v2/entities`、`POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID を持つエンティティを作成する場合 (異なる `type` でも)、`409 AlreadyExists` が返されます
 - **バッチ更新** (`POST /v2/op/update` と `append`/`appendStrict`): `entityId` のみでエンティティをマッチングします。属性は更新されますが、元の `type` は保持されます
-- **バッチ upsert** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティをマッチングします。属性は更新されます (タイプ処理は upsert セマンティクスに従います)
-- **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複する ID に対してエンティティごとのエラー詳細を含む `207` を返します
-- 同じ ID のエンティティ間のタイプの曖昧性解消のための NGSIv2 `?type=` パラメータは適用されなくなりました
+- **バッチアップサート** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティをマッチングします。属性は更新されます (タイプ処理はアップサートのセマンティクスに従います)
+- **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複する ID に対してエンティティごとのエラー詳細とともに `207` を返します
+- 同じ ID を持つエンティティ間のタイプによる曖昧性解消のための NGSIv2 `?type=` パラメータはもはや適用されません
 
-この統一により、NGSIv2 のタイプベースの曖昧性解消が NGSI-LD の一意 ID モデルと競合する相互運用性の問題のクラスが排除されます。
+この統一により、NGSIv2 のタイプベースの曖昧性解消が NGSI-LD の一意 ID モデルと競合するという相互運用性の問題が解消されます。
 
 ### NGSI-LD URI 要件
 
-NGSI-LD 仕様では、エンティティ ID は URI 形式であることが推奨されています。
+NGSI-LD 仕様では、エンティティ ID を URI 形式にすることを推奨しています。
 
 **推奨形式 (URN):**
 
@@ -691,29 +690,29 @@ urn:ngsi-ld:WeatherObserved:Tokyo-2026-02-08
 
 **NGSIv2 互換性:**
 
-- NGSIv2 では任意の文字列を ID として使用できます (例: `Room1`, `sensor-abc`)
-- 使用する API に関係なく、一貫性と将来の移行のために URN 形式の使用が推奨されます
+- NGSIv2 は任意の文字列を ID として使用できます (例: `Room1`、`sensor-abc`)
+- 使用する API に関係なく、一貫性と将来の移行のために URN 形式の使用を推奨します
 
 **ベストプラクティス:**
 
 - NGSIv2 API を使用する場合でも、すべてのエンティティに URN 形式を使用してください
-- NGSIv2 から NGSI-LD に移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコル分離により API 間のアクセスができません)
+- NGSIv2 から NGSI-LD に移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコル分離により API 間のアクセスは防止されます)
 
 ---
 
-## Federation
+## フェデレーション
 
 GeonicDB のフェデレーション機能は、リモートコンテキストプロバイダのプロトコルを自動的に検出します。
 
-### プロトコルの自動検出
+### 自動プロトコル検出
 
-登録されたリモートプロバイダに対して、GeonicDB は以下の順序でプロトコルを検出します:
+登録されたリモートプロバイダについて、GeonicDB は以下の順序でプロトコルを検出します:
 
 1. **明示的な指定** - 登録時に `information.format` が指定されている場合、そのプロトコルが使用されます
 2. **自動検出** - URL パスからの自動検出:
    - `/v2/` を含む → NGSIv2
    - `/ngsi-ld/` を含む → NGSI-LD
-   - それ以外 → NGSIv2 (デフォルト)
+   - その他 → NGSIv2 (デフォルト)
 
 ### NGSIv2 からのフェデレーション
 
@@ -748,8 +747,8 @@ curl http://localhost:3000/v2/entities/urn:ngsi-ld:Vehicle:V999 \
 **動作:**
 
 1. GeonicDB は `urn:ngsi-ld:Vehicle:V999` がローカルに存在しないことを検出します
-2. 登録情報から `http://remote-provider.example.com/ngsi-ld/v1` を特定します
-3. NGSI-LD プロトコルを使用してクエリを転送します: `GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`4. レスポンスを NGSI-LD → 内部フォーマット → NGSIv2 に変換し、クライアントに返します
+2. 登録情報から `http://remote-provider.example.com/ngsi-ld/v1` を識別します
+3. NGSI-LD プロトコルを使用してクエリを転送します: `GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`4. NGSI-LD → 内部形式 → NGSIv2 の順にレスポンスを変換し、クライアントに返します
 
 ### NGSI-LD からのフェデレーション
 
@@ -783,55 +782,53 @@ curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:S888 \
 **動作:**
 
 1. GeonicDB は `urn:ngsi-ld:Sensor:S888` がローカルに存在しないことを検出します
-2. 登録情報から `http://legacy-system.example.com/v2` を特定します
-3. NGSIv2 プロトコルを使用してクエリを転送します: `GET /v2/entities/urn:ngsi-ld:Sensor:S888`4. レスポンスを NGSIv2 → 内部フォーマット → NGSI-LD に変換し、クライアントに返します
+2. 登録情報から `http://legacy-system.example.com/v2` を識別します
+3. NGSIv2 プロトコルを使用してクエリを転送します: `GET /v2/entities/urn:ngsi-ld:Sensor:S888`4. NGSIv2 → 内部形式 → NGSI-LD の順にレスポンスを変換し、クライアントに返します
 
 ---
 
-## ユースケースとベストプラクティス
+## ユースケースとベストプラクティス### どのAPIを使用すべきか？
 
-### どの API を使用すべきか？
+#### NGSIv2を選択すべき場合
 
-#### NGSIv2 を選択すべき場合
+- **既存のFIWARE Orion互換システム** - レガシーシステムとの統合
+- **シンプルなIoTデータ管理** - センサーデータの収集と可視化
+- **低い学習コスト** - NGSI-LDよりもシンプルな仕様
+- **豊富な既存ドキュメントとツール** - 成熟したNGSIv2エコシステム
 
-- **既存の FIWARE Orion 互換システム** - レガシーシステムとの統合
-- **シンプルな IoT データ管理** - センサーデータの収集と可視化
-- **学習曲線が低い** - NGSI-LD よりもシンプルな仕様
-- **豊富な既存のドキュメントとツール** - 成熟した NGSIv2 エコシステム
+**推奨される使用例：**
 
-**推奨されるユースケース：**
-
-- IoT センサーネットワーク
+- IoTセンサーネットワーク
 - 基本的なスマートシティデータ収集
-- プロトタイピングと PoC
+- プロトタイピングとPoC
 
-#### NGSI-LD を選択すべき場合
+#### NGSI-LDを選択すべき場合
 
-- **セマンティック Web / リンクトデータ** - JSON-LD と RDF の活用
-- **複雑なエンティティ関係** - Relationship と LanguageProperty の使用
-- **国際標準への準拠** - ETSI 標準に準拠したシステム
-- **将来の拡張性** - NGSI-LD 仕様は継続的に拡張されています
+- **セマンティックWeb / リンクトデータ** - JSON-LDとRDFの活用
+- **複雑なエンティティの関係** - RelationshipとLanguagePropertyの使用
+- **国際標準への準拠** - ETSI標準に準拠したシステム
+- **将来の拡張性** - NGSI-LD仕様は継続的に拡張されている
 
-**推奨されるユースケース：**
+**推奨される使用例：**
 
-- Smart Data Models を活用したデータカタログ
+- Smart Data Modelsを活用したデータカタログ
 - 多言語サポートが必要なシステム
 - エンティティ間の複雑な関係を表現する必要があるシステム
-- データ統合とオープンデータ公開
+- データ統合とオープンデータの公開
 
-#### 両方の API の同時実行
+#### 両方のAPIの同時実行
 
-GeonicDB は両方の API を同時にサポートしていますが、エンティティはプロトコルごとに分離されています。各 API は独自のエンティティセットで独立して動作します。
+GeonicDBは両方のAPIを同時にサポートしていますが、エンティティはプロトコルごとに分離されています。各APIは独自のエンティティセットに対して独立して動作します。
 
 **推奨されるアプローチ：**
 
-1. **ユースケースごとに 1 つの API を選択** - 同じデータに対してプロトコルを混在させないでください。要件に基づいて NGSIv2 または NGSI-LD を選択し、それに従ってください
-2. **クロスプロトコルのニーズには Federation を使用** - NGSIv2 クライアントが NGSI-LD エンティティにアクセスする必要がある場合（またはその逆）、Federation を介してコンテキストソースを登録します
-3. **マイグレーションには再作成が必要** - エンティティを NGSIv2 から NGSI-LD に移行するには、NGSIv2 API からエクスポートし、NGSI-LD API を介して再作成します。自動的なクロスプロトコルマイグレーションはありません
+1. **使用例ごとに1つのAPIを選択** - 同じデータに対してプロトコルを混在させないでください。要件に基づいてNGSIv2またはNGSI-LDを選択し、それを使い続けてください
+2. **プロトコル間の連携にはFederationを使用** - NGSIv2クライアントがNGSI-LDエンティティにアクセスする必要がある場合（またはその逆）、Federationを介してコンテキストソースを登録してください
+3. **マイグレーションには再作成が必要** - エンティティをNGSIv2からNGSI-LDに移行するには、NGSIv2 APIからエクスポートし、NGSI-LD APIを介して再作成してください。自動的なプロトコル間マイグレーションはありません
 
 ### ベストプラクティス
 
-#### 1. エンティティ ID に URN 形式を使用する
+#### 1. エンティティ ID には URN 形式を使用する
 
 **推奨:**
 
@@ -848,7 +845,7 @@ sensor-abc
 
 理由: NGSI-LD 仕様に準拠し、両方の API で互換性を維持できます。
 
-#### 2. 地理空間データに GeoJSON を使用する
+#### 2. 地理空間データには GeoJSON を使用する
 
 **推奨 (NGSIv2):**
 
@@ -878,7 +875,7 @@ sensor-abc
 }
 ```
 
-理由: ジオクエリは GeoJSON 形式のみをサポートしています。
+理由: ジオクエリは GeoJSON 形式のみをサポートします。
 
 #### 3. Smart Data Models を活用する
 
@@ -897,19 +894,19 @@ GeonicDB は Smart Data Models の `@context` を自動補完します。
 }
 ```
 
-理由: `type` が Smart Data Models のモデル名と一致する場合、適切な `@context` が自動的に補完されます。
+理由: `type` が Smart Data Models のモデル名と一致すると、適切な `@context` が自動的に補完されます。
 
-#### 4. 目的に応じてサブスクリプションを選択する
+#### 4. 用途に応じてサブスクリプションを選択する
 
-| 目的 | 推奨チャネル | 理由 |
-|------|-------------|------|
-| Web アプリ (リアルタイム更新) | WebSocket | 低レイテンシ、サーバ不要 |
-| サーバ間連携 | HTTP Webhook | 信頼性、リトライ機能 |
+| 用途 | 推奨チャネル | 理由 |
+|---------|---------------------|--------|
+| Web アプリ (リアルタイム更新) | WebSocket | 低レイテンシ、サーバー不要 |
+| サーバー間統合 | HTTP Webhook | 信頼性、リトライ機能 |
 | IoT デバイス | MQTT | 軽量、QoS 保証 |
 
 #### 5. テナント分離を活用する
 
-`Fiware-Service` ヘッダを使用してテナントを分離します。
+`Fiware-Service` ヘッダーを使用してテナントを分離します。
 
 ```bash
 # Create entity in tenant "demo"
@@ -930,19 +927,19 @@ curl -X POST http://localhost:3000/v2/entities \
 ## まとめ
 
 | 項目 | NGSIv2 | NGSI-LD | GeonicDB の動作 |
-|------|--------|---------|----------------|
-| **プロトコル** | REST/JSON | REST/JSON-LD | 両方サポート; エンティティは `protocol` フィールドで分離 |
+|------|--------|---------|-------------------|
+| **プロトコル** | REST/JSON | REST/JSON-LD | 両方サポート。エンティティは `protocol` フィールドで分離 |
 | **エンティティ分離** | `protocol: 'ngsiv2'` | `protocol: 'ngsild'` | 各 API は自身のエンティティのみを参照 |
-| **エンティティ ID** | 任意の文字列 | URI (URN 推奨) | URN 推奨。**ID はテナント + servicePath ごとに一意** (タイプによる曖昧性排除は削除) |
-| **属性タイプ** | シンプル (Number、Text など) | セマンティック (Property、Relationship など) | タイプマッピングルールで対応関係を定義 (上記の表を参照) |
+| **エンティティ ID** | 任意の文字列 | URI (URN 推奨) | URN 推奨。**ID はテナント + servicePath ごとに一意** (型による曖昧さ解消は削除) |
+| **属性タイプ** | シンプル (Number、Text など) | セマンティック (Property、Relationship など) | 型マッピングルールで対応関係を定義 (上記表を参照) |
 | **システム属性** | `dateCreated`、`dateModified` | `createdAt`、`modifiedAt` | 内部的に統一、API ごとに変換 |
 | **ジオクエリ** | ✅ | ✅ | 共有機能 |
 | **サブスクリプション** | ✅ (HTTP、MQTT、WebSocket) | ✅ (HTTP、MQTT、WebSocket) | 共有機能 |
-| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出; プロトコル間アクセスを実現 |
+| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出。プロトコル間アクセスを実現 |
 | **プロトコル間アクセス** | 直接サポートなし | 直接サポートなし | プロトコル間アクセスにはフェデレーションを使用 |
-| **ユースケース** | IoT、レガシーシステム | Semantic Web、オープンデータ | ユースケースごとに 1 つの API を選択 |
+| **ユースケース** | IoT、レガシーシステム | セマンティック Web、オープンデータ | ユースケースごとに 1 つの API を選択 |
 
-GeonicDB は NGSIv2 と NGSI-LD の両方の API を提供し、厳格なプロトコル分離を行います。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
+GeonicDB は NGSIv2 と NGSI-LD の両方の API を、厳密なプロトコル分離で提供します。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
 
 ---
 

--- a/docs/ja/features/smart-data-models.md
+++ b/docs/ja/features/smart-data-models.md
@@ -37,8 +37,7 @@ GeonicDB は、次のドメインから主要な Smart Data Models をサポー�
 - スキーマ URL
 - サンプル プロパティ
 
-## MCP ツール: `data_models`
-Smart Data Models カタログを参照するための MCP ツールが利用可能です。
+## MCP ツール: `data_models`Smart Data Models カタログを参照するための MCP ツールが利用可能です。
 
 ### アクション
 

--- a/docs/ja/features/subscriptions.md
+++ b/docs/ja/features/subscriptions.md
@@ -3,11 +3,11 @@ title: "Event Streaming"
 description: "Real-time event streaming"
 outline: deep
 ---
-# WebSocket イベントストリーミング
+# WebSocket Event Streaming
 
-GeonicDB は WebSocket によるリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムで購読し、Web アプリケーションやダッシュボードに即座に反映できます。
+GeonicDB は WebSocket を介したリアルタイムのイベントストリーミングをサポートしています。エンティティの変更をリアルタイムでサブスクリプションライブし、Web アプリケーションやダッシュボードに即座に反映できます。
 
-## 目次
+## Table of Contents
 
 - [概要](#概要)
 - [アーキテクチャと有効化](#アーキテクチャと有効化)
@@ -16,13 +16,13 @@ GeonicDB は WebSocket によるリアルタイムイベントストリーミン
 - [クライアント実装](#クライアント実装)
 - [ベストプラクティス](#ベストプラクティス)
 - [トラブルシューティング](#トラブルシューティング)
-- [制約](#制約)
+- [制約事項](#制約事項)
 
 ---
 
 ## 概要
 
-イベントストリーミングは、既存の MongoDB Change Streams → EventBridge パイプラインに並行パスを追加し、エンティティの変更を WebSocket クライアントにブロードキャストします。
+Event Streaming は、既存の MongoDB Change Streams → EventBridge パイプラインに並列パスを追加し、エンティティの変更を WebSocket クライアントにブロードキャストします。
 
 ### 通知チャネルの比較
 
@@ -79,19 +79,19 @@ ws://localhost:3000?tenant={tenantName}
 
 | パラメータ | 必須 | 説明 |
 |-----------|------|------|
-| `tenant` | ✅ | テナント名 (`Fiware-Service` ヘッダーと同等) |
+| `tenant` | ✅ | テナント名(`Fiware-Service` ヘッダーと同等) |
 
 ### 認証
 
-`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは次の優先順位で抽出されます:
+`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは以下の優先順位で抽出されます:
 
-1. **`Authorization` ヘッダー (推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
-2. **`Sec-WebSocket-Protocol` ヘッダー (ブラウザ向け)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用
+1. **`Authorization` ヘッダー(推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
+2. **`Sec-WebSocket-Protocol` ヘッダー(ブラウザ向け)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用
 
-> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。これまで URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
+> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。以前に URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
 
-- REST API `/auth/login` エンドポイントから取得した `accessToken` をトークンとして直接使用してください。
-- `super_admin` ロールは、WebSocket ストリーミングのために任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API (`/v2/*`、`/ngsi-ld/*`) にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
+- REST API `/auth/login` エンドポイントから取得した `accessToken` を直接トークンとして使用します。
+- `super_admin` ロールは、WebSocket ストリーミングのためにあらゆるテナントに接続できます。注意: `super_admin` は REST 経由でデータ API(`/v2/*`、`/ngsi-ld/*`)にアクセスできませんが、運用監視目的で WebSocket イベントストリーミングは許可されています。
 - `tenant_admin` / `user` ロールは自分のテナントにのみ接続できます。
 
 | 条件 | 結果 |
@@ -105,10 +105,10 @@ ws://localhost:3000?tenant={tenantName}
 
 ### 接続フロー
 
-1. クライアントが WebSocket URL に接続 (`tenant` クエリパラメータは必須; 認証が有効な場合はトークンも必須)
-2. サーバーがトークンを検証し、テナントアクセス権限を確認 (認証が有効な場合)
-3. トークンに `cnf.jkt` クレーム (DPoP バインドトークン) が含まれている場合、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります (下記の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
-4. サーバーが DynamoDB に接続を記録 (TTL: 2 時間)
+1. クライアントが WebSocket URL に接続(`tenant` クエリパラメータが必要。認証が有効な場合はトークンも必要)
+2. サーバーがトークンを検証し、テナントアクセス権限を確認(認証が有効な場合)
+3. トークンに `cnf.jkt` クレームが含まれている場合(DPoP バインドトークン)、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります(以下の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
+4. サーバーが DynamoDB に接続を記録(TTL: 2 時間)
 5. オプション: `subscribe` メッセージでフィルター条件を設定
 6. エンティティが変更されると、サーバーがクライアントにイベントをプッシュ
 
@@ -131,10 +131,10 @@ ws://localhost:3000?tenant={tenantName}
 | フィールド | 型 | 説明 |
 |-------|------|-------------|
 | `action` | string | `subscribe` |
-| `entityTypes` | string[] | フィルタリングするエンティティタイプ |
+| `entityTypes` | string[] | フィルタするエンティティタイプ |
 | `idPattern` | string | エンティティ ID の正規表現パターン |
 
-#### dpop_bind (DPoP 証明検証)
+#### dpop_bind (DPoP proof 検証)
 
 ```json
 {
@@ -143,7 +143,7 @@ ws://localhost:3000?tenant={tenantName}
 }
 ```
 
-DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する場合に必要です。接続後 5 秒以内に送信する必要があります。サーバーは証明の JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` で応答します。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否されます。
+DPoP バインドトークン(`cnf.jkt` を含む JWT)で接続する場合に必須です。接続後 5 秒以内に送信する必要があります。サーバーは proof の JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` で応答します。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否されます。
 
 詳細は AUTH.md — DPoP Token Binding を参照してください。
 
@@ -155,7 +155,7 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 }
 ```
 
-サーバーは `{"type": "pong"}` を返します。10 分間のアイドルタイムアウトを防ぐため、5 分ごとに ping を送信してください。
+サーバーは `{"type": "pong"}` を返します。10 分のアイドルタイムアウトを防ぐため、5 分ごとに ping を送信してください。
 
 ### サーバー → クライアント
 
@@ -184,32 +184,32 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 | `entityId` | string | エンティティ ID |
 | `entityType` | string | エンティティタイプ |
 | `data` | object | エンティティ属性データ |
-| `changedAttributes` | string[] | 変更された属性の名前 (更新時のみ) |
-| `timestamp` | string | イベントタイムスタンプ (ISO 8601) |
+| `changedAttributes` | string[] | 変更された属性の名前(更新時のみ) |
+| `timestamp` | string | イベントタイムスタンプ(ISO 8601) |
 
 ### フィルタリング
 
-フィルタリングは次の順序で 3 つの層で適用されます:
+フィルタリングは次の順序で 3 つのレイヤーで適用されます:
 
-1. **テナントフィルタ (必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
-2. **接続側の `subscribe` フィルタ (オプション)** — クライアントが受信したい内容を絞り込みます:
+1. **テナントフィルタ(必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
+2. **接続側の `subscribe` フィルタ(オプション)** — クライアントが受信したい内容を絞り込みます:
    - `entityTypes`: 受信するエンティティタイプの配列
-   - `idPattern`: `entityId` に対してマッチングされる正規表現
-3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターはアクティブな XACML ポリシーを実行します。サブジェクトがイベントに対して `Permit` された接続のみに配信されます。
+   - `idPattern`: `entityId` と照合される正規表現
+3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターはアクティブな XACML ポリシーを実行します。イベントに対してサブジェクトが `Permit` された接続のみに配信されます。
 
 #### XACML で利用可能なイベントごとのリソース属性 (#1107)
 
-ブロードキャスターが配信を認可する際、以下のエンティティごとのリソース属性を AuthzRequest に注入します:
+ブロードキャスターが配信を認可する際、これらのエンティティごとのリソース属性を AuthzRequest に注入します:
 
 | attributeId | ソース |
 |-------------|--------|
 | `entityType` | イベントのエンティティタイプ |
 | `entityId` | イベントのエンティティ ID |
-| `entityOwner` | イベントエンティティの `createdBy` (元々エンティティを `POST` したユーザー) |
+| `entityOwner` | イベントエンティティの `createdBy`(元々エンティティを `POST` したユーザー) |
 
-これにより、`${subject.userId}` テンプレート展開と `entityOwner` を使用して、単一の XACML ポリシーで「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった**ユーザーごとの配信フィルタ**を記述できます。完全なポリシー例については `docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性 を参照してください。
+これにより、「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった **ユーザーごとの配信フィルタ** を、`entityOwner` に対する `${subject.userId}` テンプレート展開を使用した単一の XACML ポリシーで記述できます。完全なポリシー例については、`docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性を参照してください。
 
-> 認証なしで書き込まれたエンティティ (または `createdBy` を設定しないレガシー / バッチパス経由) は、`owner` 属性のないイベントを発行します — 所有者ベースのルールはこれらのイベントにマッチしないため、このフォールバックを考慮してポリシーを設計してください。
+> 認証なしで書き込まれたエンティティ(または `createdBy` を設定しないレガシー/バッチパス経由)は、`owner` 属性なしでイベントを発行します — 所有者ベースのルールはこれらのイベントにマッチしないため、そのフォールバックを考慮してポリシーを設計してください。
 
 ---
 
@@ -217,7 +217,7 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 
 ### JavaScript SDK (推奨)
 
-GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンの更新、DPoP バインディング、再接続を自動的に処理します。
+GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最も簡単な方法を提供します。認証、トークンリフレッシュ、DPoP バインディング、再接続を自動的に処理します。
 
 ```bash
 npm install @geolonia/geonicdb-sdk
@@ -257,7 +257,7 @@ db.on('connected', function() {
 // db.reconnect();
 ```
 
-Bearer JWT 認証の場合(例: ログインフロー後)、`setCredentials()` で認証情報を注入します:
+Bearer JWT 認証の場合 (例: ログインフロー後)、`setCredentials()` で認証情報を注入します:
 
 ```javascript
 import GeonicDB from '@geolonia/geonicdb-sdk';
@@ -282,7 +282,7 @@ db.connect();
 
 完全な API リファレンスについては、SDK ドキュメントを参照してください。
 
-### クイックスタート (raw WebSocket、最小限のセットアップ)
+### クイックスタート (生の WebSocket、最小限のセットアップ)
 
 認証なしの最小限の接続例:
 
@@ -557,9 +557,9 @@ wscat -c "wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant=smart
 
 ---
 
-## WebSocket の DPoP バインディング {#dpop-binding-for-websocket}
+## WebSocket 用 DPoP バインディング
 
-DPoP バインドトークンを使用する WebSocket 接続には、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
+DPoP バインドトークンを使用する WebSocket 接続には、接続後のプルーフ検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP プルーフは接続確立後にメッセージとして送信されます。
 
 ### フロー
 
@@ -584,8 +584,8 @@ Client                               Server
 
 | 状態 | 説明 | 許可されるメッセージ |
 |-------|-------------|------------------|
-| `pending_dpop` | 接続後に DPoP 証明を待機中 | `dpop_bind` のみ |
-| `verified` | DPoP 証明が正常に検証された | `subscribe`、`ping` など |
+| `pending_dpop` | 接続後に DPoP プルーフを待機中 | `dpop_bind` のみ |
+| `verified` | DPoP プルーフが正常に検証されました | `subscribe`、`ping` など |
 
 `dpop_bind` メッセージが 5 秒以内に受信されない場合、接続は終了されます。
 
@@ -595,9 +595,9 @@ Client                               Server
 
 ### 1. 再接続ロジック
 
-> **注意**: JavaScript SDK を使用している場合、指数バックオフを使用した再接続が組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続試行を追跡できます。以下の例は、raw WebSocket 実装向けです。
+> **注意**: JavaScript SDK を使用している場合、エクスポネンシャルバックオフによる再接続が組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続の試行を追跡してください。以下の例は生の WebSocket 実装用です。
 
-指数バックオフを使用した堅牢な再接続を実装します:
+エクスポネンシャルバックオフによる堅牢な再接続を実装します:
 
 ```javascript
 class GeonicDBWebSocket {
@@ -633,9 +633,9 @@ class GeonicDBWebSocket {
 }
 ```
 
-### 2. Keep-Alive
+### 2. キープアライブ
 
-10 分間のアイドルタイムアウトを防ぐために、5 分ごとに ping を送信します:
+10 分のアイドルタイムアウトを防ぐために、5 分ごとに ping を送信します:
 
 ```javascript
 setInterval(() => {
@@ -681,7 +681,7 @@ async function getToken() {
 }
 ```
 
-**トークン有効期限の管理:**
+**トークン有効期限管理:**
 
 ```javascript
 function isTokenExpired(token, bufferSeconds = 60) {
@@ -716,7 +716,7 @@ onUnmounted(() => {
 
 ## トラブルシューティング
 
-### 1. 接続が拒否される (1008 エラー)
+### 1. 接続拒否 (1008 エラー)
 
 **原因:**
 - トークンが無効または期限切れ
@@ -737,7 +737,7 @@ ws.onclose = (event) => {
 
 ### 2. 10 分後に接続が切断される
 
-**原因:** Keep-alive (ping) メッセージが送信されていない。
+**原因:** Keep-alive (ping) メッセージが送信されていません。
 
 **解決方法:**
 
@@ -814,16 +814,16 @@ class DebugWebSocket {
 
 ---
 
-## 制約
+## 制約事項
 
 | 項目 | 値 | 説明 |
 |------|-------|-------------|
 | アイドルタイムアウト | 10 分 | クライアントは 5 分ごとに ping を送信する必要があります |
-| 同時接続数 | 500 (デフォルト) | AWS Support 経由で増やすことができます |
+| 同時接続数 | 500 (デフォルト) | AWS Support 経由で増やすことが可能です |
 | フレームサイズ | 128KB | 大きなエンティティは切り詰めが必要です |
 | レイテンシ | ~1 分 | MongoDB Change Stream のポーリング間隔に依存します |
-| 接続 TTL | 2 時間 | DynamoDB TTL によって自動的にクリーンアップされます |
-| ローカル開発 | サポート対象 | ローカル WebSocket サーバー経由で利用可能 |
+| 接続 TTL | 2 時間 | DynamoDB TTL により自動的にクリーンアップされます |
+| ローカル開発 | サポート | ローカル WebSocket サーバー経由で利用可能です |
 
 ---
 

--- a/docs/ja/reference/cli.md
+++ b/docs/ja/reference/cli.md
@@ -9,8 +9,7 @@ outline: deep
 
 - **リポジトリ**: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)
 - **ランタイム**: Node.js >= 20
-- **パッケージ**: `@geolonia/geonicdb-cli`
-## 目次
+- **パッケージ**: `@geolonia/geonicdb-cli`## 目次
 
 - [インストール](#インストール)
 - [クイックスタート](#クイックスタート)
@@ -135,26 +134,21 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 }
 ```
 
-**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`
-#
+**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`#
 
-### `geonic config set <key> <value>`
-設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
+### `geonic config set <key> <value>`設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
 
 #
 
-### `geonic config get <key>`
-設定値を取得します。
+### `geonic config get <key>`設定値を取得します。
 
 #
 
-### `geonic config list`
-現在のプロファイルのすべての設定値を表示します。
+### `geonic config list`現在のプロファイルのすべての設定値を表示します。
 
 #
 
-### `geonic config delete <key>`
-設定値を削除します。
+### `geonic config delete <key>`設定値を削除します。
 
 ### プロファイル管理
 
@@ -162,28 +156,23 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 
 #
 
-### `geonic profile list`
-すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
+### `geonic profile list`すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
 
 #
 
-### `geonic profile use <name>`
-アクティブなプロファイルを切り替えます。
+### `geonic profile use <name>`アクティブなプロファイルを切り替えます。
 
 #
 
-### `geonic profile create <name>`
-新しい空のプロファイルを作成します。
+### `geonic profile create <name>`新しい空のプロファイルを作成します。
 
 #
 
-### `geonic profile delete <name>`
-プロファイルを削除します。`default` プロファイルは削除できません。
+### `geonic profile delete <name>`プロファイルを削除します。`default` プロファイルは削除できません。
 
 #
 
-### `geonic profile show [name]`
-プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
+### `geonic profile show [name]`プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
 
 ### 環境変数
 
@@ -343,13 +332,11 @@ CLI は 24 時間ごとに新しいバージョンをチェックし、アップ
 
 ## コマンドリファレンス
 
-### `entities`
-NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
+### `entities`NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
 
 #
 
-### `geonic entities list`
-オプションのフィルタを使用してエンティティをリストします。
+### `geonic entities list`オプションのフィルタを使用してエンティティをリストします。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -384,8 +371,7 @@ geonic entities list --type Sensor --count-only
 
 #
 
-### `geonic entities get <id>`
-ID で単一のエンティティを取得します。
+### `geonic entities get <id>`ID で単一のエンティティを取得します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -393,8 +379,7 @@ ID で単一のエンティティを取得します。
 
 #
 
-### `geonic entities create [json]`
-新しいエンティティを作成します。
+### `geonic entities create [json]`新しいエンティティを作成します。
 
 ```bash
 geonic entities create '{
@@ -410,8 +395,7 @@ geonic entities create '{
 
 #
 
-### `geonic entities update <id> [json]`
-エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
+### `geonic entities update <id> [json]`エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
 
 ```bash
 geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property", "value": 25.0}}'
@@ -419,23 +403,19 @@ geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property"
 
 #
 
-### `geonic entities replace <id> [json]`
-すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
+### `geonic entities replace <id> [json]`すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
 
 #
 
-### `geonic entities upsert [json]`
-エンティティを作成または更新します (`POST /entityOperations/upsert`)。
+### `geonic entities upsert [json]`エンティティを作成または更新します (`POST /entityOperations/upsert`)。
 
 #
 
-### `geonic entities delete <id>`
-エンティティを削除します。
+### `geonic entities delete <id>`エンティティを削除します。
 
 ---
 
-### `entities attrs`
-エンティティの個別の属性を管理します。
+### `entities attrs`エンティティの個別の属性を管理します。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -455,8 +435,7 @@ geonic entities attrs update urn:ngsi-ld:Room:001 temperature '{"type": "Propert
 
 ---
 
-### `entityOperations`
- (バッチ)
+### `entityOperations` (バッチ)
 
 エンティティのバッチ操作 (`/ngsi-ld/v1/entityOperations`)。エイリアス: `batch`。
 
@@ -479,8 +458,7 @@ cat entities.json | geonic batch upsert
 
 ---
 
-### `subscriptions`
- (sub)
+### `subscriptions` (sub)
 
 コンテキストサブスクリプション (`/ngsi-ld/v1/subscriptions`) を管理します。エイリアス: `sub`。
 
@@ -492,8 +470,7 @@ cat entities.json | geonic batch upsert
 | `geonic sub update <id> [json]` | サブスクリプションの更新 |
 | `geonic sub delete <id>` | サブスクリプションの削除 |
 
-**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
-```bash
+**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count````bash
 geonic sub create '{
   "type": "Subscription",
   "entities": [{"type": "Room"}],
@@ -506,8 +483,7 @@ geonic sub create '{
 
 ---
 
-### `registrations`
- (reg)
+### `registrations` (reg)
 
 コンテキストソース登録 (`/ngsi-ld/v1/csourceRegistrations`) を管理します。エイリアス: `reg`。
 
@@ -519,11 +495,9 @@ geonic sub create '{
 | `geonic reg update <id> [json]` | 登録の更新 |
 | `geonic reg delete <id>` | 登録の削除 |
 
-**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
----
+**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`---
 
-### `types`
-利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
+### `types`利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -532,13 +506,11 @@ geonic sub create '{
 
 ---
 
-### `temporal`
-時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
+### `temporal`時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
 
 #
 
-### `geonic temporal entities list`
-時系列エンティティの一覧を取得します。
+### `geonic temporal entities list`時系列エンティティの一覧を取得します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -566,24 +538,19 @@ geonic temporal entities get urn:ngsi-ld:Room:001 \
 
 #
 
-### `geonic temporal entities get <id>`
-エンティティの時系列表現を取得します。
+### `geonic temporal entities get <id>`エンティティの時系列表現を取得します。
 
-**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`
-#
+**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`#
 
-### `geonic temporal entities create [json]`
-時系列エンティティを作成します。
+### `geonic temporal entities create [json]`時系列エンティティを作成します。
 
 #
 
-### `geonic temporal entities delete <id>`
-時系列エンティティを削除します。
+### `geonic temporal entities delete <id>`時系列エンティティを削除します。
 
 #
 
-### `geonic temporal entityOperations query [json]`
-集約サポート付きで POST による時系列エンティティのクエリを実行します。
+### `geonic temporal entityOperations query [json]`集約サポート付きで POST による時系列エンティティのクエリを実行します。
 
 | オプション | 説明 |
 |--------|-------------|
@@ -599,8 +566,7 @@ geonic temporal entityOperations query @query.json \
 
 ---
 
-### `snapshots`
-エンティティスナップショットを管理します。
+### `snapshots`エンティティスナップショットを管理します。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -610,11 +576,9 @@ geonic temporal entityOperations query @query.json \
 | `geonic snapshots delete <id>` | スナップショットを削除 |
 | `geonic snapshots clone <id>` | スナップショットをクローン |
 
-**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`
----
+**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`---
 
-### `rules`
-ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
+### `rules`ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -655,13 +619,11 @@ DCAT-AP データカタログを参照します。
 
 ---
 
-### `admin`
-管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
+### `admin`管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
 
 #
 
-### `admin tenants`
-| コマンド | 説明 |
+### `admin tenants`| コマンド | 説明 |
 |---------|-------------|
 | `geonic admin tenants list` | テナント一覧を取得 |
 | `geonic admin tenants get <id>` | テナントを取得 |
@@ -673,8 +635,7 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin users`
-| コマンド | 説明 |
+### `admin users`| コマンド | 説明 |
 |---------|-------------|
 | `geonic admin users list` | ユーザー一覧を取得 |
 | `geonic admin users get <id>` | ユーザーを取得 |
@@ -687,8 +648,7 @@ DCAT-AP データカタログを参照します。
 
 #
 
-### `admin policies`
-XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
+### `admin policies`XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -702,8 +662,7 @@ XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照�
 
 #
 
-### `admin oauth-clients`
-OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
+### `admin oauth-clients`OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -715,8 +674,7 @@ OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照し�
 
 #
 
-### `admin api-keys`
-API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
+### `admin api-keys`API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -759,8 +717,7 @@ geonic admin api-keys update gdb_abc123 '{"name": "renamed-key", "isActive": fal
 
 #
 
-### `admin cadde`
-CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
+### `admin cadde`CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -770,22 +727,19 @@ CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
 
 ---
 
-### `health`
-```bash
+### `health````bash
 geonic health
 ```
 
 サーバーのヘルス状態を確認します (`GET /health`)。
 
-### `version`
-```bash
+### `version````bash
 geonic version
 ```
 
 CLI のバージョンとサーバーのバージョンを表示します (`GET /version`)。
 
-### `me`
-現在認証されているユーザーを表示し、ユーザーリソースを管理します。
+### `me`現在認証されているユーザーを表示し、ユーザーリソースを管理します。
 
 ```bash
 geonic me
@@ -795,8 +749,7 @@ geonic me
 
 #
 
-### `me oauth-clients`
-自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
+### `me oauth-clients`自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -827,8 +780,7 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 
 #
 
-### `me api-keys`
-自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
+### `me api-keys`自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
 
 | コマンド | 説明 |
 |---------|-------------|
@@ -836,8 +788,7 @@ geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 | `geonic me api-keys create [json]` | 新しい API キーを作成 |
 | `geonic me api-keys delete <key-id>` | API キーを削除 |
 
-**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count`
-```bash
+**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count````bash
 # Create a personal API key
 geonic me api-keys create '{
   "name": "my-dev-key",
@@ -854,8 +805,7 @@ geonic me api-keys delete gdb_abc123
 
 > **注意**: 平文の API キーは、作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
 
-### `help`
-WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
+### `help`WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
 
 ```bash
 geonic help                    # All commands overview


### PR DESCRIPTION
## Automated Sync & Translation

**Trigger**: workflow_dispatch
**GeonicDB SHA**: N/A (manual dispatch)
**Base branch**: main

### Changed files
docs/en/ai-integration/examples.md
docs/en/ai-integration/overview.md
docs/en/ai-integration/tools-json.md
docs/en/api-reference/endpoints.md
docs/en/api-reference/ngsiv2.md
docs/en/changelog.md
docs/en/core-concepts/ngsiv2-vs-ngsild.md
docs/en/features/subscriptions.md

### Process
1. Synced English source docs from geolonia/geonicdb → docs/en/
2. Translated English docs to Japanese via yuuhitsu → docs/ja/
3. Build verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CEL式に新しい関数（distance()、within()、now()、dayOfWeek()）を追加、CELコンテキスト機能を拡張
  * カスタムデータモデル用の拡張PropertyDetail型を追加
  * WebSocketイベントペイロードにエンティティ情報を含める
  * 新しいエラークラスセットで例外処理を強化
  * APIクエリパラメータを大幅に拡張し、リンク済みエンティティ取得機能を追加

* **ドキュメント**
  * API リファレンス、CLIガイド、コア概念について日本語ドキュメントを大幅に更新・充実
  * Vector Tiles対応やMCP/A2A統合に関する詳細ガイドを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->