### PR TITLE
fix: add ), ], > to negLookaheads in fix-doc-quality.ts

### DIFF
--- a/scripts/fix-doc-quality.ts
+++ b/scripts/fix-doc-quality.ts
@@ -44,7 +44,7 @@ export const JA_GLOSSARY_RULES: GlossaryRule[] = [
   // "geonicdb" without suffix is prose violation; compound names ("geonicdb-docs"),
   // URLs ("geonicdb.geolonia.com", "geolonia/geonicdb/compare"), IAM keys ("geonicdb:purpose"),
   // metrics ("geonicdb_uptime"), and inline code ("`npx geonicdb`") are excluded.
-  { forbidden: 'geonicdb', correct: 'GeonicDB', negLookaheads: ['-', '.', '/', ':', '_', '`'] },
+  { forbidden: 'geonicdb', correct: 'GeonicDB', negLookaheads: ['-', '.', '/', ':', '_', '`', ')', ']', '>'] },
   { forbidden: 'リアクティブコア', correct: 'ReactiveCore' },
   { forbidden: 'マップリブレ', correct: 'MapLibre' },
   { forbidden: 'ファイウェア', correct: 'FIWARE' },

--- a/tests/unit/fix-doc-quality.test.ts
+++ b/tests/unit/fix-doc-quality.test.ts
@@ -482,6 +482,35 @@ describe('fixGlossaryViolations', () => {
     // コンテキストブローカー (with ー) is preserved
     expect(result).toBe('コンテキストブローカー への接続と、コンテキストブローカー を使用します。')
   })
+
+  it('does not replace geonicdb when followed by ) (Markdown link suffix)', () => {
+    // URL ending: ./introduction/why-geonicdb) — geonicdb is followed by ) → not replaced
+    const content = '詳細は [link](./introduction/why-geonicdb) を参照。'
+    const { content: result } = fixGlossaryViolations(content)
+    // geonicdb) → negLookahead on ) → not replaced
+    expect(result).toBe('詳細は [link](./introduction/why-geonicdb) を参照。')
+  })
+
+  it('does not replace geonicdb when followed by ] (Markdown link text close)', () => {
+    // e.g. [geonicdb] in link text should not be replaced
+    const content = '[geonicdb] の詳細はこちら。'
+    const { content: result } = fixGlossaryViolations(content)
+    expect(result).toBe('[geonicdb] の詳細はこちら。')
+  })
+
+  it('does not replace geonicdb when followed by > (HTML tag or angle bracket)', () => {
+    // e.g. <geonicdb> should not be replaced
+    const content = '<geonicdb> タグの説明。'
+    const { content: result } = fixGlossaryViolations(content)
+    expect(result).toBe('<geonicdb> タグの説明。')
+  })
+
+  it('replaces standalone geonicdb in prose (regression: normal replacement)', () => {
+    const content = 'geonicdb は高性能なコンテキストブローカーです。'
+    const { content: result, count } = fixGlossaryViolations(content)
+    expect(result).toBe('GeonicDB は高性能なコンテキストブローカーです。')
+    expect(count).toBe(1)
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #205

## Root cause

`fix-doc-quality.ts` の `geonicdb` glossary rule の `negLookaheads` に `)`, `]`, `>` が欠落していたため、Markdown リンク末尾の `geonicdb)` が `GeonicDB)` に誤置換され、broken link `/ja/introduction/why-GeonicDB` が生成されていた。

gunshi cmd_433 deep-dive 分析により特定。

## Changes

- `scripts/fix-doc-quality.ts`: `negLookaheads` に `')'`, `']'`, `'>'` を追加
- `tests/unit/fix-doc-quality.test.ts`: 新規 negLookaheads ケース 4 件追加
  - `geonicdb)` (Markdown link suffix) が置換されないこと
  - `[geonicdb]` (link text) が置換されないこと  
  - `<geonicdb>` (HTML tag) が置換されないこと
  - 通常散文の `geonicdb` は `GeonicDB` に置換されること（回帰）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ドキュメント品質チェックの用語置換ルールを改善し、特定の記号（括弧、角括弧、HTMLタグなど）の直後での不正な置換を防止するようになりました。

## テスト
* マークダウンリンクやHTMLタグ周辺での置換エッジケースをカバーするテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->