### PR TITLE
docs: sync and translate from geonicdb/docs

### DIFF
--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -12,6 +12,8 @@ outline: deep
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-05
+
 ### 2026-05-05
 - **修正**: SDK の `db.request()` が空ボディ + JSON Content-Type のレスポンスで `SyntaxError: Unexpected end of JSON input` を投げて落ちる問題 (issue #1145) (#1146)
   - 背景: NGSI-LD `POST /entities` (201) など仕様上ボディが空のレスポンスでも、サーバ実装は `Content-Type: application/ld+json` を付けて返している。SDK 側 `db.request()` は Content-Type が `json` を含むと無条件に `res.json()` を呼ぶため、空ボディで SyntaxError を投げていた (`db.createEntity` 等の専用メソッドは body を読まないので影響なし、`db.request()` 経由で同パスを叩くと壊れる、という非対称が問題)
@@ -50,7 +52,7 @@ outline: deep
   - 旧: `encodeURIComponent` でフィールドごとに直列化
   - 新: `URLSearchParams` ベースに refactor (DRY 化のため)
   - 影響を受ける文字: 半角スペース `%20` → `+` / `'` 素通し → `%27` / `!` `*` `(` `)` `~` 素通し → `%21` `%2A` `%28` `%29` `%7E`
-  - サーバ側 (GeonicDB 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
+  - サーバ側 (geonicdb 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
   - 公開メソッドのシグネチャは追加のみで完全後方互換 (新パラメータはすべて optional)
 - **改善**: SDK のクエリパラメータ表面を NGSI-LD §5.7.2 (Query Entities) に揃えて拡充 (issue #1132) (#1149)
   - 背景: `db.getEntities()` 等は `type / limit / offset / q` の 4 パラメータしか URL に乗せておらず、サーバが実装している `scopeQ` / `georel` / `geometry` / `coordinates` / `attrs` / `pick` / `omit` / `lang` / `orderBy` / `count` 等を SDK 経由で使えなかった。実アプリで scope に基づくフィルタが必要になり (geonicdb-gis 関連)、SDK を諦めて `db.request()` で素のパスを組み立てる回避が必要だった

--- a/docs/ja/ai-integration/examples.md
+++ b/docs/ja/ai-integration/examples.md
@@ -5,19 +5,20 @@ outline: deep
 ---
 # AI 統合
 
-GeonicDB は AI エージェント（Claude、GPT-4、Gemini など）が API を簡単に利用できるよう、複数の AI 指向インターフェースを提供しています。
+GeonicDB は複数の AI 指向インターフェースを提供しており、AI エージェント (Claude、GPT-4、Gemini など) が簡単に API を利用できます。
 
 ## エンドポイント一覧
 
-| エンドポイント | 形式 | 説明 |
-|---------------|------|------|
-| `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
-| `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
-| `GET /.well-known/ai-plugin.json` | JSON | AI プラグインマニフェスト |
-| `GET /openapi.json` | JSON | OpenAPI 3.0 仕様 |
-| `GET /api.json` | JSON | API リファレンス |
+| エンドポイント                           | 形式                  | 説明                                               |
+| --------------------------------- | ------------------- | ------------------------------------------------ |
+| `GET /llms.txt`                   | Markdown (llms.txt) | LLM 向け API ドキュメント                                |
+| `GET /tools.json`                 | JSON                | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
+| `GET /.well-known/ai-plugin.json` | JSON                | AI プラグインマニフェスト                                   |
+| `GET /openapi.json`               | JSON                | OpenAPI 3.0 仕様                                   |
+| `GET /api.json`                   | JSON                | API リファレンス                                       |
 
-## Tool Use スキーマ (`/tools.json`
+## Tool Use Schema (`/tools.json`
+
 )
 
 Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
@@ -26,29 +27,33 @@ Claude Tool Use および OpenAI Function Calling と互換性のあるツール
 
 各ツールは `action` および `resource` パラメータを介して操作を選択します。
 
-| ツール名 | リソース | アクション | 説明 |
-|---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、型、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作（最大 1,000 件） |
-| `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
-| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理（super_admin、get/update/delete） |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理（認証が必要） |
+| ツール名       | リソース                                              | アクション                                                                                                                                                    | 説明                                                                                                                        |
+| ---------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `entities` | entities (デフォルト)、types、attributes                 | list、get、create、update、delete、replace、search\_by\_location、search\_by\_attribute、get\_info、get\_all、append、patch\_all、patch                              | IoT エンティティ、タイプ、および属性の管理                                                                                                   |
+| `batch`    | -                                                 | create、upsert、update、merge、delete、query、purge                                                                                                            | 一括エンティティ操作 (最大 1,000 アイテム)                                                                                                |
+| `temporal` | -                                                 | get、query、create、delete、add\_attributes、delete\_attribute、merge、modify\_instance、delete\_instance、batch\_create、batch\_upsert、batch\_delete、batch\_query | 時系列データ管理                                                                                                                  |
+| `config`   | rules、jsonld\_contexts、data\_models、cadde\_config | list、get、create、update、delete、activate、deactivate、list\_domains、list\_models、get\_model、generate\_template                                               | ReactiveCore Rules、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理 (super\_admin、get/update/delete) |
+| `admin`    | users、tenants、policies                            | list、get、create、update、delete、activate、deactivate、change\_password                                                                                       | ユーザー、テナント、およびポリシー管理 (認証が必要)                                                                                               |
 
 ### 自動 NGSI-LD 属性タイプ検出
 
-MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動的に推測します:
 
-| 値のパターン | 検出されるタイプ | 例 |
-|------------|-----------|-----|
-| `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
-| `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
-| その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
+| 値パターン                                                                             | 検出されたタイプ           | 例                                                 |
+| --------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| String で始まる `urn:`                                                                | `Relationship`     | `"urn:ngsi-ld:Building:001"`                      |
+| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty`      | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| Object を含む `languageMap` フィールド                                                    | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
+| その他すべての値                                                                          | `Property`         | `25.5`、`"text"`、`true`、`[1, 2, 3]`                |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
+
+* `{"type": "Property", "value": 25.5}`
+  
+* `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
+  
+* `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
+
 ### レスポンス構造
 
 ```json
@@ -80,7 +85,8 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 }
 ```
 
-## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
+## AI Plugin Manifest (`/.well-known/ai-plugin.json`
+
 )
 
 API 検出情報を提供します。
@@ -148,20 +154,24 @@ response = client.chat.completions.create(
 
 ## MCP (Model Context Protocol) サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント（Claude Desktop など）は、コンテキストブローカーに直接接続できます。
+GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント(Claude Desktop など)は、コンテキストブローカーに直接接続できます。
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
-- **プロトコルバージョン**: 2025-03-26
-- **動作モード**: ステートレス (Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
+
+* **エンドポイント**: `POST /mcp`
+  
+* **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+  
+* **プロトコルバージョン**: 2025-03-26
+  
+* **動作モード**: ステートレス(Lambda 互換)
+  
+* **認証**: `AUTH_ENABLED=true` の場合、アクセス制御とテナント分離は JWT Bearer トークンによって実施されます
 
 ### Claude Desktop の設定
 
-
-
-### ローカル開発環境（認証なし）
+#### ローカル開発(認証なし)
 
 ```json
 {
@@ -180,11 +190,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` は必須です。これは GeonicDB が Streamable HTTP (POST) のみをサポートしており、SSE が利用できないためです。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要です）。
+> **注意**:`--transport http-only` は必須です。GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できないためです。`--allow-http` は `http://` の URL に必要です(本番環境の `https://` では不要です)。
 
-
-
-### 本番環境（JWT 認証あり）
+#### 本番環境(JWT 認証あり)
 
 ```json
 {
@@ -206,19 +214,17 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンは有効期限があり、定期的な更新が必要です。
 
+#### 本番環境(API キー認証あり)
 
+API キーは有効期限がなく、Claude Desktop などの長期間にわたる統合に推奨されます。
 
-### 本番環境（API キー認証あり）
-
-API キーは有効期限がなく、Claude Desktop などの長期的な統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**ステップ 1: GeonicDB CLI をインストールする**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: ログインと CLI の設定**
+**ステップ 2: CLI にログインして設定する**
 
 ```bash
 # Set the server URL
@@ -228,7 +234,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**ステップ 3: API キーを作成する**
 
 ```bash
 geonic me api-keys create \
@@ -239,24 +245,28 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー（`gdb_` で始まる文字列）は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のためにキーを CLI 設定に保存します。
+> **重要**: API キー(`gdb_` で始まる文字列)は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のためにキーを CLI 設定に保存します。
 
 API キーで利用可能なスコープ:
 
-| スコープ | 説明 |
-|---|---|
-| `read:entities` | エンティティ、タイプ、属性の読み取り |
-| `write:entities` | エンティティの作成、更新、削除 |
-| `read:subscriptions` | サブスクリプションの読み取り |
+| スコープ                  | 説明                 |
+| --------------------- | ------------------ |
+| `read:entities`       | エンティティ、タイプ、属性の読み取り |
+| `write:entities`      | エンティティの作成、更新、削除    |
+| `read:subscriptions`  | サブスクリプションの読み取り     |
 | `write:subscriptions` | サブスクリプションの作成、更新、削除 |
-| `read:registrations` | コンテキストソース登録の読み取り |
-| `write:registrations` | 登録の作成、更新、削除 |
+| `read:registrations`  | コンテキストソース登録の読み取り   |
+| `write:registrations` | 登録の作成、更新、削除        |
 
-**ステップ 4: Claude Desktop の設定**
+**ステップ 4: Claude Desktop を設定する**
 
-Claude Desktop 設定ファイルを編集します:
+Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+* **macOS**:`~/Library/Application Support/Claude/claude_desktop_config.json`
+  
+* **Windows**:`%APPDATA%\Claude\claude_desktop_config.json`
+
 ```json
 {
   "mcpServers": {
@@ -281,15 +291,13 @@ Claude Desktop 設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列から分離できます。
+> **注記**: 値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `env` 配列の外に保持できます。`args` 配列。
 
-**ステップ 5: Claude Desktop の再起動**
+**ステップ 5: Claude Desktop を再起動**
 
 設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -303,20 +311,23 @@ geonic me api-keys delete <key-id>
 
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効の場合**: 省略すると、ログインしているユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません（403 を返します）。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
-### ServicePath仕様
+* **認証が無効の場合**: 省略した場合、 `default` テナントが使用されます。
+  
+* **認証が有効の場合**: 省略した場合、ログインユーザーのテナントがデフォルトとして使用されます。 `super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、 `tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
-`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+### ServicePathの指定
+
+The `entities`、 `types`、 `attributes`、 `batch`、および `temporal` ツールには、階層スコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+
+#### 基本形式
 
 
-
-### 基本フォーマット
-
-- **フォーマット**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
-- **デフォルト**: 省略された場合、ルートパス `/` が使用されます
-- **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+* **形式**: で始まるパス (例: `/`、 `/hello`、 `/city/sensors`)
+  
+* **デフォルト**: 省略した場合、ルートパス `/` が使用されます
+  
+* **使用例**: 同一テナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -326,12 +337,11 @@ entities tool:
   servicePath: "/hello"
 ```
 
+#### 階層検索 ( `/#`
 
-
-### 階層検索 (`/#`
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
+&#x20;サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。`/#` サフィックスを検索します。
 
 ```yaml
 # Search /Madrid/Gardens and its child paths (e.g., /Madrid/Gardens/ParqueNorte)
@@ -341,9 +351,7 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
-
-
-### 複数パス指定 (カンマ区切り)
+#### 複数パスの指定 (カンマ区切り)
 
 カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
 
@@ -355,26 +363,26 @@ entities tool:
   servicePath: "/park1, /park2"
 ```
 
-**注意**: 書き込み操作 (作成、更新、削除) は、単一の非階層パスのみをサポートします。
+**注記**: 書き込み操作 (作成、更新、削除) は、単一の非階層パスのみをサポートします。
 
 ### NGSI-LD クエリパラメータ
 
-`entities` ツールは、NGSI-LD クエリパラメータの完全なセットをサポートしています:
+この `entities` ツールは NGSI-LD クエリパラメータの全セットをサポートしています:
 
-| パラメータ | 説明 | 例 |
-|---|---|---|
-| `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
-| `idPattern` | エンティティ ID に一致する正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` をプレフィックスとして付与 | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
-| `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
-| `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
-| `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
-| `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
-| `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
-| `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY フォーマットの空間 ID | `"18/232814/103224"` |
-| `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
+| パラメータ            | 説明                                          | 例                                             |
+| ---------------- | ------------------------------------------- | --------------------------------------------- |
+| `idList`         | 一括取得のためのカンマ区切りのエンティティ ID                    | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
+| `idPattern`      | エンティティ ID にマッチする正規表現パターン                    | `"Room.*"`                                    |
+| `orderBy`        | 属性またはシステムフィールドでソート。降順の場合は `!` を前に付ける        | `"createdAt"`、`"!modifiedAt"`                 |
+| `orderDirection` | ソート方向 (`!` プレフィックスの代替)                      | `"asc"`、`"desc"`                              |
+| `sysAttrs`       | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める   | `true`                                        |
+| `pick`           | 含める属性名をカンマ区切りで指定                            | `"temperature,humidity"`                      |
+| `omit`           | 除外する属性名をカンマ区切りで指定                           | `"status"`                                    |
+| `scopeQ`         | スコープクエリ式                                    | `"/Madrid/Gardens"`                           |
+| `lang`           | LanguageProperty 値の言語フィルタ                   | `"ja"`                                        |
+| `geoproperty`    | 地理クエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"`                           |
+| `spatialId`      | ZFXY 形式の空間 ID                               | `"18/232814/103224"`                          |
+| `spatialIdDepth` | 空間 ID の階層検索の深さ                              | `2`                                           |
 
 ```yaml
 # List entities sorted by creation time (newest first) with system attributes
@@ -398,7 +406,7 @@ entities tool:
   q: "temperature>20"
 ```
 
-`batch` ツールの `query` アクションも `orderBy`、`orderDirection`、`sysAttrs` をサポートしています。
+この `batch` ツールの `query` アクションは `orderBy`、`orderDirection`、および `sysAttrs` もサポートしています。
 
 ### 検証
 
@@ -424,21 +432,26 @@ curl -X POST http://localhost:3000/mcp \
 
 ### 制限事項
 
-- **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
-- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
-- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
 
-## JSON スキーマとカスタムデータモデル
+* **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
+  
+* **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) および `DELETE /mcp` (セッション終了) は 405 を返します。
+  
+* **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が続行されます。
+  
+* **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: `read:entities` はエンティティの読み取り用、`write:entities` は書き込み用)。スコープ制限は JWT RBAC トークンには適用されません。
+  
+* **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
 
-カスタムデータモデルは、作成時に JSON スキーマ (Draft 2020-12) が自動的に生成されます。この JSON スキーマは、AI ツールで以下の目的に活用できます。
+## JSON Schema とカスタムデータモデル
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加の属性を許可します)。厳密な検証を強制するには `false` に設定します。この場合、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
+カスタムデータモデルは、作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は、AI ツールが以下の目的で活用できます。
 
-### AI ツールでの使用例
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` です (NGSI-LD セマンティクスに従って、追加の属性を許可します)。`false` に設定すると厳格な検証が行われます — 定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
+### AI ツールを使った活用例
+
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、 `jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -457,11 +470,11 @@ entities tool:
     unit: "Celsius"    # enum: ["Celsius", "Fahrenheit", "Kelvin"]
 ```
 
-**検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON スキーマを参照してエラーの原因を特定し、有効な値に修正できます。
+**検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON Schema を参照してエラーの原因を特定し、有効な値に修正できます。
 
 ### エンティティテンプレートの生成
 
-`config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+&#x20;ツールの `generate_template` アクションを使用して、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。`config` ツール、&#x20;
 
 ```yaml
 # Generate a template
@@ -471,7 +484,7 @@ config tool:
   type: "TemperatureSensor"
 ```
 
-**レスポンスの例:**
+**レスポンス例:**
 
 ```json
 {
@@ -492,15 +505,23 @@ config tool:
 }
 ```
 
-テンプレートは、以下の優先順位で値を決定します:
-1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` の値
-3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
+テンプレートは次の優先順位で値を決定します:
 
-AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
+1. &#x20;(定義されている場合)
+   
+`defaultValue` (定義されている場合)
+   
+2. &#x20;値 (定義されている場合)
+   
+`example` 値 (定義されている場合)
+   
+3. &#x20;に基づくデフォルト値 (string → `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
+
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON スキーマを `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
+&#x20;エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -508,7 +529,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON スキーマは、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
 
 ```json
 {
@@ -528,9 +549,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### 語彙マッピングのためのプロパティ @context
+### Vocabulary Mapping のためのプロパティ @context
 
-`propertyDetails` の各プロパティには、オプションで HTTP(S) URL を持つ `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
+各プロパティは`propertyDetails`オプションの`@context`フィールドに HTTP(S) URL を含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html)で一致する語彙を確認し、それを`@context`値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -553,7 +574,7 @@ config tool:
       # No @context → auto-generated URL
 ```
 
-生成される JSON-LD `@context` は以下のようになります:
+生成される JSON-LD`@context`は次のようになります:
 
 ```json
 {
@@ -565,76 +586,86 @@ config tool:
 }
 ```
 
-プロパティ URI はエンティティタイプに依存しません。同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
+プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名(例:`email`)は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
-### @context 解決の拡張
+### @context 解決拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに`contextUrl`が設定されている場合、カスタムコンテキストは自動的にレスポンスの`@context`に含まれます。Smart Data Models コンテキストと同様に、AI エージェントはこの`@context`を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使った JavaScript SDK
+## AI コーディングアシスタントを用いた JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加設定なしで完全なパブリック API を自動的に検出できます。
+GeonicDB JavaScript SDK(`@geolonia/geonicdb-sdk`)は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント(Claude Code、Cursor、GitHub Copilot など)は追加の設定なしで完全なパブリック API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
-| 情報 | ソース |
-|------------|--------|
-| コンストラクタオプション | `GeonicDBOptions` 型 |
-| メソッドシグネチャ (17 メソッド) | TypeScript 宣言 |
-| 認証情報の型 | `CredentialsOptions`、`RefreshedCredentials` 型 |
-| クエリパラメータ | `GetEntitiesParams` 型 |
-| サブスクリプションオプション | `SubscribeOptions` 型 |
-| イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言に記載 |
+| 情報                 | ソース                                          |
+| ------------------ | -------------------------------------------- |
+| コンストラクタオプション       | `GeonicDBOptions`型                           |
+| メソッドシグネチャ(17 メソッド) | TypeScript 宣言                                |
+| 認証情報の型             | `CredentialsOptions`、`RefreshedCredentials`型 |
+| クエリパラメータ           | `GetEntitiesParams`型                         |
+| サブスクリプションオプション     | `SubscribeOptions`型                          |
+| イベントペイロード          | `EntityEvent`、`ReconnectingEvent`型           |
+| 全 10 種類のイベントタイプ    | 型宣言に文書化されています                                |
 
 ### 仕組み
 
-1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
-4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE の自動補完がすぐに利用できます。詳細は SDK ドキュメントを参照してください。
+1. 開発者が SDK をインストール:`npm install @geolonia/geonicdb-sdk`
+   
+2. 開発者が SDK をインポート:`import GeonicDB from '@geolonia/geonicdb-sdk'`
+   
+3. AI がパッケージから TypeScript 宣言を読み取る
+   
+4. AI が文書化された API を使用して正しいコードを生成
+
+別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがすぐに利用できます。詳細は SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーとやり取りできるようにします。
 
 ### エンドポイント
 
-| エンドポイント | メソッド | 説明 |
-|----------|--------|-------------|
-| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証を記述 |
-| `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
+| エンドポイント                        | メソッド | 説明                            |
+| ------------------------------ | ---- | ----------------------------- |
+| `/.well-known/agent-card.json` | GET  | エージェントカード — 機能、スキル、認証を記述      |
+| `/a2a`                         | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
 
-### サポートされているメソッド (フェーズ 1)
+### サポートされるメソッド (フェーズ 1)
 
-| JSON-RPC メソッド | 説明 |
-|-----------------|-------------|
-| `message/send` | メッセージを送信し同期レスポンスを受信 |
-| `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションを使用してタスクを一覧表示 |
-| `tasks/cancel` | タスクのキャンセルをリクエスト |
+| JSON-RPC メソッド  | 説明                            |
+| -------------- | ----------------------------- |
+| `message/send` | メッセージを送信し、同期レスポンスを受信          |
+| `tasks/get`    | タスクの現在の状態を取得                  |
+| `tasks/list`   | フィルタリングとページネーションを使用してタスクを一覧表示 |
+| `tasks/cancel` | タスクのキャンセルをリクエスト               |
 
 ### スキル
 
 A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピングされます:
 
-| スキル ID | 説明 |
-|----------|-------------|
-| `entities` | NGSI-LD エンティティの CRUD、地理空間/属性検索 |
-| `batch` | 一括作成、アップサート、更新、削除操作 |
-| `temporal` | 時系列データ管理 |
-| `config` | リアクティブルール、JSON-LD コンテキスト、データモデル |
-| `admin` | ユーザー、テナント、ポリシー管理 |
+| スキル ID     | 説明                              |
+| ---------- | ------------------------------- |
+| `entities` | NGSI-LD エンティティ CRUD、地理空間/属性検索   |
+| `batch`    | 一括作成、アップサート、更新、削除操作             |
+| `temporal` | 時系列データ管理                        |
+| `config`   | リアクティブルール、JSON-LD コンテキスト、データモデル |
+| `admin`    | ユーザー、テナント、ポリシー管理                |
 
 ### 認証
 
 A2A は REST API と同じ認証方法を使用します:
-- **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
-- **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` によるクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` 証明ヘッダー (有効化時)
 
-`Fiware-Service` ヘッダーによるテナント指定を推奨します (未指定時はデフォルトテナントにフォールバック)。
+* **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
+  
+* **API Key**: `X-Api-Key: <key>` ヘッダー
+  
+* **OAuth 2.0**: `POST /oauth/token` 経由のクライアントクレデンシャルフロー
+  
+* **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効な場合)
+
+`Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
 
 ### 例: メッセージの送信
 
@@ -664,15 +695,22 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 ### MCP との関係
 
 A2A と MCP は補完的です:
-- **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-両方とも同じ基盤となるサービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
+* **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
+  
+* **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-## 参考資料
+両方とも同じ基盤サービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
-- [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
-- [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
-- [Model Context Protocol](https://modelcontextprotocol.io/)
-- [A2A Protocol](https://google.github.io/A2A/)
-- [llms.txt](https://llmstxt.org/)
+## 参考文献
+
+
+* [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+  
+* [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
+  
+* [Model Context Protocol](https://modelcontextprotocol.io/)
+  
+* [A2A Protocol](https://google.github.io/A2A/)
+  
+* [llms.txt](https://llmstxt.org/)

--- a/docs/ja/ai-integration/overview.md
+++ b/docs/ja/ai-integration/overview.md
@@ -5,50 +5,55 @@ outline: deep
 ---
 # AI 統合
 
-GeonicDB は、AI エージェント(Claude、GPT-4、Gemini など)が API を簡単に利用できるように、複数の AI 向けインターフェースを提供しています。
+GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 指向のインターフェースを提供しています。
 
 ## エンドポイント一覧
 
-| エンドポイント | 形式 | 説明 |
-|---------------|------|------|
-| `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
-| `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
-| `GET /.well-known/ai-plugin.json` | JSON | AI プラグインマニフェスト |
-| `GET /openapi.json` | JSON | OpenAPI 3.0 仕様 |
-| `GET /api.json` | JSON | API リファレンス |
+| エンドポイント                           | 形式                  | 説明                                               |
+| --------------------------------- | ------------------- | ------------------------------------------------ |
+| `GET /llms.txt`                   | Markdown (llms.txt) | LLM 向け API ドキュメント                                |
+| `GET /tools.json`                 | JSON                | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
+| `GET /.well-known/ai-plugin.json` | JSON                | AI プラグインマニフェスト                                   |
+| `GET /openapi.json`               | JSON                | OpenAPI 3.0 仕様                                   |
+| `GET /api.json`                   | JSON                | API リファレンス                                       |
 
-## Tool Use スキーマ (`/tools.json`
+## Tool Use Schema (`/tools.json`
+
 )
 
-Claude Tool Use と OpenAI Function Calling に互換性のあるツール定義を提供します。
+Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
 
 ### 利用可能なツール (5 ツール)
 
-各ツールは `action` と `resource` パラメータで操作を選択します。
+各ツールは `action` および `resource` パラメータを介して操作を選択します。
 
-| ツール名 | リソース | アクション | 説明 |
-|---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作(最大 1,000 件) |
-| `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
-| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理(super_admin、get/update/delete) |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理(認証が必要) |
+| ツール名       | リソース                                              | アクション                                                                                                                                                    | 説明                                                                                                                        |
+| ---------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `entities` | entities (デフォルト)、types、attributes                 | list、get、create、update、delete、replace、search\_by\_location、search\_by\_attribute、get\_info、get\_all、append、patch\_all、patch                              | IoT エンティティ、タイプ、および属性の管理                                                                                                   |
+| `batch`    | -                                                 | create、upsert、update、merge、delete、query、purge                                                                                                            | 一括エンティティ操作 (最大 1,000 項目)                                                                                                  |
+| `temporal` | -                                                 | get、query、create、delete、add\_attributes、delete\_attribute、merge、modify\_instance、delete\_instance、batch\_create、batch\_upsert、batch\_delete、batch\_query | 時系列データ管理                                                                                                                  |
+| `config`   | rules、jsonld\_contexts、data\_models、cadde\_config | list、get、create、update、delete、activate、deactivate、list\_domains、list\_models、get\_model、generate\_template                                               | ReactiveCore Rules、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 構成管理 (super\_admin、get/update/delete) |
+| `admin`    | users、tenants、policies                            | list、get、create、update、delete、activate、deactivate、change\_password                                                                                       | ユーザー、テナント、およびポリシー管理 (認証が必要)                                                                                               |
 
-### NGSI-LD 属性タイプの自動検出
+### 自動 NGSI-LD 属性タイプ検出
 
-MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動的に推測します:
 
-| 値のパターン | 検出されるタイプ | 例 |
-|------------|-----------|-----|
-| `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
-| `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
-| その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
+| 値のパターン                                                                            | 検出されたタイプ           | 例                                                 |
+| --------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| で始まる文字列 `urn:`                                                                    | `Relationship`     | `"urn:ngsi-ld:Building:001"`                      |
+| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty`      | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| フィールドを含むオブジェクト `languageMap` フィールド                                                | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
+| その他すべての値                                                                          | `Property`         | `25.5`、`"text"`、`true`、`[1, 2, 3]`                |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
+
+* `{"type": "Property", "value": 25.5}`
+  
+* `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
+  
+* `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
+
 ### レスポンス構造
 
 ```json
@@ -80,10 +85,11 @@ MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 }
 ```
 
-## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
+## AI Plugin Manifest (`/.well-known/ai-plugin.json`
+
 )
 
-API 検出情報を提供します。
+API 発見情報を提供します。
 
 ```json
 {
@@ -148,20 +154,24 @@ response = client.chat.completions.create(
 
 ## MCP (Model Context Protocol) サポート
 
-GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) をサポートしています。MCP 互換の AI クライアント(Claude Desktop など)はコンテキストブローカーに直接接続できます。
+GeonicDB は[Model Context Protocol (MCP)](https://modelcontextprotocol.io/)をサポートしています。MCP 対応の AI クライアント (Claude Desktop など) は、コンテキストブローカーに直接接続できます。
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
-- **プロトコルバージョン**: 2025-03-26
-- **動作モード**: ステートレス(Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
 
-### Claude Desktop の設定
+* **エンドポイント**:`POST /mcp`
+  
+* **トランスポート**: ストリーマブル HTTP (JSON レスポンスモード)
+  
+* **プロトコルバージョン**: 2025-03-26
+  
+* **動作モード**: ステートレス (Lambda 互換)
+  
+* **認証**:`AUTH_ENABLED=true`の場合、アクセス制御とテナント分離は JWT Bearer トークンによって強制されます
 
+### Claude Desktop 設定
 
-
-### ローカル開発環境 (認証なし)
+#### ローカル開発(認証なし)
 
 ```json
 {
@@ -180,11 +190,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` は、GeonicDB が Streamable HTTP (POST) のみをサポートしているため必須です（SSE は利用できません）。`--allow-http` は `http://` URL に必要です（本番環境の `https://` では不要）。
+> **注意**:`--transport http-only` は必須です。GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できないためです。`--allow-http` は `http://` URL に必要です(本番環境の `https://` には不要です)。
 
-
-
-### 本番環境 (JWT 認証を使用)
+#### 本番環境(JWT 認証を使用)
 
 ```json
 {
@@ -206,19 +214,17 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
 
+#### 本番環境(API キー認証を使用)
 
+API キーには有効期限がなく、Claude Desktop のような長期的な統合に推奨されます。
 
-### 本番環境 (API キー認証を使用)
-
-API キーには有効期限がなく、Claude Desktop などの長期間の統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**ステップ 1:GeonicDB CLI をインストールする**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: CLI へのログインと設定**
+**ステップ 2:CLI にログインして設定する**
 
 ```bash
 # Set the server URL
@@ -228,7 +234,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**ステップ 3:API キーを作成する**
 
 ```bash
 geonic me api-keys create \
@@ -239,25 +245,28 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー (`gdb_` プレフィックスの文字列) は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグを使用すると、自動使用のために CLI 設定にキーが保存されます。
+> **重要**:API キー(`gdb_` プレフィックスが付いた文字列)は、作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
 
-API キーの利用可能なスコープ:
+API キーで利用可能なスコープ:
 
-| スコープ | 説明 |
-|---|---|
-| `read:entities` | エンティティ、タイプ、属性の読み取り |
-| `write:entities` | エンティティの作成、更新、削除 |
-| `read:subscriptions` | サブスクリプションの読み取り |
+| スコープ                  | 説明                 |
+| --------------------- | ------------------ |
+| `read:entities`       | エンティティ、タイプ、属性の読み取り |
+| `write:entities`      | エンティティの作成、更新、削除    |
+| `read:subscriptions`  | サブスクリプションの読み取り     |
 | `write:subscriptions` | サブスクリプションの作成、更新、削除 |
-| `read:registrations` | コンテキストソース登録の読み取り |
-| `write:registrations` | 登録の作成、更新、削除 |
+| `read:registrations`  | コンテキストソース登録の読み取り   |
+| `write:registrations` | 登録の作成、更新、削除        |
 
-**ステップ 4: Claude Desktop の設定**
+**ステップ 4:Claude Desktop を設定する**
 
-Claude Desktop の設定ファイルを編集します:
+Claude Desktop 設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+* **macOS**:`~/Library/Application Support/Claude/claude_desktop_config.json`
+  
+* **Windows**:`%APPDATA%\Claude\claude_desktop_config.json`
+
 ```json
 {
   "mcpServers": {
@@ -282,15 +291,13 @@ Claude Desktop の設定ファイルを編集します:
 }
 ```
 
-> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保つことができます。
+> **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用すると、認証情報を `args` 配列の外に保持できます。
 
-**ステップ 5: Claude Desktop の再起動**
+**ステップ 5: Claude Desktop を再起動**
 
-設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されます。
+設定を保存したら、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -304,20 +311,23 @@ geonic me api-keys delete <key-id>
 
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効な場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効な場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントのみにアクセスできます。
+
+* **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
+  
+* **認証が有効の場合**: 省略すると、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません(403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
 ### ServicePathの指定
 
-`entities`、`types`、`attributes`、`batch`、および `temporal` ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+The `entities`、`types`、`attributes`、`batch`、`temporal` ツールには、階層スコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+
+#### 基本形式
 
 
-
-### 基本フォーマット
-
-- **フォーマット**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
-- **デフォルト**: 省略した場合、ルートパス `/` が使用されます
-- **ユースケース**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+* **形式**: `/` で始まるパス(例: `/hello`、`/city/sensors`)
+  
+* **デフォルト**: 省略すると、ルートパス `/` が使用されます
+  
+* **使用例**: 同じテナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -327,12 +337,11 @@ entities tool:
   servicePath: "/hello"
 ```
 
+#### 階層検索(`/#`
 
-
-### 階層検索 (`/#`
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
+&#x20;サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。`/#` suffix searches the specified path and all its child paths.
 
 ```yaml
 # Search /Madrid/Gardens and its child paths (e.g., /Madrid/Gardens/ParqueNorte)
@@ -342,11 +351,9 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
+#### 複数パスの指定(カンマ区切り)
 
-
-### 複数パスの指定 (カンマ区切り)
-
-カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
+カンマで区切ることで、複数のパスを同時に検索できます(最大 10 パス)。
 
 ```yaml
 # Search both /park1 and /park2
@@ -356,26 +363,26 @@ entities tool:
   servicePath: "/park1, /park2"
 ```
 
-**注意**: 書き込み操作 (作成、更新、削除) は、単一の非階層パスのみをサポートします。
+**注意**: 書き込み操作(作成、更新、削除)は、単一の非階層パスのみをサポートします。
 
 ### NGSI-LD クエリパラメータ
 
-`entities` ツールは、NGSI-LD クエリパラメータの完全なセットをサポートします:
+The `entities` ツールは、NGSI-LD クエリパラメータのフルセットをサポートしています:
 
-| パラメータ | 説明 | 例 |
-|---|---|---|
-| `idList` | 一括取得のためのカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
-| `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を前に付ける | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` プレフィックスの代替) | `"asc"`、`"desc"` |
-| `sysAttrs` | 結果にシステム属性 (`createdAt`、`modifiedAt`) を含める | `true` |
-| `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
-| `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
-| `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
-| `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
-| `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY フォーマットの空間 ID | `"18/232814/103224"` |
-| `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
+| パラメータ            | 説明                                         | 例                                             |
+| ---------------- | ------------------------------------------ | --------------------------------------------- |
+| `idList`         | 一括取得のためのカンマ区切りのエンティティ ID                   | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
+| `idPattern`      | エンティティ ID にマッチする正規表現パターン                   | `"Room.*"`                                    |
+| `orderBy`        | 属性またはシステムフィールドで並べ替え。降順の場合は接頭辞 `!` を付ける     | `"createdAt"`、`"!modifiedAt"`                 |
+| `orderDirection` | 並べ替え方向(`!` 接頭辞の代替)                         | `"asc"`、`"desc"`                              |
+| `sysAttrs`       | システム属性(`createdAt`、`modifiedAt`)を結果に含める    | `true`                                        |
+| `pick`           | 含める属性名のカンマ区切りリスト                           | `"temperature,humidity"`                      |
+| `omit`           | 除外する属性名のカンマ区切りリスト                          | `"status"`                                    |
+| `scopeQ`         | スコープクエリ式                                   | `"/Madrid/Gardens"`                           |
+| `lang`           | LanguageProperty 値の言語フィルタ                  | `"ja"`                                        |
+| `geoproperty`    | ジオクエリ用の GeoProperty 属性名(デフォルト: `location`) | `"observationArea"`                           |
+| `spatialId`      | ZFXY 形式の空間 ID                              | `"18/232814/103224"`                          |
+| `spatialIdDepth` | 空間 ID 階層検索の深さ                              | `2`                                           |
 
 ```yaml
 # List entities sorted by creation time (newest first) with system attributes
@@ -399,7 +406,7 @@ entities tool:
   q: "temperature>20"
 ```
 
-`batch` ツールの `query` アクションも `orderBy`、`orderDirection`、および `sysAttrs` をサポートします。
+The `batch` ツールの `query` アクションも `orderBy`、`orderDirection`、および `sysAttrs` をサポートしています。
 
 ### 検証
 
@@ -425,19 +432,24 @@ curl -X POST http://localhost:3000/mcp \
 
 ### 制限事項
 
-- **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
-- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) および `DELETE /mcp` (セッション終了) は 405 を返します。
-- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が進行します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
+
+* **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
+  
+* **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp`(SSE)および `DELETE /mcp`(セッション終了)は 405 を返します。
+  
+* **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
+  
+* **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です(例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+  
+* **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
 
 ## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは作成時に、JSON Schema (Draft 2020-12) が自動的に生成されます。この JSON Schema は、以下の目的で AI ツールに活用できます。
+カスタムデータモデルは、作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は、AI ツールで以下の目的に活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持てるかどうかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加属性を許可します)。`false` に設定すると厳密な検証が強制され、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加属性が許可されているかどうかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true` です(NGSI-LD セマンティクスに従い、任意の追加属性を許可します)。`false` に設定すると、厳密な検証が実施され、定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドを確認し、追加属性が許可されているかどうかを判断する必要があります。
 
-### AI ツールでのユースケース例
+### AI ツールでの使用例
 
 **エンティティ作成時のスキーマ参照**: AI エージェントは、`config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照して、正しい型と検証ルールに準拠したエンティティを生成できます。
 
@@ -462,7 +474,7 @@ entities tool:
 
 ### エンティティテンプレート生成
 
-`config` ツールの `generate_template` アクションを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+&#x20;ツールの `generate_template` アクションを使用して、`config`カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
 
 ```yaml
 # Generate a template
@@ -494,14 +506,20 @@ config tool:
 ```
 
 テンプレートは以下の優先順位で値を決定します:
-1. 定義されている場合は `defaultValue`2. 定義されている場合は `example` 値
-3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントは、このテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
+1. &#x20;が定義されている場合はその値
+   
+`defaultValue` が定義されている場合はその値
+   
+2. &#x20;に基づくデフォルト値 (string → `example` value if defined
+   
+3. , number → `valueType` (string → `""`, boolean → `0`, boolean → `false`, など)
+
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
+&#x20;エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `/openapi.json` endpoint dynamically adds the JSON Schema of custom data models associated with the authenticated user's tenant to `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -529,9 +547,9 @@ curl https://api.example.com/openapi.json \
 }
 ```
 
-### ボキャブラリマッピングのための Property @context
+### 語彙マッピングのための @context プロパティ
 
-`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致するボキャブラリを確認し、それを `@context` 値として設定してください。
+各プロパティには`propertyDetails`オプションの`@context`フィールドを HTTP(S) URL として含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html)で一致する語彙を確認し、それを`@context`値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -554,7 +572,7 @@ config tool:
       # No @context → auto-generated URL
 ```
 
-生成される JSON-LD `@context` は次のようになります:
+生成される JSON-LD`@context`は次のようになります:
 
 ```json
 {
@@ -566,74 +584,84 @@ config tool:
 }
 ```
 
-プロパティ URI はエンティティタイプに依存しません。同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
+プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名(例:`email`)は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
-### @context 解決の拡張
+### @context 解決拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに`contextUrl`が設定されている場合、カスタムコンテキストが自動的にレスポンスの`@context`に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの`@context`を使用してエンティティのセマンティック情報を解釈できます。
 
 ## AI コーディングアシスタントを使用した JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は、AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は、追加の設定なしで完全なパブリック API を自動的に発見できます。
+GeonicDB JavaScript SDK(`@geolonia/geonicdb-sdk`)は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント(Claude Code、Cursor、GitHub Copilot など)は追加の設定なしで完全な公開 API を自動的に発見できます。
 
 ### AI ツールが SDK から学習する内容
 
-| 情報 | ソース |
-|------------|--------|
-| コンストラクタオプション | `GeonicDBOptions` 型 |
-| メソッドシグネチャ (17 メソッド) | TypeScript 宣言 |
-| 認証情報の型 | `CredentialsOptions`、`RefreshedCredentials` 型 |
-| クエリパラメータ | `GetEntitiesParams` 型 |
-| サブスクリプションオプション | `SubscribeOptions` 型 |
-| イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言にドキュメント化 |
+| 情報                 | ソース                                          |
+| ------------------ | -------------------------------------------- |
+| コンストラクタオプション       | `GeonicDBOptions`型                           |
+| メソッドシグネチャ(17 メソッド) | TypeScript 宣言                                |
+| 認証情報の型             | `CredentialsOptions`、`RefreshedCredentials`型 |
+| クエリパラメータ           | `GetEntitiesParams`型                         |
+| サブスクリプションオプション     | `SubscribeOptions`型                          |
+| イベントペイロード          | `EntityEvent`、`ReconnectingEvent`型           |
+| 全 10 種類のイベントタイプ    | 型宣言内に文書化                                     |
 
 ### 仕組み
 
-1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取る
-4. AI がドキュメント化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、完全な型チェックと IDE のオートコンプリートがそのまま利用できます。詳細は SDK ドキュメントを参照してください。
+1. 開発者が SDK をインストールします:`npm install @geolonia/geonicdb-sdk`
+   
+2. 開発者が SDK をインポートします:`import GeonicDB from '@geolonia/geonicdb-sdk'`
+   
+3. AI がパッケージから TypeScript 宣言を読み取ります
+   
+4. AI が文書化された API を使用して正しいコードを生成します
+
+別途ドキュメント URL や特別な設定は必要ありません。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細については、SDK ドキュメントを参照してください。
 
 ## A2A (Agent-to-Agent Protocol) サポート
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できます。
+GeonicDB は [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/) をサポートしており、標準化されたエージェント間通信を通じて他の AI エージェントがコンテキストブローカーと対話できます。
 
 ### エンドポイント
 
-| エンドポイント | メソッド | 説明 |
-|----------|--------|-------------|
-| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証方法を記述 |
-| `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
+| エンドポイント                        | メソッド | 説明                              |
+| ------------------------------ | ---- | ------------------------------- |
+| `/.well-known/agent-card.json` | GET  | エージェントカード — 機能、スキル、認証について記述     |
+| `/a2a`                         | POST | A2A 操作のための JSON-RPC 2.0 エンドポイント |
 
 ### サポートされているメソッド (フェーズ 1)
 
-| JSON-RPC メソッド | 説明 |
-|-----------------|-------------|
-| `message/send` | メッセージを送信し、同期的なレスポンスを受信 |
-| `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションによるタスクの一覧表示 |
-| `tasks/cancel` | タスクのキャンセルをリクエスト |
+| JSON-RPC メソッド  | 説明                             |
+| -------------- | ------------------------------ |
+| `message/send` | メッセージを送信し、同期レスポンスを受信           |
+| `tasks/get`    | タスクの現在の状態を取得                   |
+| `tasks/list`   | フィルタリングとページネーションを使用してタスクをリスト表示 |
+| `tasks/cancel` | タスクのキャンセルを要求                   |
 
 ### スキル
 
 A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピングされます:
 
-| スキル ID | 説明 |
-|----------|-------------|
-| `entities` | NGSI-LD エンティティの CRUD、地理空間/属性検索 |
-| `batch` | 一括作成、アップサート、更新、削除操作 |
-| `temporal` | 時系列データ管理 |
-| `config` | リアクティブルール、JSON-LD コンテキスト、データモデル |
-| `admin` | ユーザー、テナント、ポリシー管理 |
+| スキル ID     | 説明                              |
+| ---------- | ------------------------------- |
+| `entities` | NGSI-LD エンティティの CRUD、地理空間/属性検索  |
+| `batch`    | 一括作成、アップサート、更新、削除操作             |
+| `temporal` | 時系列データ管理                        |
+| `config`   | リアクティブルール、JSON-LD コンテキスト、データモデル |
+| `admin`    | ユーザー、テナント、ポリシー管理                |
 
 ### 認証
 
-A2A は REST API と同じ認証方法を使用します:
-- **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
-- **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` によるクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効な場合)
+A2A は REST API と同じ認証方式を使用します:
+
+* **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
+  
+* **API Key**: `X-Api-Key: <key>` ヘッダー
+  
+* **OAuth 2.0**: Client credentials フローによる `POST /oauth/token`
+  
+* **DPoP**: `Authorization: DPoP <token>` + `DPoP` proof ヘッダー (有効化されている場合)
 
 `Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
 
@@ -665,15 +693,22 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 ### MCP との関係
 
 A2A と MCP は補完的な関係にあります:
-- **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして連携
 
-両方とも同じ基盤となるサービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートしています。
+* **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
+  
+* **A2A** はエージェント間通信用 — AI エージェントが GeonicDB をピアエージェントとして協調
+
+両者は同じ基盤サービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
 ## 参考文献
 
-- [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
-- [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
-- [Model Context Protocol](https://modelcontextprotocol.io/)
-- [A2A Protocol](https://google.github.io/A2A/)
-- [llms.txt](https://llmstxt.org/)
+
+* [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+  
+* [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
+  
+* [Model Context Protocol](https://modelcontextprotocol.io/)
+  
+* [A2A Protocol](https://google.github.io/A2A/)
+  
+* [llms.txt](https://llmstxt.org/)

--- a/docs/ja/ai-integration/tools-json.md
+++ b/docs/ja/ai-integration/tools-json.md
@@ -3,52 +3,57 @@ title: "tools.json"
 description: "AI tool definitions (tools.json)"
 outline: deep
 ---
-# AI インテグレーション
+# AI 統合
 
-GeonicDB は、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるように、複数の AI 向けインターフェースを提供しています。
+GeonicDB は複数の AI 指向インターフェースを提供しており、AI エージェント (Claude、GPT-4、Gemini など) が API を簡単に利用できるようになっています。
 
 ## エンドポイント一覧
 
-| エンドポイント | フォーマット | 説明 |
-|---------------|------|------|
-| `GET /llms.txt` | Markdown (llms.txt) | LLM 向け API ドキュメント |
-| `GET /tools.json` | JSON | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
-| `GET /.well-known/ai-plugin.json` | JSON | AI プラグインマニフェスト |
-| `GET /openapi.json` | JSON | OpenAPI 3.0 仕様 |
-| `GET /api.json` | JSON | API リファレンス |
+| エンドポイント                           | 形式                  | 説明                                               |
+| --------------------------------- | ------------------- | ------------------------------------------------ |
+| `GET /llms.txt`                   | Markdown (llms.txt) | LLM 向け API ドキュメント                                |
+| `GET /tools.json`                 | JSON                | Claude Tool Use / OpenAI Function Calling 互換スキーマ |
+| `GET /.well-known/ai-plugin.json` | JSON                | AI プラグインマニフェスト                                   |
+| `GET /openapi.json`               | JSON                | OpenAPI 3.0 仕様                                   |
+| `GET /api.json`                   | JSON                | API リファレンス                                       |
 
 ## Tool Use スキーマ (`/tools.json`
+
 )
 
 Claude Tool Use および OpenAI Function Calling と互換性のあるツール定義を提供します。
 
-### 利用可能なツール (5 つのツール)
+### 利用可能なツール (5 ツール)
 
-各ツールは `action` および `resource` パラメータで操作を選択します。
+各ツールは `action` と `resource` パラメータを介して操作を選択します。
 
-| ツール名 | リソース | アクション | 説明 |
-|---------|---------|-----------|------|
-| `entities` | entities (デフォルト)、types、attributes | list、get、create、update、delete、replace、search_by_location、search_by_attribute、get_info、get_all、append、patch_all、patch | IoT エンティティ、タイプ、属性の管理 |
-| `batch` | - | create、upsert、update、merge、delete、query、purge | 一括エンティティ操作 (最大 1,000 アイテム) |
-| `temporal` | - | get、query、create、delete、add_attributes、delete_attribute、merge、modify_instance、delete_instance、batch_create、batch_upsert、batch_delete、batch_query | 時系列データ管理 |
-| `config` | rules、jsonld_contexts、data_models、cadde_config | list、get、create、update、delete、activate、deactivate、list_domains、list_models、get_model、generate_template | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理 (super_admin、get/update/delete) |
-| `admin` | users、tenants、policies | list、get、create、update、delete、activate、deactivate、change_password | ユーザー、テナント、ポリシー管理 (認証が必要) |
+| ツール名       | リソース                                              | アクション                                                                                                                                                    | 説明                                                                                                                     |
+| ---------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `entities` | entities (デフォルト)、types、attributes                 | list、get、create、update、delete、replace、search\_by\_location、search\_by\_attribute、get\_info、get\_all、append、patch\_all、patch                              | IoT エンティティ、タイプ、および属性の管理                                                                                                |
+| `batch`    | -                                                 | create、upsert、update、merge、delete、query、purge                                                                                                            | 一括エンティティ操作(最大 1,000 アイテム)                                                                                              |
+| `temporal` | -                                                 | get、query、create、delete、add\_attributes、delete\_attribute、merge、modify\_instance、delete\_instance、batch\_create、batch\_upsert、batch\_delete、batch\_query | 時系列データ管理                                                                                                               |
+| `config`   | rules、jsonld\_contexts、data\_models、cadde\_config | list、get、create、update、delete、activate、deactivate、list\_domains、list\_models、get\_model、generate\_template                                               | ReactiveCore ルール、JSON-LD コンテキスト、Smart Data Models、カスタムデータモデル管理、テンプレート生成、および CADDE 設定管理(super\_admin、get/update/delete) |
+| `admin`    | users、tenants、policies                            | list、get、create、update、delete、activate、deactivate、change\_password                                                                                       | ユーザー、テナント、およびポリシー管理(認証が必要)                                                                                             |
 
-### NGSI-LD 属性タイプの自動検出
+### 自動 NGSI-LD 属性タイプ検出
 
-MCP ツールは、属性値から NGSI-LD タイプを自動的に推論します:
+MCP ツールは属性値から NGSI-LD タイプを自動的に推論します:
 
-| 値のパターン | 検出されるタイプ | 例 |
-|------------|-----------|-----|
-| `urn:` で始まる文字列 | `Relationship` | `"urn:ngsi-ld:Building:001"` |
-| GeoJSON オブジェクト (Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty` | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
-| `languageMap` フィールドを含むオブジェクト | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
-| その他すべての値 | `Property` | `25.5`、`"text"`、`true`、`[1, 2, 3]` |
+| 値のパターン                                                                           | 検出されるタイプ           | 例                                                 |
+| -------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------- |
+| 文字列が `urn:`                                                                      | `Relationship`     | `"urn:ngsi-ld:Building:001"`                      |
+| GeoJSON オブジェクト(Point、Polygon、LineString、MultiPoint、MultiPolygon、MultiLineString) | `GeoProperty`      | `{"type": "Point", "coordinates": [139.7, 35.6]}` |
+| オブジェクトに `languageMap` フィールドが含まれる                                                 | `LanguageProperty` | `{"languageMap": {"en": "Hello", "ja": "こんにちは"}}` |
+| その他すべての値                                                                         | `Property`         | `25.5`、`"text"`、`true`、`[1, 2, 3]`                |
 
 タイプを明示的に指定することもできます:
-- `{"type": "Property", "value": 25.5}`
-- `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
-- `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
+
+* `{"type": "Property", "value": 25.5}`
+  
+* `{"type": "Relationship", "object": "urn:ngsi-ld:Building:001"}`
+  
+* `{"type": "GeoProperty", "value": {"type": "Point", "coordinates": [139.7, 35.6]}}`
+
 ### レスポンス構造
 
 ```json
@@ -81,9 +86,10 @@ MCP ツールは、属性値から NGSI-LD タイプを自動的に推論しま�
 ```
 
 ## AI プラグインマニフェスト (`/.well-known/ai-plugin.json`
+
 )
 
-API 検出情報を提供します。
+API ディスカバリー情報を提供します。
 
 ```json
 {
@@ -152,16 +158,20 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
-- **プロトコルバージョン**: 2025-03-26
-- **動作モード**: ステートレス (Lambda 互換)
-- **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
 
-### Claude Desktop の設定
+* **エンドポイント**: `POST /mcp`
+  
+* **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+  
+* **プロトコルバージョン**: 2025-03-26
+  
+* **動作モード**: ステートレス (Lambda 互換)
+  
+* **認証**: `AUTH_ENABLED=true` の場合、アクセス制御とテナント分離は JWT Bearer トークンを介して適用されます
 
+### Claude Desktop 設定
 
-
-### ローカル開発 (認証なし)
+#### ローカル開発(認証なし)
 
 ```json
 {
@@ -180,11 +190,9 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-> **注意**: `--transport http-only` が必要です。GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できません。`--allow-http` は `http://` URL に必要です (本番環境の `https://` では不要です)。
+> **注意**: `--transport http-only` は必須です。GeonicDB は Streamable HTTP (POST) のみをサポートしており、SSE は利用できません。`--allow-http` は `http://` URL に必要です(本番環境の `https://` には不要です)。
 
-
-
-### 本番環境 (JWT 認証を使用)
+#### 本番環境(JWT 認証あり)
 
 ```json
 {
@@ -204,21 +212,19 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 }
 ```
 
-JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンには有効期限があり、定期的な更新が必要です。
+JWT トークンは `/auth/login` エンドポイントから取得できます。JWT トークンは有効期限があり、定期的な更新が必要です。
 
+#### 本番環境(API キー認証あり)
 
+API キーは有効期限がなく、Claude Desktop のような長期間の統合に推奨されます。
 
-### 本番環境 (API キー認証を使用)
-
-API キーには有効期限がなく、Claude Desktop などの長期間使用する統合に推奨されます。
-
-**ステップ 1: GeonicDB CLI のインストール**
+**ステップ 1: GeonicDB CLI をインストール**
 
 ```bash
 npm install -g @geolonia/geonicdb-cli
 ```
 
-**ステップ 2: ログインと CLI の設定**
+**ステップ 2: ログインして CLI を設定**
 
 ```bash
 # Set the server URL
@@ -228,7 +234,7 @@ geonic config set url https://geonicdb.geolonia.com
 geonic auth login
 ```
 
-**ステップ 3: API キーの作成**
+**ステップ 3: API キーを作成**
 
 ```bash
 geonic me api-keys create \
@@ -239,24 +245,28 @@ geonic me api-keys create \
   --save
 ```
 
-> **重要**: API キー (`gdb_` プレフィックスの文字列) は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
+> **重要**: API キー(`gdb_` プレフィックスの文字列)は作成時に一度だけ表示されます。安全に保管してください。`--save` フラグは、自動使用のために CLI 設定にキーを保存します。
 
 API キーで利用可能なスコープ:
 
-| スコープ | 説明 |
-|---|---|
-| `read:entities` | エンティティ、タイプ、属性の読み取り |
-| `write:entities` | エンティティの作成、更新、削除 |
-| `read:subscriptions` | サブスクリプションの読み取り |
+| スコープ                  | 説明                 |
+| --------------------- | ------------------ |
+| `read:entities`       | エンティティ、タイプ、属性の読み取り |
+| `write:entities`      | エンティティの作成、更新、削除    |
+| `read:subscriptions`  | サブスクリプションの読み取り     |
 | `write:subscriptions` | サブスクリプションの作成、更新、削除 |
-| `read:registrations` | コンテキストソース登録の読み取り |
-| `write:registrations` | 登録の作成、更新、削除 |
+| `read:registrations`  | コンテキストソース登録の読み取り   |
+| `write:registrations` | 登録の作成、更新、削除        |
 
-**ステップ 4: Claude Desktop の設定**
+**ステップ 4: Claude Desktop を設定**
 
-Claude Desktop の設定ファイルを編集します:
+Claude Desktop 設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+* **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+  
+* **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
 ```json
 {
   "mcpServers": {
@@ -283,13 +293,11 @@ Claude Desktop の設定ファイルを編集します:
 
 > **注意**: `env` の値を実際の API キーとテナント名に置き換えてください。環境変数を使用することで、認証情報を `args` 配列の外に保持できます。
 
-**ステップ 5: Claude Desktop の再起動**
+**ステップ 5: Claude Desktop を再起動**
 
-設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されるはずです。
+設定を保存した後、Claude Desktop を完全に終了して再起動してください。GeonicDB MCP サーバーが利用可能なツールに表示されます。
 
-
-
-### API キーの管理
+#### API キーの管理
 
 ```bash
 # List your API keys
@@ -303,20 +311,23 @@ geonic me api-keys delete <key-id>
 
 各ツールには、操作の対象テナントを指定するための `tenant` パラメータがあります。
 
-- **認証が無効の場合**: 省略すると、`default` テナントが使用されます。
-- **認証が有効の場合**: 省略すると、ログイン中のユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
+
+* **認証が無効の場合**: 省略された場合、`default` テナントが使用されます。
+  
+* **認証が有効の場合**: 省略された場合、ログインユーザーのテナントがデフォルトとして使用されます。`super_admin` はデータツールを使用できません (403 を返します)。代わりに `tenant_admin` または `user` ロールを使用してください。ただし、`tenant_admin`/`user` は自分のテナントにのみアクセスできます。
 
 ### ServicePathの指定
 
-`entities`、`types`、`attributes`、`batch`、`temporal` の各ツールには、階層的なスコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+The `entities`、`types`、`attributes`、`batch`、および `temporal` ツールには、階層スコープ内でエンティティを管理できる `servicePath` パラメータがあります。
+
+#### 基本形式
 
 
-
-### 基本形式
-
-- **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
-- **デフォルト**: 省略した場合、ルートパス `/` が使用されます
-- **ユースケース**: 同じテナント内でエンティティをグループ化または分離するために使用されます
+* **形式**: `/` で始まるパス (例: `/hello`、`/city/sensors`)
+  
+* **デフォルト**: 省略された場合、ルートパス `/` が使用されます
+  
+* **使用例**: 同一テナント内でエンティティをグループ化または分離するために使用されます
 
 ```yaml
 # Get entities under the /hello path
@@ -326,12 +337,11 @@ entities tool:
   servicePath: "/hello"
 ```
 
+#### 階層検索 (`/#`
 
-
-### 階層検索 (`/#`
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。
+&#x20;サフィックスを使用すると、指定されたパスとそのすべての子パスを検索します。`/#` suffix searches the specified path and all its child paths.
 
 ```yaml
 # Search /Madrid/Gardens and its child paths (e.g., /Madrid/Gardens/ParqueNorte)
@@ -341,11 +351,9 @@ entities tool:
   servicePath: "/Madrid/Gardens/#"
 ```
 
+#### 複数パスの指定 (カンマ区切り)
 
-
-### 複数パスの指定 (カンマ区切り)
-
-カンマで区切ることで、複数のパス (最大 10 パス) を同時に検索できます。
+カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス)。
 
 ```yaml
 # Search both /park1 and /park2
@@ -359,22 +367,22 @@ entities tool:
 
 ### NGSI-LD クエリパラメータ
 
-`entities` ツールは、NGSI-LD クエリパラメータの完全なセットをサポートしています:
+The `entities` ツールは、NGSI-LD クエリパラメータの全セットをサポートしています:
 
-| パラメータ | 説明 | 例 |
-|---|---|---|
-| `idList` | 一括取得用のカンマ区切りエンティティ ID | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
-| `idPattern` | エンティティ ID にマッチする正規表現パターン | `"Room.*"` |
-| `orderBy` | 属性またはシステムフィールドでソート。降順の場合は `!` を接頭辞として付ける | `"createdAt"`、`"!modifiedAt"` |
-| `orderDirection` | ソート方向 (`!` 接頭辞の代替) | `"asc"`、`"desc"` |
-| `sysAttrs` | システム属性 (`createdAt`、`modifiedAt`) を結果に含める | `true` |
-| `pick` | 含める属性名のカンマ区切りリスト | `"temperature,humidity"` |
-| `omit` | 除外する属性名のカンマ区切りリスト | `"status"` |
-| `scopeQ` | スコープクエリ式 | `"/Madrid/Gardens"` |
-| `lang` | LanguageProperty 値の言語フィルタ | `"ja"` |
-| `geoproperty` | ジオクエリ用の GeoProperty 属性名 (デフォルト: `location`) | `"observationArea"` |
-| `spatialId` | ZFXY 形式の空間 ID | `"18/232814/103224"` |
-| `spatialIdDepth` | 空間 ID 階層検索の深さ | `2` |
+| パラメータ            | 説明                                           | 例                                             |
+| ---------------- | -------------------------------------------- | --------------------------------------------- |
+| `idList`         | 一括取得のためのカンマ区切りのエンティティ ID                     | `"urn:ngsi-ld:Room:001,urn:ngsi-ld:Room:002"` |
+| `idPattern`      | エンティティ ID にマッチする正規表現パターン                     | `"Room.*"`                                    |
+| `orderBy`        | 属性またはシステムフィールドでソート。降順の場合は接頭辞に `!` を付ける       | `"createdAt"`、`"!modifiedAt"`                 |
+| `orderDirection` | ソート方向(`!` 接頭辞の代替)                            | `"asc"`、`"desc"`                              |
+| `sysAttrs`       | 結果にシステム属性(`createdAt`、`modifiedAt`)を含める      | `true`                                        |
+| `pick`           | 含めるカンマ区切りの属性名                                | `"temperature,humidity"`                      |
+| `omit`           | 除外するカンマ区切りの属性名                               | `"status"`                                    |
+| `scopeQ`         | スコープクエリ式                                     | `"/Madrid/Gardens"`                           |
+| `lang`           | LanguageProperty 値の言語フィルタ                    | `"ja"`                                        |
+| `geoproperty`    | ジオクエリのための GeoProperty 属性名(デフォルト: `location`) | `"observationArea"`                           |
+| `spatialId`      | ZFXY 形式の空間 ID                                | `"18/232814/103224"`                          |
+| `spatialIdDepth` | 空間 ID 階層検索の深さ                                | `2`                                           |
 
 ```yaml
 # List entities sorted by creation time (newest first) with system attributes
@@ -398,7 +406,7 @@ entities tool:
   q: "temperature>20"
 ```
 
-`batch` ツールの `query` アクションも `orderBy`、`orderDirection`、`sysAttrs` をサポートしています。
+The `batch` ツールの `query` アクションも `orderBy`、`orderDirection`、および `sysAttrs` をサポートしています。
 
 ### 検証
 
@@ -424,21 +432,26 @@ curl -X POST http://localhost:3000/mcp \
 
 ### 制限事項
 
-- **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
-- **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp` (SSE) と `DELETE /mcp` (セッション終了) は 405 を返します。
-- **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで動作します。
-- **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です (例: エンティティの読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
-- **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、リクエストボディサイズ制限の対象となります。
+
+* **ステートレスモード**: Lambda 環境の制約により、SSE ストリーミングは利用できません。すべてのリクエストは JSON レスポンスとして返されます。
+  
+* **セッション管理なし**: 各リクエストは独立して処理されます。`GET /mcp`(SSE)および `DELETE /mcp`(セッション終了)は 405 を返します。
+  
+* **認証**: `AUTH_ENABLED=true` の場合、Bearer トークンが必要です。`AUTH_ENABLED=false` の場合、認証なしで操作が続行されます。
+  
+* **OAuth スコープ**: OAuth トークンを使用する場合、各 MCP ツール操作に対応する OAuth スコープが必要です(例: エンティティ読み取りには `read:entities`、書き込みには `write:entities`)。スコープ制限は JWT RBAC トークンには適用されません。
+  
+* **レート制限**: MCP エンドポイントは、REST API と同じレート制限、ストレージクォータ、およびリクエストボディサイズ制限の対象となります。
 
 ## JSON Schema とカスタムデータモデル
 
-カスタムデータモデルは作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は AI ツールで以下の目的に利用できます。
+カスタムデータモデルは、作成時に自動的に JSON Schema (Draft 2020-12) が生成されます。この JSON Schema は、AI ツールによって以下の目的で活用できます。
 
-**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかを制御します。デフォルトは `true` (NGSI-LD のセマンティクスに従い、追加属性を許可) です。`false` に設定すると厳密な検証が適用され、定義された属性のみが受け入れられます。AI エージェントはエンティティ作成時にこのフィールドを確認して、追加属性が許可されているかを判断する必要があります。
+**`additionalProperties` フィールド**: エンティティが `propertyDetails` で定義されていない属性を持つことができるかどうかを制御します。デフォルトは `true`(NGSI-LD セマンティクスに従い、任意の追加属性を許可)です。`false` に設定すると、厳密な検証が強制されます — 定義された属性のみが受け入れられます。AI エージェントは、エンティティを作成する際にこのフィールドをチェックして、追加の属性が許可されているかどうかを判断する必要があります。
 
 ### AI ツールでの使用例
 
-**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースを使用してカスタムデータモデルを取得し、`jsonSchema` フィールドを参照することで、正しい型と検証ルールに準拠したエンティティを生成できます。
+**エンティティ作成時のスキーマ参照**: AI エージェントは `config` ツールの `data_models` リソースと参照 `jsonSchema` フィールドを使用してカスタムデータモデルを取得し、正しい型と検証ルールに準拠したエンティティを生成できます。
 
 ```yaml
 # 1. Retrieve the JSON Schema for the custom data model
@@ -459,9 +472,9 @@ entities tool:
 
 **検証エラーの自動修正**: エンティティ作成時に検証エラーが返された場合、AI エージェントは JSON Schema を参照してエラーの原因を特定し、有効な値に修正できます。
 
-### エンティティテンプレート生成
+### エンティティテンプレートの生成
 
-`config` ツールの `generate_template` アクションを使用することで、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動生成できます。
+を使用して `generate_template` アクション `config` ツールを使用すると、カスタムデータモデルから NGSI-LD エンティティテンプレートを自動的に生成できます。
 
 ```yaml
 # Generate a template
@@ -493,15 +506,18 @@ config tool:
 ```
 
 テンプレートは以下の優先順位で値を決定します:
-1. `defaultValue` が定義されている場合はその値
-2. `example` の値が定義されている場合はその値
-3. `valueType` に基づくデフォルト値 (string → `""`、number → `0`、boolean → `false` など)
 
-AI エージェントはこのテンプレートをベースとして、ユーザーの指示に従って値を変更し、エンティティを作成できます。
+1. The `defaultValue` が定義されている場合
+   
+2. The `example` 値が定義されている場合
+   
+3. &#x20;に基づくデフォルト値 `valueType` (string → `""`、number → `0`、boolean → `false`、など)
+
+AI エージェントはこのテンプレートをベースとして使用し、ユーザーの指示に従って値を変更してエンティティを作成できます。
 
 ### OpenAPI 仕様との動的統合
 
-`/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールは、テナント固有のデータモデルを自動的に認識できるようになります。
+The `/openapi.json` エンドポイントは、認証されたユーザーのテナントに関連付けられたカスタムデータモデルの JSON Schema を `components/schemas` に動的に追加します。これにより、OpenAPI 仕様を参照する AI ツールやコード生成ツールが、テナント固有のデータモデルを自動的に認識できるようになります。
 
 ```bash
 # Retrieve the OpenAPI specification with authentication (includes custom schemas)
@@ -509,7 +525,7 @@ curl https://api.example.com/openapi.json \
   -H "Authorization: Bearer <accessToken>"
 ```
 
-カスタムデータモデルの JSON Schema は、レスポンスの `components.schemas` に追加されます:
+カスタムデータモデルの JSON Schema は `components.schemas` のレスポンスに追加されます:
 
 ```json
 {
@@ -531,7 +547,7 @@ curl https://api.example.com/openapi.json \
 
 ### 語彙マッピングのための Property @context
 
-`propertyDetails` の各プロパティには、HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。属性を定義する際は、[schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` の値として設定してください。
+各プロパティには `propertyDetails` オプションの `@context` フィールドに HTTP(S) URL を含めることができます。属性を定義する際は、 [schema.org](https://schema.org/docs/full.html) で一致する語彙を確認し、それを `@context` 値として設定してください。
 
 ```yaml
 # Create a model with schema.org vocabulary
@@ -554,7 +570,7 @@ config tool:
       # No @context → auto-generated URL
 ```
 
-生成される JSON-LD `@context` は以下のようになります:
+生成される JSON-LD `@context` は次のようになります:
 
 ```json
 {
@@ -566,76 +582,86 @@ config tool:
 }
 ```
 
-プロパティ URI はエンティティタイプに依存しません — 同じプロパティ名 (例: `email`) は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
+Property URI はエンティティタイプに依存しません — 同じプロパティ名(例: `email`)は、同じテナント内の異なるエンティティタイプ間で同じ URI を共有します。
 
-### @context 解決の拡張
+### @context 解決拡張
 
-NGSI-LD API を介してエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがレスポンスの `@context` に自動的に含まれます。Smart Data Models のコンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
+NGSI-LD API 経由でエンティティを取得する際、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはレスポンスの `@context` に自動的に含まれます。Smart Data Models コンテキストと同様に、AI エージェントはこの `@context` を使用してエンティティのセマンティック情報を解釈できます。
 
-## AI コーディングアシスタントを使用した JavaScript SDK
+## AI コーディングアシスタントによる JavaScript SDK
 
-GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント (Claude Code、Cursor、GitHub Copilot など) は追加設定なしで完全なパブリック API を自動的に認識できます。
+GeonicDB JavaScript SDK (`@geolonia/geonicdb-sdk`) は AI 支援開発向けに設計されています。npm パッケージには完全な TypeScript 型宣言が含まれているため、AI コーディングアシスタント(Claude Code、Cursor、GitHub Copilot など)は追加の設定なしで完全な公開 API を自動的に検出できます。
 
 ### AI ツールが SDK から学習する内容
 
-| 情報 | ソース |
-|------------|--------|
-| コンストラクタオプション | `GeonicDBOptions` 型 |
-| メソッドシグネチャ (17 メソッド) | TypeScript 宣言 |
-| 認証情報の型 | `CredentialsOptions`、`RefreshedCredentials` 型 |
-| クエリパラメータ | `GetEntitiesParams` 型 |
-| サブスクリプションオプション | `SubscribeOptions` 型 |
-| イベントペイロード | `EntityEvent`、`ReconnectingEvent` 型 |
-| 全 10 種類のイベントタイプ | 型宣言内に文書化 |
+| 情報                  | ソース                                           |
+| ------------------- | --------------------------------------------- |
+| コンストラクタオプション        | `GeonicDBOptions` 型                           |
+| メソッドシグネチャ (17 メソッド) | TypeScript 宣言                                 |
+| 認証情報タイプ             | `CredentialsOptions`、`RefreshedCredentials` 型 |
+| クエリパラメータ            | `GetEntitiesParams` 型                         |
+| サブスクリプションオプション      | `SubscribeOptions` 型                          |
+| イベントペイロード           | `EntityEvent`、`ReconnectingEvent` 型           |
+| 全 10 種類のイベントタイプ     | 型宣言にドキュメント化されています                             |
 
-### 動作の仕組み
+### 仕組み
 
-1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`3. AI がパッケージから TypeScript 宣言を読み取り
-4. AI が文書化された API を使用して正しいコードを生成
 
-別途ドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE のオートコンプリートが利用できます。詳細は SDK ドキュメントを参照してください。
+1. 開発者が SDK をインストール: `npm install @geolonia/geonicdb-sdk`
+   
+2. 開発者が SDK をインポート: `import GeonicDB from '@geolonia/geonicdb-sdk'`
+   
+3. AI がパッケージから TypeScript 宣言を読み取る
+   
+4. AI がドキュメント化された API を使用して正しいコードを生成
 
-## A2A (Agent-to-Agent プロトコル) サポート
+別途のドキュメント URL や特別な設定は不要です。TypeScript プロジェクトでは、すぐに完全な型チェックと IDE オートコンプリートが利用できます。詳細については SDK ドキュメントを参照してください。
 
-GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーと対話できるようにします。
+## A2A (Agent-to-Agent Protocol) サポート
+
+GeonicDB は [A2A (Agent-to-Agent) プロトコル](https://google.github.io/A2A/)をサポートしており、他の AI エージェントが標準化されたエージェント間通信を通じてコンテキストブローカーとやり取りすることを可能にします。
 
 ### エンドポイント
 
-| エンドポイント | メソッド | 説明 |
-|----------|--------|-------------|
-| `/.well-known/agent-card.json` | GET | エージェントカード — 機能、スキル、認証方法を記述 |
-| `/a2a` | POST | A2A 操作用の JSON-RPC 2.0 エンドポイント |
+| エンドポイント                        | メソッド | 説明                              |
+| ------------------------------ | ---- | ------------------------------- |
+| `/.well-known/agent-card.json` | GET  | エージェントカード — 機能、スキル、認証について記述     |
+| `/a2a`                         | POST | A2A 操作のための JSON-RPC 2.0 エンドポイント |
 
-### サポートされているメソッド (フェーズ 1)
+### サポートされるメソッド（フェーズ 1）
 
-| JSON-RPC メソッド | 説明 |
-|-----------------|-------------|
-| `message/send` | メッセージを送信し、同期レスポンスを受信 |
-| `tasks/get` | タスクの現在の状態を取得 |
-| `tasks/list` | フィルタリングとページネーションによるタスク一覧取得 |
-| `tasks/cancel` | タスクのキャンセルをリクエスト |
+| JSON-RPC メソッド  | 説明                       |
+| -------------- | ------------------------ |
+| `message/send` | メッセージを送信し、同期レスポンスを受信     |
+| `tasks/get`    | タスクの現在の状態を取得             |
+| `tasks/list`   | フィルタリングとページネーションでタスクをリスト |
+| `tasks/cancel` | タスクのキャンセルをリクエスト          |
 
 ### スキル
 
-A2A は MCP で利用可能な同じ 5 つのツールにマッピングされます:
+A2A は MCP 経由で利用可能な同じ 5 つのツールにマッピングされます:
 
-| スキル ID | 説明 |
-|----------|-------------|
-| `entities` | NGSI-LD エンティティの CRUD、地理空間/属性検索 |
-| `batch` | 一括作成、アップサート、更新、削除操作 |
-| `temporal` | 時系列データ管理 |
-| `config` | リアクティブルール、JSON-LD コンテキスト、データモデル |
-| `admin` | ユーザー、テナント、ポリシー管理 |
+| スキル ID     | 説明                              |
+| ---------- | ------------------------------- |
+| `entities` | NGSI-LD エンティティ CRUD、地理空間/属性検索   |
+| `batch`    | 一括作成、アップサート、更新、削除操作             |
+| `temporal` | 時系列データ管理                        |
+| `config`   | リアクティブルール、JSON-LD コンテキスト、データモデル |
+| `admin`    | ユーザー、テナント、ポリシー管理                |
 
 ### 認証
 
 A2A は REST API と同じ認証方法を使用します:
-- **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
-- **API キー**: `X-Api-Key: <key>` ヘッダー
-- **OAuth 2.0**: `POST /oauth/token` を介したクライアントクレデンシャルフロー
-- **DPoP**: `Authorization: DPoP <token>` + `DPoP` プルーフヘッダー (有効時)
 
-`Fiware-Service` ヘッダーによるテナント指定を推奨します(未指定時はデフォルトテナントにフォールバック)。
+* **Bearer JWT**: `Authorization: Bearer <token>` ヘッダー
+  
+* **API Key**: `X-Api-Key: <key>` ヘッダー
+  
+* **OAuth 2.0**: Client credentials フロー（ `POST /oauth/token` 経由）
+  
+* **DPoP**: `Authorization: DPoP <token>` + `DPoP` proof ヘッダー（有効時）
+
+`Fiware-Service` ヘッダーによるテナント指定を推奨します（未指定時はデフォルトテナントにフォールバック）。
 
 ### 例: メッセージの送信
 
@@ -665,15 +691,22 @@ curl -X POST https://your-geonicdb.example.com/a2a \
 ### MCP との関係
 
 A2A と MCP は補完的な関係にあります:
-- **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
-- **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-両者は同じ基盤サービス層を共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
+* **MCP** はツール呼び出し用 — AI エージェントが GeonicDB をツールとして使用
+  
+* **A2A** はエージェント間通信用 — AI エージェントが GeonicDB とピアエージェントとして協調
 
-## 参考資料
+両者は同じ基礎サービスレイヤーを共有し、同じ 5 つのスキル/ツールカテゴリをサポートします。
 
-- [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
-- [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
-- [Model Context Protocol](https://modelcontextprotocol.io/)
-- [A2A Protocol](https://google.github.io/A2A/)
-- [llms.txt](https://llmstxt.org/)
+## 参考文献
+
+
+* [Claude Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use)
+  
+* [OpenAI Function Calling](https://platform.openai.com/docs/guides/function-calling)
+  
+* [Model Context Protocol](https://modelcontextprotocol.io/)
+  
+* [A2A Protocol](https://google.github.io/A2A/)
+  
+* [llms.txt](https://llmstxt.org/)

--- a/docs/ja/api-reference/endpoints.md
+++ b/docs/ja/api-reference/endpoints.md
@@ -9,34 +9,54 @@ outline: deep
 
 ## 目次
 
-- [概要](#概要)
-- [認証とマルチテナンシー](#認証とマルチテナンシー)
-- [ページネーション](#ページネーション)
-- [認証 API](#認証-api)
-- [メタエンドポイント](#メタエンドポイント)
-- [NGSIv2 API](#ngsiv2-api) (→ [API_NGSIV2.md](./ngsiv2.md))
-- [NGSI-LD API](#ngsi-ld-api) (→ [API_NGSILD.md](./ngsild.md))
-- [クエリ言語](#クエリ言語)
-- [ジオクエリ](#ジオクエリ)
-- [空間 ID 検索](#空間-id-検索)
-- [GeoJSON 出力](#geojson-出力)
-- [ベクタータイル](#ベクタータイル)
-- [座標参照系 (CRS)](#座標参照系-crs)
-- [データカタログ API](#データカタログ-api)
-- [CADDE 統合](#cadde-統合)
-- [イベントストリーミング](#イベントストリーミング)
-- [エラーレスポンス](#エラーレスポンス)
-- [実装状況](#実装状況)
 
----
+* [概要](#overview)
+  
+* [認証とマルチテナンシー](#認証とマルチテナンシー)
+  
+* [ページネーション](#ページネーション)
+  
+* [認証 API](#認証-api)
+  
+* [メタエンドポイント](#メタエンドポイント)
+  
+* [NGSIv2 API](#ngsiv2-api) (→ [API\_NGSIV2.md](./ngsiv2.md))
+  
+* [NGSI-LD API](#ngsi-ld-api) (→ [API\_NGSILD.md](./ngsild.md))
+  
+* [クエリ言語](#クエリ言語)
+  
+* [ジオクエリ](#ジオクエリ)
+  
+* [空間 ID 検索](#空間-id-検索)
+  
+* [GeoJSON 出力](#geojson-出力)
+  
+* [ベクトルタイル](#vector-tiles)
+  
+* [座標参照系 (CRS)](#座標参照系-crs)
+  
+* [データカタログ API](#data-catalog-api)
+  
+* [CADDE 統合](#cadde-統合)
+  
+* [イベントストリーミング](#イベントストリーミング)
+  
+* [エラーレスポンス](#エラーレスポンス)
+  
+* [実装状況](#実装状況)
+
+***
 
 ## 概要
 
 この Context Broker は、FIWARE NGSI (Next Generation Service Interface) 仕様に準拠した RESTful API を提供します。
 
 **関連ドキュメント:**
-- [NGSIv2 / NGSI-LD 互換性ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の互換性、型マッピング、ベストプラクティス
-- [WebSocket イベントストリーミング](../features/subscriptions.md) - リアルタイムイベントサブスクリプション、実装例、ベストプラクティス
+
+* [NGSIv2 / NGSI-LD 相互運用ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の相互運用性、型のマッピング、およびベストプラクティス
+  
+* [WebSocket イベントストリーミング](../features/subscriptions.md) - リアルタイムイベントサブスクリプション、実装例、およびベストプラクティス
 
 ### ベース URL
 
@@ -44,20 +64,20 @@ outline: deep
 https://{api-gateway-url}/{stage}
 ```
 
-### サポートされている API
+### サポートされる API
 
-| API バージョン | ベースパス | Content-Type |
-|-------------|-----------|--------------|
-| NGSIv2 | `/v2` | `application/json` |
-| NGSI-LD | `/ngsi-ld/v1` | `application/ld+json` |
+| API バージョン | ベースパス         | Content-Type          |
+| --------- | ------------- | --------------------- |
+| NGSIv2    | `/v2`         | `application/json`    |
+| NGSI-LD   | `/ngsi-ld/v1` | `application/ld+json` |
 
 ### OPTIONS メソッド
 
-`OPTIONS` メソッドはすべてのエンドポイントでサポートされています。CORS プリフライトリクエストに対して、許可されたメソッドとヘッダーに関する情報を返します。
+The `OPTIONS` メソッドはすべてのエンドポイントでサポートされています。これは CORS プリフライトリクエストに応じて、許可されたメソッドとヘッダーに関する情報を返します。
 
 #### レスポンス形式
 
-OPTIONS リクエストは `204 No Content` を返し、以下のヘッダーが含まれます:
+OPTIONS リクエストは `204 No Content` を次のヘッダーと共に返します:
 
 ```http
 OPTIONS /v2/entities/urn:ngsi-ld:Room:Room1
@@ -84,35 +104,40 @@ Access-Control-Allow-Headers: Content-Type, NGSILD-Tenant, Fiware-Service, Link,
 Access-Control-Max-Age: 86400
 ```
 
-> **注意**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証や SDK の条件付きリクエストがプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
+> **注記**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証と SDK 条件付きリクエストがプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
 
 ### エンティティ ID の一意性 (GeonicDB 拡張)
 
-> **GeonicDB 拡張**: この動作は、同じ ID で異なる型を持つエンティティの共存を許可する標準 NGSIv2 仕様とは異なります。
+> **GeonicDB 拡張**: この動作は標準の NGSIv2 仕様とは異なります。標準仕様では、同じ ID でも異なる型を持つエンティティが共存することが許可されています。
 
-GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の一部では **ありません**。
+GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の **一部ではありません**。
 
 **主な動作:**
 
-- 既存のエンティティと同じ ID でエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- バッチ upsert 操作は `entityId` のみでエンティティをマッチングします (型は上書き可能)
-- 同一 ID のエンティティ間で型を区別するための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
 
-この設計は NGSI-LD 仕様に準拠しており、エンティティ ID は URI であり、本質的に一意です。エンティティ ID は、テナント、servicePath、プロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
+* 既存のエンティティと同じ ID を持つエンティティを作成すると (異なる `type` であっても) `409 AlreadyExists` を返します
+  
+* &#x20;のみでエンティティを照合します (型は上書き可能)
+  
+`entityId` のみでエンティティを照合します (型は上書き可能)
+  
+* NGSIv2 の `?type=` クエリパラメータ (同じ ID を持つエンティティ間の型による曖昧性解消のため) は適用されなくなりました
 
----
+この設計は NGSI-LD 仕様に沿ったものであり、エンティティ ID は URI であり本質的に一意です。エンティティ ID は、テナント、servicePath、およびプロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
+
+***
 
 ## 認証とマルチテナンシー
 
 ### 必須ヘッダー
 
-すべてのリクエストには、以下のヘッダーを含めることを推奨します:
+すべてのリクエストには以下のヘッダーを含めることが推奨されます:
 
-| ヘッダー | 必須 | 説明 | デフォルト |
-|--------|------|------|---------|
-| `Fiware-Service` / `NGSILD-Tenant` | 推奨 | テナント名 (英数字とアンダースコアのみ) | `default` |
-| `Fiware-ServicePath` | NGSIv2 のみ | テナント内の階層パス (`/` で開始)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/` (クエリ時は `/#` と同等) |
-| `Fiware-Correlator` | オプション | リクエストトレーシング用の相関 ID | 自動生成 |
+| ヘッダー                               | 必須        | 説明                                                                                          | デフォルト               |
+| ---------------------------------- | --------- | ------------------------------------------------------------------------------------------- | ------------------- |
+| `Fiware-Service` / `NGSILD-Tenant` | 推奨        | テナント名(英数字とアンダースコアのみ)                                                                        | `default`           |
+| `Fiware-ServicePath`               | NGSIv2 のみ | テナント内の階層パス(`/` で始まる)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/`(クエリでは `/#` と同等) |
+| `Fiware-Correlator`                | オプション     | リクエストトレーシングのための相関 ID                                                                        | 自動生成                |
 
 ### 使用例
 
@@ -122,21 +147,28 @@ curl -X GET "https://api.example.com/v2/entities" \
   -H "Fiware-ServicePath: /buildings/floor1"
 ```
 
-### テナントの分離
+### テナント分離
 
-- 異なる `Fiware-Service` 値のデータは完全に分離されます
-- 同じテナント内では、`Fiware-ServicePath` を使用してデータを階層的に整理できます
-- テナント名は自動的に小文字に変換されます
+
+* 異なる `Fiware-Service` 値のデータは完全に分離されます
+  
+* 同じテナント内では、`Fiware-ServicePath` を使用してデータを階層的に整理できます
+  
+* テナント名は自動的に小文字に変換されます
 
 ### ServicePathの仕様
 
-[FIWARE Orion 仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html) に準拠しています。
+Conforms to the [FIWARE Orion 仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html)に準拠しています。
 
 #### 基本形式
 
-- `/` で始まる絶対パスのみ許可されます
-- 英数字とアンダースコアのみ許可されます
-- 最大 10 階層、各レベル最大 50 文字
+
+* &#x20;で始まる絶対パスのみが許可されます
+  
+`/`英数字とアンダースコアのみが許可されます
+  
+* 最大 10 レベル、1レベルあたり最大 50 文字
+* 階層検索(
 
 ```bash
 # Retrieve entities at a specific path
@@ -145,10 +177,11 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /Madrid/Gardens"
 ```
 
-#### 階層検索 (`/#`
+#### 階層検索(`/#`
+
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます (**クエリ操作のみ**)。
+&#x20;サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます(`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます(**クエリ操作のみ**)。
 
 ```bash
 # Search /Madrid/Gardens and all its child paths
@@ -157,9 +190,9 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /Madrid/Gardens/#"
 ```
 
-#### 複数パス (カンマ区切り)
+#### 複数パス(カンマ区切り)
 
-カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス、**クエリ操作のみ**)。
+カンマで区切ることで、複数のパスを同時に検索できます(最大 10 パス、**クエリ操作のみ**)。
 
 ```bash
 # Search both /park1 and /park2
@@ -168,16 +201,16 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /park1, /park2"
 ```
 
-#### デフォルト動作
+#### デフォルトの動作
 
-| 操作 | ヘッダー省略時 | 説明 |
-|------|--------------|------|
-| クエリ (GET) | `/` | ルートパスのみ検索 |
-| 書き込み (POST/PUT/PATCH/DELETE) | `/` | ルートパスで作成/更新 |
+| 操作                          | ヘッダーが省略された場合 | 説明          |
+| --------------------------- | ------------ | ----------- |
+| クエリ(GET)                    | `/`          | ルートパスのみを検索  |
+| 書き込み(POST/PUT/PATCH/DELETE) | `/`          | ルートパスに作成/更新 |
 
-**注意**: 書き込み操作では、単一の非階層パスのみ使用できます。`/#` や複数パスを指定するとエラーになります。
+**注意**: 書き込み操作では、単一の非階層パスのみを使用できます。`/#` または複数パスを指定するとエラーになります。
 
----
+***
 
 ## ページネーション
 
@@ -185,41 +218,41 @@ curl "http://localhost:3000/v2/entities" \
 
 ### パラメータ
 
-| パラメータ | 説明 | デフォルト | 最大値 |
-|-----------|-------------|---------|---------|
-| `limit` | 返される結果の最大数 | 20 | 1000 (Admin API: 100) |
-| `offset` | スキップする結果の数 | 0 | - |
+| パラメータ    | 説明         | デフォルト | 最大値                   |
+| -------- | ---------- | ----- | --------------------- |
+| `limit`  | 返される結果の最大数 | 20    | 1000 (Admin API: 100) |
+| `offset` | スキップする結果の数 | 0     | -                     |
 
 ### レスポンスヘッダー
 
-各 API タイプごとに、合計数を示すヘッダーが返されます:
+各 API タイプには、合計カウントを示すヘッダーが返されます:
 
-| API | ヘッダー名 | 条件 |
-|-----|-------------|-----------|
-| NGSIv2 | `Fiware-Total-Count` | 常に返される (すべてのリストエンドポイント) |
-| NGSI-LD | `NGSILD-Results-Count` | 常に返される |
-| Admin API | `X-Total-Count` | 常に返される |
-| Catalog API | `X-Total-Count` | 常に返される |
+| API         | ヘッダー名                  | 条件                     |
+| ----------- | ---------------------- | ---------------------- |
+| NGSIv2      | `Fiware-Total-Count`   | 常に返される(すべてのリストエンドポイント) |
+| NGSI-LD     | `NGSILD-Results-Count` | 常に返される                 |
+| Admin API   | `X-Total-Count`        | 常に返される                 |
+| Catalog API | `X-Total-Count`        | 常に返される                 |
 
 ### Link ヘッダー
 
-すべてのリストエンドポイントは、[RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) に準拠した `Link` ヘッダーを返し、次のページ (`rel="next"`) と前のページ (`rel="prev"`) の URL を提供します。結果が 1 ページに収まる場合、`Link` ヘッダーは返されません。
+すべてのリストエンドポイントは `Link` ヘッダーを返します。これは [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) に準拠しており、次のページ(`rel="next"`)と前のページ(`rel="prev"`)の URL を提供します。結果が単一ページに収まる場合、`Link` ヘッダーは返されません。
 
 ```http
 Link: <https://api.example.com/v2/entities?limit=10&offset=20>; rel="next", <https://api.example.com/v2/entities?limit=10&offset=0>; rel="prev"
 ```
 
-### 検証
+### バリデーション
 
 無効なページネーションパラメータは `400 Bad Request` を返します:
 
-| エラー条件 | エラーメッセージ |
-|-----------------|---------------|
-| 負の limit | `Invalid limit: must not be negative` |
-| 負の offset | `Invalid offset: must not be negative` |
-| limit=0 | `Invalid limit: must be greater than 0` |
-| 最大値を超過 | `Invalid limit: must not exceed 1000` |
-| 数値以外 | `Invalid limit: must be a valid integer` |
+| エラー条件     | エラーメッセージ                                 |
+| --------- | ---------------------------------------- |
+| 負の limit  | `Invalid limit: must not be negative`    |
+| 負の offset | `Invalid offset: must not be negative`   |
+| limit=0   | `Invalid limit: must be greater than 0`  |
+| 最大値を超過    | `Invalid limit: must not exceed 1000`    |
+| 数値以外      | `Invalid limit: must be a valid integer` |
 
 ### 使用例
 
@@ -233,55 +266,57 @@ curl "http://localhost:3000/v2/entities?limit=10&options=count" \
   -H "Fiware-Service: smartcity"
 ```
 
-### 注意事項
+### 注記
 
-- `offset` が合計数を超える場合、空の配列が返されます (エラーではありません)
-- FIWARE Orion の仕様に準拠しています
 
----
+* もし `offset` が合計カウントを超えた場合、空の配列が返されます(エラーではありません)
+  
+* FIWARE Orion 仕様に準拠しています
 
-## HTTP キャッシュコントロール (ETag / 条件付きリクエスト)
+***
 
-GET エンドポイントはエンドポイントクラスに基づいてキャッシュ関連ヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップでき、[RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠しています。
+## HTTP キャッシュ制御 (ETag / 条件付きリクエスト)
+
+GET エンドポイントは、エンドポイントクラスに基づいてキャッシュ関連のヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップできます。これは [RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠しています。
 
 ### エンドポイントクラス
 
-| クラス | エンドポイント | バリデータ (ETag/Last-Modified) | 条件付きリクエスト | Cache-Control |
-|-------|-----------|-------------------------------|----------------------|---------------|
-| **Data** | `/v2/entities` (リスト、単一、attrs、attrs/{name}、attrs/{name}/value)、`/v2/subscriptions`、`/v2/registrations`、`/ngsi-ld/v1/entities` (リスト、単一、attrs、attrs/{name})、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions` | ✓ | ✓ (`If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache` |
-| **Temporal** | `/ngsi-ld/v1/temporal/entities` (リストと単一、集約を含む) | ✗ (ETag なし — 時系列集約には安価な単調バリデータがない) | ✗ | `private, no-cache` |
-| **Meta** | `/v2/types`、`/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes` (リストと単一) | ✗ (ETag なし、Last-Modified なし) | ✗ (`304` サポートなし) | `max-age=60, stale-while-revalidate=120` |
+| クラス       | エンドポイント                                                                                                                                                                                                                                                                           | バリデーター (ETag/Last-Modified)            | 条件付きリクエスト                                          | Cache-Control                            |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | -------------------------------------------------- | ---------------------------------------- |
+| **データ**   | `/v2/entities` (list, single, attrs, attrs/{name}, attrs/{name}/value)、 `/v2/subscriptions`、 `/v2/registrations`、 `/ngsi-ld/v1/entities` (list, single, attrs, attrs/{name})、 `/ngsi-ld/v1/subscriptions`、 `/ngsi-ld/v1/csourceRegistrations`、 `/ngsi-ld/v1/csourceSubscriptions` | ✓                                      | ✓ ( `If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache`                      |
+| **時系列** | `/ngsi-ld/v1/temporal/entities` (list, single、集約を含む)                                                                                                                                                                                                                              | ✗ (ETag なし — 時系列集約には安価な単調バリデーターがありません) | ✗                                                  | `private, no-cache`                      |
+| **メタ**    | `/v2/types`、 `/ngsi-ld/v1/types`、 `/ngsi-ld/v1/attributes` (list および single)                                                                                                                                                                                                      | ✗ (ETag なし、Last-Modified なし)           | ✗ ( `304` サポートなし)                                  | `max-age=60, stale-while-revalidate=120` |
 
-すべてのキャッシュ制御されたレスポンスは同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーション分離、CloudFront のような共有キャッシュに必要)。
+すべてのキャッシュ制御されたレスポンスは同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーション分離、CloudFront のような共有キャッシュに必要)
 
-### レスポンスヘッダー (Data エンドポイント)
+### レスポンスヘッダー (データエンドポイント)
 
-| ヘッダー | 説明 |
-|--------|-------------|
-| `ETag` | 弱いエンティティタグ (`W/"..."`、RFC 7232 §2.3.2 弱いバリデータ)。生成は常に **リソーススコープ** (`path + Accept + tenant + Fiware-ServicePath`) をシードに混ぜ込むため、異なるエンドポイント、Accept フォーマット、**テナント**、または **ServicePath** は、基礎となる状態が同一であっても異なる ETag を生成します。`tenant` スロットは最初に `NGSILD-Tenant` を読み取り、`Fiware-Service` にフォールバックし、`extractTenantContext` の優先順位と一致します。テナント / ServicePathシードは、中間キャッシュが `Vary` を誤って処理した場合でも、テナント間の ETag 衝突を防ぎます。<br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェスト、合計カウントとリソーススコープと組み合わせ。<br>• **単一リソース**: `modifiedAt` のハッシュとリソーススコープの組み合わせ。|
-| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP 日付。|
-| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) への保存を禁止します。`no-cache` はプライベートキャッシュからの再利用前に再検証を強制します。|
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`。|
+| ヘッダー            | 説明                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETag`          | 弱いエンティティタグ ( `W/"..."`、RFC 7232 §2.3.2 弱いバリデーター)。生成時には常に **リソーススコープ** ( `path + Accept + tenant + Fiware-ServicePath`) をシードに混ぜ込むため、異なるエンドポイント、Accept フォーマット、 **テナント**、または **ServicePath** は、基盤となる状態が同一であっても異なる ETag を生成します。 `tenant` スロットは最初に `NGSILD-Tenant` を読み取り、 `Fiware-Service` にフォールバックします。これは `extractTenantContext` の優先順位と一致します。テナント / servicePath シードは、中間キャッシュによって `Vary` が誤って処理された場合でも、テナント間の ETag 衝突を防ぎます。 <br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェストを、合計カウントとリソーススコープと組み合わせます。 <br>• **単一リソース**: `modifiedAt` のハッシュをリソーススコープと組み合わせます。 |
+| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP-date。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) への保存を禁止します。 `no-cache` はプライベートキャッシュからの再利用前に再検証を強制します。                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`。                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
-### レスポンスヘッダー (Meta エンドポイント)
+### レスポンスヘッダー (メタエンドポイント)
 
-| ヘッダー | 説明 |
-|--------|-------------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証による短期キャッシング。|
-| `Vary` | Data エンドポイントと同じ。|
+| ヘッダー            | 説明                                                                 |
+| --------------- | ------------------------------------------------------------------ |
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証を伴う短期キャッシング。 |
+| `Vary`          | データエンドポイントと同じ。                                                     |
 
-Meta エンドポイントは意図的に `ETag` / `Last-Modified` を省略します。これは、そのコンテンツが安価な単調バリデータを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストではなく `max-age` に依存する必要があります。
+メタエンドポイントは意図的に `ETag` / `Last-Modified` を省略しています。これは、そのコンテンツが安価な単調バリデーターを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストではなく `max-age` に依存する必要があります。
 
-### 条件付きリクエスト (Data エンドポイントのみ)
+### 条件付きリクエスト (データエンドポイントのみ)
 
-クライアントは条件付きリクエストヘッダーを送信して、結果が変更されていない場合に `304 Not Modified` (空のボディ) を受け取ることができます:
+クライアントは条件付きリクエストヘッダーを送信して、結果が変更されていない場合に `304 Not Modified` (空のボディ) を受信できます:
 
-| リクエストヘッダー | 動作 |
-|----------------|----------|
-| `If-None-Match: <ETag>` | サーバーは現在の `ETag` と比較します。一致する場合、`304` を返します。ワイルドカード `*` は常に一致します。|
-| `If-Modified-Since: <HTTP-date>` | サーバーは現在の `Last-Modified` と比較します。変更されていない場合、`304` を返します。|
+| リクエストヘッダー                        | 動作                                                               |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `If-None-Match: <ETag>`          | サーバーは現在の `ETag` と比較します。一致した場合、 `304` を返します。ワイルドカード `*` は常に一致します。 |
+| `If-Modified-Since: <HTTP-date>` | サーバーは現在の `Last-Modified` と比較します。変更されていない場合、 `304` を返します。         |
 
-両方のヘッダーが存在する場合、RFC 7232 §6 に従い `If-None-Match` が優先されます。
+両方のヘッダーが存在する場合、RFC 7232 §6 に従って `If-None-Match` が優先されます。
 
 ### 例
 
@@ -302,26 +337,38 @@ curl -i "http://localhost:3000/v2/entities" \
 # Last-Modified: Sun, 26 Apr 2026 00:00:00 GMT
 ```
 
-### 注記
+### 注意事項
 
-- ETag は弱い (`W/`) です — これらはバイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータを持つが属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
-- ETag 生成はリソースパスと `Accept` ヘッダーをシードに含めます。異なるエンドポイントと異なるコンテンツネゴシエーションは、基礎となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
-- `304` レスポンスは `ETag`、`Last-Modified`、`Cache-Control`、`Vary`、および CORS ヘッダーを保持します。
-- 条件評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
-- キャッシュコントロールは以下に適用されます:
-  - **NGSIv2**: `/v2/entities` (リスト / 単一 / attrs / attrs+name / attrs+name+value)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`  - **NGSI-LD Data**: `/ngsi-ld/v1/entities` (リスト / 単一 / attrs / attrs+name)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`  - **NGSI-LD Meta**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`  - **NGSI-LD Temporal**: `/ngsi-ld/v1/temporal/entities` (リストと単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
 
-### クライアント主導のキャッシュコントロール
+* ETag は弱い ( `W/`) です — バイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータで属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
+  
+* ETag 生成には、リソースパスと `Accept` ヘッダーがシードに含まれます。異なるエンドポイントと異なるコンテンツネゴシエーションは、基盤となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
+  
+* `304` レスポンスは `ETag`、 `Last-Modified`、 `Cache-Control`、 `Vary`、および CORS ヘッダーを保持します。
+  
+* 条件付き評価は、ステータスが `GET` および `HEAD` リクエストに適用されます。 `200`。 `HEAD` は `GET` と同じヘッダーを空のボディで返します (RFC 7231 §4.3.2)。これにより、 `200` の場合でもボディを転送せずに軽量な再検証が可能になります。
+  
+* キャッシュ制御は以下に適用されます:
+  
+  * **NGSIv2**: `/v2/entities` (list / single / attrs / attrs+name / attrs+name+value)、 `/v2/subscriptions`、 `/v2/registrations`、 `/v2/types`
+    
+  * **NGSI-LD データ**: `/ngsi-ld/v1/entities` (list / single / attrs / attrs+name)、 `/ngsi-ld/v1/subscriptions`、 `/ngsi-ld/v1/csourceRegistrations`、 `/ngsi-ld/v1/csourceSubscriptions`
+    
+  * **NGSI-LD メタ**: `/ngsi-ld/v1/types`、 `/ngsi-ld/v1/attributes`
+    
+  * **NGSI-LD 時系列**: `/ngsi-ld/v1/temporal/entities` (list および single、 `Cache-Control` のみ —  `ETag` / `Last-Modified` なし)
+
+### クライアント駆動キャッシュ制御
 
 クライアントは `Cache-Control` リクエストヘッダーを送信して、キャッシング動作に影響を与えることができます:
 
-| リクエストヘッダー | サーバーの動作 |
-|----------------|-----------------|
-| `Cache-Control: no-store` | サーバーはレスポンス `Cache-Control` を `no-store` にオーバーライドします (CDN / 中間キャッシュ抑制ヒント)。|
-| `Cache-Control: no-cache` | サーバーは特別なオーバーライドを行いません; エンドポイントのデフォルトポリシーが引き続き適用されます (data → 再検証; meta → `max-age=60` など)。|
-| `Cache-Control: max-age=N` | エッジキャッシュレイヤー用に予約済み (Phase 3 / CloudFront)。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。|
+| リクエストヘッダー                  | サーバーの動作                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| `Cache-Control: no-store`  | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします (CDN / 中間キャッシュ抑制ヒント)。              |
+| `Cache-Control: no-cache`  | サーバーは特別なオーバーライドを行いません。エンドポイントのデフォルトポリシーが引き続き適用されます (データ → 再検証; メタ → `max-age=60` など)。   |
+| `Cache-Control: max-age=N` | エッジキャッシュレイヤー (フェーズ 3 / CloudFront) 用に予約されています。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。 |
 
----
+***
 
 ## 認証 API
 
@@ -329,29 +376,29 @@ curl -i "http://localhost:3000/v2/entities" \
 
 ### 有効化
 
-認証はデフォルトで無効になっています。以下の環境変数で有効化できます。
+認証はデフォルトで無効になっています。以下の環境変数で有効にすることができます。
 
-**注意**: `AUTH_ENABLED=false` の場合、認証関連のエンドポイント (`/auth/*`、`/me`、`/me/*`、`/admin/*`) は 404 を返します。
+**注意**: `AUTH_ENABLED=false` の場合、認証関連のエンドポイント(`/auth/*`、`/me`、`/me/*`、`/admin/*`)は 404 を返します。
 
-**重要**: `AUTH_ENABLED=true` の場合、NGSI API エンドポイント (`/v2/*`、`/ngsi-ld/*`、`/catalog/*`) へのアクセスには認証が必要です。認証なしでアクセスすると `401 Unauthorized` エラーが返されます。
+**重要**: `AUTH_ENABLED=true` の場合、NGSI API エンドポイント(`/v2/*`、`/ngsi-ld/*`、`/catalog/*`)へのアクセスには認証が必要です。認証なしでアクセスすると `401 Unauthorized` エラーを返します。
 
-| 環境変数 | デフォルト | 説明 |
-|---------|-----------|------|
-| `AUTH_ENABLED` | `false` | 認証を有効化 |
-| `JWT_SECRET` | - | JWT トークン署名用のシークレット (32 文字以上推奨) |
-| `JWT_EXPIRES_IN` | `1h` | アクセストークンの有効期限 |
-| `JWT_REFRESH_EXPIRES_IN` | `7d` | リフレッシュトークンの有効期限 |
-| `SUPER_ADMIN_EMAIL` | - | 環境変数で設定されるスーパー管理者のメールアドレス |
-| `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定されるスーパー管理者のパスワード |
-| `ADMIN_ALLOWED_IPS` | - | Admin API へのアクセスを許可する IP/CIDR (カンマ区切り) |
+| 環境変数                     | デフォルト   | 説明                                    |
+| ------------------------ | ------- | ------------------------------------- |
+| `AUTH_ENABLED`           | `false` | 認証を有効化                                |
+| `JWT_SECRET`             | -       | JWT トークン署名用のシークレット(32文字以上推奨)          |
+| `JWT_EXPIRES_IN`         | `1h`    | アクセストークンの有効期限                         |
+| `JWT_REFRESH_EXPIRES_IN` | `7d`    | リフレッシュトークンの有効期限                       |
+| `SUPER_ADMIN_EMAIL`      | -       | 環境変数で設定されるスーパー管理者のメールアドレス             |
+| `SUPER_ADMIN_PASSWORD`   | -       | 環境変数で設定されるスーパー管理者のパスワード               |
+| `ADMIN_ALLOWED_IPS`      | -       | Admin API へのアクセスを許可する IP/CIDR(カンマ区切り) |
 
 ### ロールと権限
 
-| ロール | 説明 | 権限 |
-|-------|------|------|
-| `super_admin` | スーパー管理者 | `/admin/*`、`/auth/*`、`/me/*`、監視エンドポイントのみ。データ API (`/v2/*`、`/ngsi-ld/*`、`/catalog*`、`/rules*`) にはアクセス**できません** — 403 を返します |
-| `tenant_admin` | テナント管理者 | 自分のテナント内のユーザーを管理 |
-| `user` | 一般ユーザー | 自分のプロフィール表示とパスワード変更のみ |
+| ロール            | 説明      | 権限                                                                                                                    |
+| -------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `super_admin`  | スーパー管理者 | `/admin/*`、`/auth/*`、`/me/*`、監視エンドポイントのみ。**アクセス不可** データ API(`/v2/*`、`/ngsi-ld/*`、`/catalog*`、`/rules*`)には — 403 を返します |
+| `tenant_admin` | テナント管理者 | 自分のテナント内のユーザーを管理                                                                                                      |
+| `user`         | 一般ユーザー  | 自分のプロフィール表示とパスワード変更のみ                                                                                                 |
 
 ### ログイン
 
@@ -374,14 +421,14 @@ Content-Type: application/json
 }
 ```
 
-| パラメータ | 型 | 必須 | 説明 |
-|-----------|------|------|------|
-| `email` | string | はい | メールアドレス |
-| `password` | string | はい | パスワード |
-| `tenantId` | string | いいえ | 指定された場合、そのテナントにスコープされた JWT を発行します。省略時はプライマリテナントがデフォルト |
-| `resourceScopes` | ResourceScope[] | いいえ | エンティティレベルのアクセス制御スコープ。省略時は完全アクセス。詳細は AUTH.md を参照 |
+| パラメータ            | 型                | 必須  | 説明                                                           |
+| ---------------- | ---------------- | --- | ------------------------------------------------------------ |
+| `email`          | string           | Yes | メールアドレス                                                      |
+| `password`       | string           | Yes | パスワード                                                        |
+| `tenantId`       | string           | No  | 指定した場合、そのテナントにスコープされた JWT を発行します。省略した場合はプライマリテナントがデフォルトになります |
+| `resourceScopes` | ResourceScope\[] | No  | エンティティレベルのアクセス制御スコープ。省略した場合はフルアクセス。詳細は AUTH.md を参照してください     |
 
-**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダー経由でテナントを指定できます (テナント名で解決)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダー値は `^[a-z0-9_]+$` と一致する必要があります。
+**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダーでテナントを指定できます(テナント名で解決されます)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダー値は `^[a-z0-9_]+$` と一致する必要があります。
 
 **レスポンス例**
 
@@ -417,7 +464,7 @@ Content-Type: application/json
 
 **レスポンス**: ログインと同じ形式
 
-### 現在のユーザー情報取得
+### 現在のユーザー情報を取得
 
 ```http
 GET /me
@@ -436,7 +483,7 @@ Authorization: Bearer <accessToken>
 }
 ```
 
-### パスワード変更
+### パスワードの変更
 
 ```http
 POST /me/password
@@ -453,7 +500,9 @@ Content-Type: application/json
 }
 ```
 
-**レスポンス**: `204 No Content`**注意**: パスワード変更後、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
+**レスポンス**: `204 No Content`
+
+**注意**: パスワードを変更すると、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
 
 ### ログアウト
 
@@ -462,10 +511,11 @@ POST /auth/logout
 Authorization: Bearer <accessToken>
 ```
 
-すべてのセッションを無効化します。このユーザーに対して発行されたすべてのアクセストークンとリフレッシュトークンが即座に無効化されます。
+すべてのセッションを無効化します。このユーザーに対して発行されたすべてのアクセストークンとリフレッシュトークンは直ちに無効化されます。
 
 **レスポンス**: `204 No Content`
-### API キー トークン交換
+
+### API Key トークン交換
 
 #### Nonce の取得
 
@@ -513,11 +563,11 @@ Origin: https://example.com
 }
 ```
 
-**DPoP トークン バインディング**(オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明キーにバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を必要とします — 最初のリクエストは `DPoP-Nonce` ヘッダーと共に `400 use_dpop_nonce` を返します。証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
+**DPoP トークンバインディング** (オプション): ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます ([RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に準拠)。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明鍵にバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を要求します。最初のリクエストは `400 use_dpop_nonce` と `DPoP-Nonce` ヘッダーを返します。証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
 
 ### 管理 API
 
-管理 API は `super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセス可能です。
+管理 API は、`super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセスできます。
 
 #### ユーザー一覧
 
@@ -528,12 +578,12 @@ Authorization: Bearer <accessToken>
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `tenantId` | テナント ID でフィルター (super_admin のみ) |
-| `role` | ロールでフィルター |
-| `limit` | 取得する結果の数 |
-| `offset` | オフセット |
+| パラメータ      | 説明                                |
+| ---------- | --------------------------------- |
+| `tenantId` | テナント ID でフィルタリング(super\_admin のみ) |
+| `role`     | ロールでフィルタリング                       |
+| `limit`    | 取得する結果の数                          |
+| `offset`   | オフセット                             |
 
 #### ユーザー作成
 
@@ -602,7 +652,7 @@ POST /admin/users/{userId}/unlock
 Authorization: Bearer <accessToken>
 ```
 
-**レスポンス (200):**
+**レスポンス(200):**
 
 ```json
 {
@@ -614,7 +664,7 @@ Authorization: Bearer <accessToken>
 }
 ```
 
-### テナント管理 (super_admin のみ)
+### テナント管理 (super\_admin のみ)
 
 #### テナント一覧
 
@@ -643,7 +693,7 @@ Content-Type: application/json
 }
 ```
 
-> **注意**: テナント名には小文字の英数字とアンダースコアのみを含める必要があります (`^[a-z0-9_]+$`)。
+> **注意**: テナント名には小文字の英数字とアンダースコアのみ使用できます (`^[a-z0-9_]+$`)。
 
 #### テナント取得
 
@@ -667,9 +717,9 @@ DELETE /admin/tenants/{tenantId}
 Authorization: Bearer <accessToken>
 ```
 
-**カスケード削除**: テナントが削除されると、関連するすべてのデータ (エンティティ、サブスクリプション、登録、ルール、ポリシー、ユーザー、メンバーシップ、および全 16 コレクション) が自動的にカスケード削除されます。削除が開始される前に、テナントは自動的に無効化され、新しい API リクエストがブロックされます。
+**カスケード削除**: テナントが削除されると、関連するすべてのデータ (エンティティ、サブスクリプション、登録、ルール、ポリシー、ユーザー、メンバーシップ、および全 16 コレクション) が自動的にカスケード削除されます。削除が開始される前に、テナントは自動的に非アクティブ化され、新しい API リクエストがブロックされます。
 
-#### テナントの有効化/無効化
+#### テナントのアクティブ化/非アクティブ化
 
 ```http
 POST /admin/tenants/{tenantId}/activate
@@ -679,11 +729,11 @@ Authorization: Bearer <accessToken>
 
 ### カスタムデータモデル管理
 
-> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
+> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については、[カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
 
 ### IP 制限
 
-`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます。
+&#x20;環境変数を設定することで、Admin API (`ADMIN_ALLOWED_IPS`) へのアクセスを特定の IP アドレスに制限できます:`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:
 
 ```bash
 # Single IP
@@ -696,11 +746,11 @@ ADMIN_ALLOWED_IPS=192.168.1.100,10.0.0.50
 ADMIN_ALLOWED_IPS=192.168.1.0/24,10.0.0.0/8
 ```
 
-許可されていない IP からのアクセスは `403 Forbidden` エラーとなります。
+許可されていない IP からのアクセスは、`403 Forbidden` エラーになります。
 
 #### テナント毎の IP 制限
 
-テナント毎に個別の IP 制限を設定できます。テナントレベルの設定が存在する場合は、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
+個別の IP 制限はテナント毎に設定できます。テナントレベルの設定が存在する場合、グローバル設定 (`ADMIN_ALLOWED_IPS`) より優先されます。
 
 ```http
 GET /admin/tenants/{tenantId}/ip-restrictions
@@ -709,15 +759,16 @@ DELETE /admin/tenants/{tenantId}/ip-restrictions
 Authorization: Bearer <accessToken>
 ```
 
-スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかを指定できます。詳細は AUTH.md を参照してください。
+スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかです。詳細については AUTH.md を参照してください。
 
-### ルールエンジン管理（tenant_admin）
+### ルールエンジン管理 (tenant\_admin)
 
-エンティティの変更を自動的に処理するルールを管理します。`tenant_admin` ロールが必要です。`AUTH_ENABLED=true` の場合、`super_admin` は `/rules*` エンドポイントにアクセスできません。
+エンティティの変更を自動的に処理するルールを管理します。`tenant_admin` ロールが必要です;`super_admin` は `/rules*` エンドポイントにアクセスできません。条件:`AUTH_ENABLED=true`。
 
-- **REACTIVCORE_RULES.md** - ユーザーガイド(使用例、管理 API など)
 
-#### ルール一覧の取得
+* **REACTIVCORE\_RULES.md** - ユーザーガイド(使用例、Admin API など)
+
+#### ルール一覧
 
 ```http
 GET /rules
@@ -726,14 +777,14 @@ Authorization: Bearer <accessToken>
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 結果の件数(デフォルト: 20、最大: 100) |
-| `offset` | オフセット(デフォルト: 0) |
-| `servicePath` | ServicePathでフィルタ |
-| `isActive` | アクティブ/非アクティブでフィルタ(`true` / `false`) |
+| パラメータ         | 説明                           |
+| ------------- | ---------------------------- |
+| `limit`       | 結果の数(デフォルト: 20、最大: 100)      |
+| `offset`      | オフセット(デフォルト: 0)              |
+| `servicePath` | ServicePathでフィルタ                  |
+| `isActive`    | 有効/無効でフィルタ(`true` / `false`) |
 
-#### ルールの作成
+#### ルール作成
 
 ```http
 POST /rules
@@ -772,14 +823,14 @@ Content-Type: application/json
 }
 ```
 
-#### ルールの取得
+#### ルール取得
 
 ```http
 GET /rules/{ruleId}
 Authorization: Bearer <accessToken>
 ```
 
-#### ルールの更新
+#### ルール更新
 
 ```http
 PATCH /rules/{ruleId}
@@ -787,7 +838,9 @@ Authorization: Bearer <accessToken>
 Content-Type: application/json
 ```
 
-レスポンス: `204 No Content`#### ルールの削除
+レスポンス: `204 No Content`
+
+#### ルール削除
 
 ```http
 DELETE /rules/{ruleId}
@@ -804,85 +857,95 @@ Authorization: Bearer <accessToken>
 
 #### クロスプロトコルアクション
 
-ルールアクション(`createEntity`、`updateAttribute`、`deleteAttribute`)は、プロトコル境界を越えて動作するためのオプションフィールド `protocol` をサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
+ルールアクション(`createEntity`、`updateAttribute`、`deleteAttribute`)は、プロトコル境界を越えて操作するためのオプションの `protocol` フィールドをサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
 
-| フィールド | アクション | 型 | 説明 |
-|---|---|---|---|
-| `protocol` | createEntity、updateAttribute、deleteAttribute | `'ngsiv2' \| 'ngsild'` | ターゲットプロトコル(デフォルト: トリガーから継承) |
-| `servicePath` | createEntity | `string` | NGSIv2 のターゲット servicePath (テンプレート変数をサポート) |
-| `scope` | createEntity | `string[]` | NGSI-LD のターゲットスコープ(テンプレート変数をサポート) |
+| フィールド         | アクション                                          | タイプ                          | 説明                                     |
+| ------------- | ---------------------------------------------- | ---------------------------- | -------------------------------------- |
+| `protocol`    | createEntity, updateAttribute, deleteAttribute | `'ngsiv2' \| 'ngsild'` | 対象プロトコル(デフォルト: トリガーから継承)               |
+| `servicePath` | createEntity                                   | `string`                     | NGSIv2 の対象 servicePath (テンプレート変数をサポート) |
+| `scope`       | createEntity                                   | `string[]`                   | NGSI-LD の対象スコープ(テンプレート変数をサポート)         |
 
-プロトコルを越える場合、servicePath ↔ scope は自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` は、トリガーエンティティのコンテキストを参照します。
+プロトコルをまたぐ場合、servicePath ↔ scope が自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` はトリガーエンティティのコンテキストを参照します。
 
-詳細な例とマッピングルールについては、**REACTIVCORE_RULES.md** を参照してください。
+詳細な例とマッピングルールについては、**REACTIVCORE\_RULES.md** を参照してください。
 
----
+***
 
 ## OAuth 2.0 API (M2M 認証)
 
 OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (M2M) 認証がサポートされています。
 
 **主要なエンドポイント:**
-- `POST /oauth/token` - トークン取得 (Basic 認証)
-- `POST /admin/oauth-clients` - クライアント作成 (管理者)
-- `GET /admin/oauth-clients` - クライアント一覧 (管理者)
-- `POST /admin/oauth-clients/{clientId}/regenerate-secret` - シークレット再生成 (管理者)
-- `POST /me/oauth-clients` - 自分のクライアント作成 (セルフサービス)
-- `GET /me/oauth-clients` - 自分のクライアント一覧 (セルフサービス)
-- `DELETE /me/oauth-clients/{clientId}` - 自分のクライアント削除 (セルフサービス)
-- `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自分のシークレット再生成 (セルフサービス)
 
-**有効化:** `AUTH_ENABLED=true` の場合、OAuth 2.0 は常に有効になります。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
+* `POST /oauth/token` - トークン取得 (Basic 認証)
+  
+* `POST /admin/oauth-clients` - クライアント作成 (管理者)
+  
+* `GET /admin/oauth-clients` - クライアント一覧 (管理者)
+  
+* `POST /admin/oauth-clients/{clientId}/regenerate-secret` - シークレット再生成 (管理者)
+  
+* `POST /me/oauth-clients` - 自身のクライアント作成 (セルフサービス)
+  
+* `GET /me/oauth-clients` - 自身のクライアント一覧 (セルフサービス)
+  
+* `DELETE /me/oauth-clients/{clientId}` - 自身のクライアント削除 (セルフサービス)
+  
+* `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自身のシークレット再生成 (セルフサービス)
+
+**有効化:** OAuth 2.0 は常に有効です `AUTH_ENABLED=true`。`OAUTH_ENABLED` 環境変数は非推奨となり、無視されます。
 
 **利用可能なスコープ:**
 
-| スコープ | 説明 | `user` | `tenant_admin` | `super_admin` |
-|-------|-------------|:------:|:---------------:|:--------------:|
-| `read:entities` | エンティティの読み取り | ✅ | ✅ | ✅ |
-| `write:entities` | エンティティの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:subscriptions` | サブスクリプションの読み取り | ✅ | ✅ | ✅ |
-| `write:subscriptions` | サブスクリプションの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:registrations` | 登録の読み取り | ✅ | ✅ | ✅ |
-| `write:registrations` | 登録の書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:rules` | ルールの読み取り | ✅ | ✅ | ✅ |
-| `write:rules` | ルールの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:custom-data-models` | カスタムデータモデルの読み取り | ✅ | ✅ | ✅ |
-| `write:custom-data-models` | カスタムデータモデルの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `admin:users` | ユーザー管理 API | ❌ | ✅ | ✅ |
-| `admin:policies` | ポリシー管理 API | ❌ | ✅ | ✅ |
-| `admin:oauth-clients` | OAuth クライアント管理 API | ❌ | ✅ | ✅ |
-| `admin:metrics` | メトリクス API | ❌ | ✅ | ✅ |
-| `admin:tenants` | テナント管理 API | ❌ | ❌ | ✅ |
-| `permanent` | トークンが期限切れにならない | — | — | — |
-| `jwt` | JWT 形式のトークン | — | — | — |
+| スコープ                       | 説明                           | `user` | `tenant_admin` | `super_admin` |
+| -------------------------- | ---------------------------- | :----: | :------------: | :-----------: |
+| `read:entities`            | エンティティの読み取り                  |    ✅   |        ✅       |       ✅       |
+| `write:entities`           | エンティティの書き込み (作成/更新/削除のみ)     |    ✅   |        ✅       |       ✅       |
+| `read:subscriptions`       | サブスクリプションの読み取り               |    ✅   |        ✅       |       ✅       |
+| `write:subscriptions`      | サブスクリプションの書き込み (作成/更新/削除のみ)  |    ✅   |        ✅       |       ✅       |
+| `read:registrations`       | 登録の読み取り                      |    ✅   |        ✅       |       ✅       |
+| `write:registrations`      | 登録の書き込み (作成/更新/削除のみ)         |    ✅   |        ✅       |       ✅       |
+| `read:rules`               | ルールの読み取り                     |    ✅   |        ✅       |       ✅       |
+| `write:rules`              | ルールの書き込み (作成/更新/削除のみ)        |    ✅   |        ✅       |       ✅       |
+| `read:custom-data-models`  | カスタムデータモデルの読み取り              |    ✅   |        ✅       |       ✅       |
+| `write:custom-data-models` | カスタムデータモデルの書き込み (作成/更新/削除のみ) |    ✅   |        ✅       |       ✅       |
+| `admin:users`              | ユーザー管理 API                   |    ❌   |        ✅       |       ✅       |
+| `admin:policies`           | ポリシー管理 API                   |    ❌   |        ✅       |       ✅       |
+| `admin:oauth-clients`      | OAuth クライアント管理 API           |    ❌   |        ✅       |       ✅       |
+| `admin:metrics`            | メトリクス API                    |    ❌   |        ✅       |       ✅       |
+| `admin:tenants`            | テナント管理 API                   |    ❌   |        ❌       |       ✅       |
+| `permanent`                | トークンが無期限                     |    —   |        —       |       —       |
+| `jwt`                      | JWT 形式トークン                   |    —   |        —       |       —       |
 
-> ロール列は、セルフサービス (`/me/oauth-clients`) 経由でリクエスト可能なスコープを示します。管理者が作成したクライアント (`/admin/oauth-clients`) には、これらの制限は適用されません。
+> ロール列は、セルフサービス (`/me/oauth-clients`) 経由でリクエストできるスコープを示します。管理者が作成したクライアント (`/admin/oauth-clients`) はこれらの制限の対象外です。
 
-**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ (JSON 文字列) を指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細は AUTH.md を参照してください。
+**リソーススコープ:** Specifying the `resource_scopes` パラメータ (JSON 文字列) を `POST /oauth/token` で指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細は AUTH.md を参照してください。
 
 **詳細:** AUTH.md の OAuth 2.0 セクションを参照してください。
 
----
+***
 
 ## API キートークン交換 (ブラウザ SDK)
 
 ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短時間有効なセッション JWT に交換できます。
 
 **主要なエンドポイント:**
-- `POST /auth/nonce` - Nonce + PoW チャレンジのリクエスト (API キー + Origin ヘッダーが必要)
-- `POST /oauth/token` (`grant_type=api_key`) - API キー + nonce + PoW 証明をセッション JWT に交換
+
+* `POST /auth/nonce` - Nonce + PoW チャレンジのリクエスト (API キー + Origin ヘッダーが必要)
+  
+* `POST /oauth/token` (`grant_type=api_key`) - API キー + nonce + PoW 証明をセッション JWT に交換
 
 **JavaScript SDK:** `npm install @geolonia/geonicdb-sdk` — トークン交換、DPoP、WebSocket、再接続を自動的に処理します。
 
-**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60 秒 TTL) → Proof of Work → 短時間有効な JWT (1 時間)
+**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60秒 TTL) → Proof of Work → 短時間有効な JWT (1時間)
 
-**詳細:** AUTH.md の API Key Token Exchange セクションおよび SDK ドキュメントで完全な API リファレンスを参照してください。
+**詳細:** AUTH.md の API キートークン交換セクションと、完全な API リファレンスについては SDK ドキュメントを参照してください。
 
----
+***
 
 ## メタエンドポイント
 
-メタエンドポイントは認証を必要とせず、システムステータスと API 情報を提供します。
+メタエンドポイントは認証が不要で、システムステータスと API 情報を提供します。
 
 ### API ドキュメント (llms.txt 形式)
 
@@ -890,16 +953,19 @@ OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (
 GET /llms.txt
 ```
 
-AI フレンドリーな [llms.txt](https://llmstxt.org/) 形式で API ドキュメントを返します。AI エージェントや LLM が理解しやすいように構造化された Markdown 形式を使用します。
+AI フレンドリーな [llms.txt](https://llmstxt.org/) 形式で API ドキュメントを返します。AI エージェントや LLM が簡単に理解できるように構造化された Markdown 形式を使用しています。
 
 **レスポンス**
-- Content-Type: `text/markdown; charset=utf-8`### API ドキュメント (JSON 形式)
+
+* Content-Type: `text/markdown; charset=utf-8`
+
+### API ドキュメント (JSON 形式)
 
 ```http
 GET /api.json
 ```
 
-JSON 形式で API エンドポイントの一覧を返します。
+JSON 形式で API エンドポイントのリストを返します。
 
 **レスポンス例**
 
@@ -918,16 +984,20 @@ JSON 形式で API エンドポイントの一覧を返します。
   }
 }
 ```
+
 ### OpenAPI 仕様
 
 ```http
 GET /openapi.json
 ```
 
-OpenAPI 3.0 仕様を JSON 形式で返します。Swagger UI や各種 API クライアント生成ツールで使用できます。
+JSON 形式で OpenAPI 3.0 仕様を返します。Swagger UI や各種 API クライアント生成ツールで使用できます。
 
 **レスポンス**
-- Content-Type: `application/json`- OpenAPI バージョン: 3.0.3
+
+* Content-Type: `application/json`
+  
+* OpenAPI version: 3.0.3
 
 ### バージョン情報
 
@@ -979,15 +1049,15 @@ NGSI-LD API サポート情報を返します。
 
 ### ヘルスチェック
 
-すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返した場合にセカンダリへ切り替えます。
+すべてのヘルスチェックエンドポイントは `region` と `regionRole` を返し、マルチリージョン HA サポートを提供します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返すとセカンダリに切り替わります。
 
-#### 基本ヘルス
+#### 基本ヘルスチェック
 
 ```http
 GET /health
 ```
 
-サービスの基本的な稼働状態を返します。
+サービスの基本的な動作ステータスを返します。
 
 **レスポンス例**
 
@@ -1006,7 +1076,7 @@ GET /health
 GET /health/live
 ```
 
-Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中かどうかをチェックします。
+Kubernetes / Route 53 の liveness プローブ用。サービスが実行中かどうかをチェックします。
 
 **レスポンス例**
 
@@ -1025,17 +1095,22 @@ Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中か
 GET /health/ready
 ```
 
-Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチェックし、オプションで DynamoDB と EventBridge の詳細ヘルスチェックを実行します。
+Kubernetes / Route 53 の readiness プローブ用。MongoDB の接続性をチェックし、オプションで DynamoDB と EventBridge の詳細なヘルスチェックを実行します。
 
 **環境変数による詳細ヘルスチェックの有効化**
 
-| 環境変数 | 説明 |
-|---------|------|
-| `HEALTH_CHECK_DYNAMODB=true` | DynamoDB DescribeTable 接続チェックを追加 |
-| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続チェックを追加 |
+| 環境変数                            | 説明                                      |
+| ------------------------------- | --------------------------------------- |
+| `HEALTH_CHECK_DYNAMODB=true`    | DynamoDB DescribeTable 接続性チェックを追加       |
+| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続性チェックを追加 |
 
 **レスポンス**
-- 成功: `200 OK` と `status: "healthy"`- 失敗: `503 Service Unavailable` と `status: "unhealthy"`**レスポンス例(詳細ヘルスチェック有効時)**
+
+* 成功: `200 OK` と `status: "healthy"`
+  
+* 失敗: `503 Service Unavailable` と `status: "unhealthy"`
+
+**レスポンス例(詳細ヘルスチェック有効時)**
 
 ```json
 {
@@ -1051,9 +1126,10 @@ Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチ
   "totalLatencyMs": 35
 }
 ```
+
 ### 統計とメトリクス
 
-FIWARE Orion 互換の統計エンドポイントと、Prometheus 形式のメトリクスエンドポイントを提供します。
+FIWARE Orion 互換の統計エンドポイントと Prometheus 形式のメトリクスエンドポイントを提供します。
 
 #### 統計
 
@@ -1062,7 +1138,7 @@ GET /statistics
 Authorization: Bearer <token>
 ```
 
-サーバーの運用統計を FIWARE Orion 互換形式で返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+FIWARE Orion 互換形式でサーバーの運用統計を返します。認証が有効な場合(`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1102,7 +1178,7 @@ GET /cache/statistics
 Authorization: Bearer <token>
 ```
 
-サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合(`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1132,10 +1208,13 @@ GET /metrics
 Authorization: Bearer <token>
 ```
 
-Prometheus エクスポジション形式でメトリクスを返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
+Prometheus エクスポジション形式でメトリクスを返します。認証が有効な場合(`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境でのモニタリングや Grafana ダッシュボードとの統合に使用できます。
 
 **レスポンス**
-- Content-Type: `text/plain; version=0.0.4`**レスポンス例**
+
+* Content-Type: `text/plain; version=0.0.4`
+
+**レスポンス例**
 
 ```text
 # HELP geonicdb_uptime_seconds Server uptime in seconds
@@ -1178,7 +1257,9 @@ GET /tools.json
 
 Claude Tool Use / OpenAI Function Calling と互換性のある JSON 形式でツール定義を返します。これは AI エージェントが API をツールとして使用するためのスキーマです。
 
-**提供されるツール**: `list_entities`、`get_entity`、`search_by_location`、`search_by_attribute`、`create_entity`、`update_entity`、`delete_entity`、`list_entity_types`、`get_temporal_data`、`subscribe`##### AI プラグインマニフェスト
+**提供されるツール**: `list_entities`, `get_entity`, `search_by_location`, `search_by_attribute`, `create_entity`, `update_entity`, `delete_entity`, `list_entity_types`, `get_temporal_data`, `subscribe`
+
+##### AI プラグインマニフェスト
 
 ```http
 GET /.well-known/ai-plugin.json
@@ -1194,9 +1275,9 @@ Content-Type: application/json
 Accept: application/json, text/event-stream
 ```
 
-MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、MCP tools/call 経由で 5 つのツールすべてが利用可能です。
+MCP ストリーム可能な HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、MCP tools/call 経由で 5 つのツールすべてが利用可能です。
 
-`AUTH_ENABLED=true` の場合、Bearer トークン(JWT)による認証が必要です。テナントアクセス制御も適用されます。
+When `AUTH_ENABLED=true` の場合、Bearer トークン(JWT)による認証が必要です。テナントアクセス制御も適用されます。
 
 **Claude Desktop 設定例**:
 
@@ -1215,9 +1296,10 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
   }
 }
 ```
-注意: `headers` は `AUTH_ENABLED=true` の場合のみ必要です。
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+注: `headers` が必要なのは `AUTH_ENABLED=true` の場合のみです。
+
+詳細については、[AI\_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
 
 ##### A2A (Agent-to-Agent Protocol)
 
@@ -1225,7 +1307,7 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
 GET /.well-known/agent-card.json
 ```
 
-A2A Agent Card。このエージェントの機能、スキル、認証について説明します。認証は不要です。
+A2A エージェントカード。このエージェントの機能、スキル、および認証について記述します。認証は不要です。
 
 ```http
 POST /a2a
@@ -1234,24 +1316,28 @@ Authorization: Bearer <token>
 Fiware-Service: <tenant>  (optional, falls back to default tenant)
 ```
 
-エージェント間通信のための A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合、認証が必要です。サポートされるメソッド:
-- `message/send` — メッセージを送信し、同期レスポンスを受信
-- `tasks/get` — タスクの現在の状態を取得
-- `tasks/list` — フィルタリングとページネーション付きでタスクを一覧表示
-- `tasks/cancel` — タスクのキャンセルをリクエスト
+エージェント間通信のための A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合は認証が必要です。サポートされるメソッド:
 
-5 つのスキルが利用可能: entities、batch、temporal、config、admin (MCP ツールと同じ)。
+* `message/send` — メッセージを送信し、同期レスポンスを受信
+  
+* `tasks/get` — タスクの現在の状態を取得
+  
+* `tasks/list` — フィルタリングとページネーションを使用してタスクを一覧表示
+  
+* `tasks/cancel` — タスクのキャンセルをリクエスト
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+5 つのスキルが利用可能: entities、batch、temporal、config、admin(MCP ツールと同じ)。
 
-#### テナント別メトリクス (管理 API)
+詳細については、[AI\_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+
+#### テナント毎のメトリクス(Admin API)
 
 ```http
 GET /admin/metrics
 Authorization: Bearer <accessToken>
 ```
 
-テナントとServicePath別のメトリクスを返します。`super_admin` ロールが必要です。
+テナントとServicePath毎のメトリクスを返します。`super_admin` ロールが必要です。
 
 **レスポンス例**
 
@@ -1275,46 +1361,47 @@ Authorization: Bearer <accessToken>
   }
 }
 ```
----
+
+***
 
 ## NGSIv2 API
 
-NGSIv2 API の詳細については、[API_NGSIV2.md](./ngsiv2.md) を参照してください。
+NGSIv2 API の詳細については、[API\_NGSIV2.md](./ngsiv2.md)を参照してください。
 
----
+***
 
 ## NGSI-LD API
 
-NGSI-LD API の詳細については、[API_NGSILD.md](./ngsild.md) を参照してください。
+NGSI-LD API の詳細については、[API\_NGSILD.md](./ngsild.md)を参照してください。
 
----
+***
 
 ## クエリ言語
 
-属性値によるフィルタリングは `q` パラメータを使用して可能です。
+属性値によるフィルタリングは、`q`パラメータを使用して可能です。
 
 ### 基本構文
 
-| 演算子 | 説明 | 例 |
-|----------|-------------|---------|
-| `==` | 等しい | `temperature==23` |
-| `!=` | 等しくない | `status!=inactive` |
-| `>` | より大きい | `temperature>20` |
-| `<` | より小さい | `temperature<30` |
-| `>=` | 以上 | `temperature>=20` |
-| `<=` | 以下 | `temperature<=30` |
-| `..` | 範囲 | `temperature==20..30` |
-| `~=` | パターンマッチ (正規表現) | `name~=Room.*` |
+| 演算子  | 説明            | 例                     |
+| ---- | ------------- | --------------------- |
+| `==` | 等しい           | `temperature==23`     |
+| `!=` | 等しくない         | `status!=inactive`    |
+| `>`  | より大きい         | `temperature>20`      |
+| `<`  | より小さい         | `temperature<30`      |
+| `>=` | 以上            | `temperature>=20`     |
+| `<=` | 以下            | `temperature<=30`     |
+| `..` | 範囲            | `temperature==20..30` |
+| `~=` | パターンマッチ(正規表現) | `name~=Room.*`        |
 
 ### 複数条件
 
-AND 条件はセミコロン (`;`) で結合します:
+AND 条件はセミコロン(`;`)で結合します:
 
 ```text
 q=temperature>20;pressure<800
 ```
 
-OR 条件はパイプ (`|`) で結合します (`;` は `|` より優先順位が高くなります):
+OR 条件はパイプ(`|`)で結合します(`;`は`|`よりも優先されます):
 
 ```text
 q=temperature==23|temperature==35
@@ -1323,7 +1410,7 @@ q=temperature>25;humidity<40|status==active
 
 ### 範囲クエリ
 
-`==` 演算子と `..` を組み合わせて範囲フィルタリングを行います (境界値を含む):
+Combine the `==`演算子と`..`を組み合わせて範囲フィルタリングを行います(境界値を含む):
 
 ```text
 q=temperature==20..30    # 20 or above and 30 or below
@@ -1336,27 +1423,27 @@ q=status~=act     # Partial match (regular expression)
 q=name==Room1     # Exact match
 ```
 
----
+***
 
 ## ジオクエリ
 
-位置情報を持つエンティティは空間的にクエリできます。
+位置情報を持つエンティティは、空間的にクエリできます。
 
 ### パラメータ
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `georel` | 空間関係 (coveredBy、within、intersects、disjoint、equals) |
-| `geometry` | ジオメトリタイプ (point、polygon、line、box) |
-| `coords` | 座標 (NGSIv2: 緯度,経度 形式; NGSI-LD: 経度,緯度 形式; 複数のポイントはセミコロンで区切る) |
+| パラメータ      | 説明                                                         |
+| ---------- | ---------------------------------------------------------- |
+| `georel`   | 空間関係(coveredBy、within、intersects、disjoint、equals)          |
+| `geometry` | ジオメトリタイプ(point、polygon、line、box)                           |
+| `coords`   | 座標(NGSIv2: 緯度,経度 形式; NGSI-LD: 経度,緯度 形式; 複数のポイントはセミコロンで区切る) |
 
-> **注意**: `georel`、`geometry`、`coords` (または NGSI-LD では `coordinates`) はすべて一緒に指定する必要があります。一部のみを指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 4.10)。
+> **注意**: `georel`、`geometry`、および`coords`(または NGSI-LD では`coordinates`)はすべて一緒に指定する必要があります。一部のみを指定すると`400 Bad Request`が返されます(ETSI GS CIM 009 V1.9.1 clause 4.10)。
 
 ### 座標形式
 
-NGSIv2 では、座標は **緯度,経度** の順序で指定します (NGSIv2 仕様に準拠)。NGSI-LD では、座標は **経度,緯度** の順序です (GeoJSON 標準に準拠)。
+NGSIv2 では、座標は**緯度,経度**の順序で指定されます(NGSIv2 仕様に準拠)。NGSI-LD では、座標は**経度,緯度**の順序です(GeoJSON 標準に準拠)。
 
-> **重要**: NGSIv2 における緯度,経度の順序は GeoJSON 標準 (経度,緯度) からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用しています。API を使用する際は、使用している API バージョンに合わせて正しい順序で座標を指定してください。
+> **重要**: NGSIv2 の緯度,経度 の順序は、GeoJSON 標準(経度,緯度)からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ 経度,緯度 の順序を使用します。API を使用する際は、使用している API バージョンに対応した正しい順序で座標を指定してください。
 
 ```text
 # NGSIv2 (latitude,longitude)
@@ -1369,7 +1456,7 @@ coordinates=[139.7671,35.6812]       # Single point
 
 ### エリア検索 (coveredBy / within)
 
-ポリゴン内のエンティティを検索します:
+ポリゴン内のエンティティを検索:
 
 ```http
 GET /v2/entities?georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138
@@ -1377,7 +1464,7 @@ GET /v2/entities?georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;3
 
 ### 交差検索 (intersects)
 
-ジオメトリと交差するエンティティを検索します:
+ジオメトリと交差するエンティティを検索:
 
 ```http
 GET /v2/entities?georel=intersects&geometry=box&coords=35.67,139.76;35.69,139.78
@@ -1385,22 +1472,23 @@ GET /v2/entities?georel=intersects&geometry=box&coords=35.67,139.76;35.69,139.78
 
 ### 非交差検索 (disjoint)
 
-ジオメトリと交差しないエンティティを検索します:
+ジオメトリと交差しないエンティティを検索:
 
 ```http
 GET /v2/entities?georel=disjoint&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138
 ```
+
 ### 近接検索 (near)
 
-指定された座標から一定の距離内にあるエンティティを検索します。
+指定された座標から一定距離内のエンティティを検索します。
 
 #### パラメータ
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `maxDistance` | 最大距離(メートル) |
-| `minDistance` | 最小距離(メートル) |
-| `orderByDistance` | `true` に設定すると、結果を距離順にソートし、各エンティティに距離情報(`@distance`)を付加します |
+| パラメータ             | 説明                                                      |
+| ----------------- | ------------------------------------------------------- |
+| `maxDistance`     | 最大距離(メートル)                                              |
+| `minDistance`     | 最小距離(メートル)                                              |
+| `orderByDistance` | 設定すると`true`、結果を距離順にソートし、距離情報(`@distance`)を各エンティティに付加します |
 
 #### 基本的な使い方 (NGSIv2)
 
@@ -1417,7 +1505,7 @@ GET /v2/entities?georel=near;minDistance:500;maxDistance:10000&geometry=point&co
 
 #### NGSI-LD での使い方
 
-NGSI-LD では、`==` を使用してパラメータを指定します:
+NGSI-LD では、`==`を使用してパラメータを指定します:
 
 ```http
 # Search for entities within 5km of Tokyo Station
@@ -1430,26 +1518,28 @@ GET /ngsi-ld/v1/entities?georel=near;minDistance==100000&geometry=Point&coordina
 GET /ngsi-ld/v1/entities?georel=near;minDistance==500;maxDistance==10000&geometry=Point&coordinates=[139.7671,35.6812]
 ```
 
-#### georel の構文比較
+#### georel 構文の比較
 
-georel パラメータの修飾子構文は NGSIv2 と NGSI-LD で異なります:
+georel パラメータ修飾子の構文は NGSIv2 と NGSI-LD で異なります:
 
-| 機能 | NGSIv2 | NGSI-LD | 説明 |
-|---------|--------|---------|-------------|
-| 最大距離 | `georel=near;maxDistance:5000` | `georel=near;maxDistance==5000` | `:` と `==` の違い |
-| 最小距離 | `georel=near;minDistance:1000` | `georel=near;minDistance==1000` | `:` と `==` の違い |
+| 機能   | NGSIv2                                          | NGSI-LD                                           | 説明             |
+| ---- | ----------------------------------------------- | ------------------------------------------------- | -------------- |
+| 最大距離 | `georel=near;maxDistance:5000`                  | `georel=near;maxDistance==5000`                   | `:` と `==` の違い |
+| 最小距離 | `georel=near;minDistance:1000`                  | `georel=near;minDistance==1000`                   | `:` と `==` の違い |
 | 距離範囲 | `georel=near;minDistance:500;maxDistance:10000` | `georel=near;minDistance==500;maxDistance==10000` | `:` と `==` の違い |
 
-> **構文が異なる理由**: NGSIv2 では `:` を使用してパラメータ値を指定しますが、NGSI-LD では ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用する API バージョンに対応した構文を使用してください。
+> **構文が異なる理由**: NGSIv2 では`:`を使用してパラメータ値を指定しますが、NGSI-LD では ETSI 仕様に従って`==`を使用します。API を呼び出す際は、使用している API バージョンに対応した構文を使用してください。
 
-#### 距離のソートと距離情報
+#### 距離ソートと距離情報
 
-`orderByDistance=true` パラメータを指定すると、以下の機能が有効になります:
+パラメータを指定すると、以下の機能が有効になります:`orderByDistance=true` parameter enables the following features:
 
-1. **距離のソート**: 結果が指定された座標からの距離の昇順でソートされます
-2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定された座標からの距離(メートル単位)が返されます
 
-この機能は MongoDB の `$geoNear` 集約パイプラインを使用して実装されています。
+1. **距離ソート**: 結果は指定された座標からの距離の昇順でソートされます
+   
+2. **距離情報**: 各エンティティに`@distance`属性が追加され、指定された座標からの距離(メートル単位)が返されます
+
+この機能は MongoDB の`$geoNear`集約パイプラインを使用して実装されています。
 
 ##### NGSIv2 での使い方
 
@@ -1494,7 +1584,7 @@ GET /ngsi-ld/v1/entities?georel=near;maxDistance==5000&geometry=Point&coordinate
 
 ##### 降順ソート
 
-`orderDirection=desc` と組み合わせて使用すると、距離の降順(遠い順)でソートされます:
+使用 `orderDirection=desc` を組み合わせて、距離の降順(最も遠いものから)でソートします:
 
 ```http
 GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.7671&orderByDistance=true&orderDirection=desc
@@ -1502,42 +1592,43 @@ GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.
 
 #### 制限事項
 
-- **Point ジオメトリのみ**: `geometry=point` (NGSIv2) または `geometry=Point` (NGSI-LD) のみがサポートされています
+
+* **Point ジオメトリのみ**: `geometry=point` (NGSIv2) または `geometry=Point` (NGSI-LD) のみがサポートされています
 
 ### エラー処理
 
-geo-query パラメータが無効な場合、`400 Bad Request` が返されます。
+ジオクエリパラメータが無効な場合、`400 Bad Request` が返されます。
 
-| エラー条件 | エラーメッセージ例 |
-|----------------|-----------------------|
-| 無効な `georel` 値 | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
-| 無効な `geometry` 値 | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box` |
-| 不十分な座標 (Point) | `Point geometry requires at least 2 coordinates, but got 1` |
-| 不十分な座標 (Polygon) | `Polygon geometry requires at least 4 coordinate pairs (8 values), but got 6 values` |
-| 不十分な座標 (LineString) | `LineString geometry requires at least 2 coordinate pairs (4 values), but got 2 values` |
-| 不十分な座標 (Box) | `Box geometry requires 2 coordinate pairs (4 values), but got 2 values` |
-| 無効な座標値 | `Invalid coordinate value: xxx` |
-| 緯度が範囲外 | `Latitude out of range: 91. Must be between -90 and 90.` |
-| 経度が範囲外 | `Longitude out of range: 181. Must be between -180 and 180.` |
-| 距離なしの `near` | `The 'near' georel requires maxDistance and/or minDistance modifier` |
-| Point 以外のジオメトリでの `near` | `The 'near' georel requires Point geometry, but 'polygon' was provided` |
+| エラー条件                            | エラーメッセージの例                                                                                               |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 無効な `georel` 値                   | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
+| 無効な `geometry` 値                 | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box`                 |
+| 座標が不足しています (Point)               | `Point geometry requires at least 2 coordinates, but got 1`                                              |
+| 座標が不足しています (Polygon)             | `Polygon geometry requires at least 4 coordinate pairs (8 values), but got 6 values`                     |
+| 座標が不足しています (LineString)          | `LineString geometry requires at least 2 coordinate pairs (4 values), but got 2 values`                  |
+| 座標が不足しています (Box)                 | `Box geometry requires 2 coordinate pairs (4 values), but got 2 values`                                  |
+| 無効な座標値                           | `Invalid coordinate value: xxx`                                                                          |
+| 緯度が範囲外です                         | `Latitude out of range: 91. Must be between -90 and 90.`                                                 |
+| 経度が範囲外です                         | `Longitude out of range: 181. Must be between -180 and 180.`                                             |
+| `near` で距離が指定されていません             | `The 'near' georel requires maxDistance and/or minDistance modifier`                                     |
+| `near` が Point 以外のジオメトリと使用されています | `The 'near' georel requires Point geometry, but 'polygon' was provided`                                  |
 
----
+***
 
 ## 空間 ID 検索
 
-日本のデジタル庁 / IPA が定めた 3 次元空間識別規格 (ZFXY 形式) に基づく空間検索をサポートします。
+日本のデジタル庁 / IPA が策定した 3D 空間識別標準(ZFXY 形式)に基づく空間検索をサポートします。
 
 ### ZFXY 形式
 
-| 要素 | 説明 | 範囲 |
-|---------|-------------|-------|
-| Z | ズームレベル | 0-28 |
-| F | 垂直方向 (高度レベル) | 整数 |
-| X | 東西方向 (経度タイル) | 0 to 2^z-1 |
-| Y | 南北方向 (緯度タイル) | 0 to 2^z-1 |
+| 要素 | 説明          | 範囲         |
+| -- | ----------- | ---------- |
+| Z  | ズームレベル      | 0-28       |
+| F  | 垂直方向(高度レベル) | 整数         |
+| X  | 東西方向(経度タイル) | 0 to 2^z-1 |
+| Y  | 南北方向(緯度タイル) | 0 to 2^z-1 |
 
-形式: `{z}/{f}/{x}/{y}` (例: `20/0/929593/410773`)
+形式:`{z}/{f}/{x}/{y}`(例:`20/0/929593/410773`)
 
 ### NGSIv2 での使用方法
 
@@ -1551,9 +1642,9 @@ GET /v2/entities?spatialId=20/0/929593/410773
 GET /ngsi-ld/v1/entities?spatialId=20/0/929593/410773
 ```
 
-### 階層展開 (spatialIdDepth)
+### 階層展開(spatialIdDepth)
 
-`spatialIdDepth` パラメータを指定すると、指定した空間 ID を中心とした周囲のタイルに検索を拡張します。
+Specifying the `spatialIdDepth`パラメータを指定すると、指定した空間 ID を中心とした周囲のタイルに検索を展開します。
 
 ```http
 # depth=1: Expands to a 3x3 tile grid (9 tiles)
@@ -1563,13 +1654,13 @@ GET /v2/entities?spatialId=20/0/929593/410773&spatialIdDepth=1
 GET /v2/entities?spatialId=20/0/929593/410773&spatialIdDepth=2
 ```
 
-| spatialIdDepth | 展開範囲 | タイル数 |
-|----------------|-----------------|------------|
-| 0 (デフォルト) | 指定したタイルのみ | 1 |
-| 1 | 3x3 | 9 |
-| 2 | 5x5 | 25 |
-| 3 | 7x7 | 49 |
-| 4 | 9x9 | 81 |
+| spatialIdDepth | 展開範囲    | タイル数 |
+| -------------- | ------- | ---- |
+| 0(デフォルト)       | 指定タイルのみ | 1    |
+| 1              | 3x3     | 9    |
+| 2              | 5x5     | 25   |
+| 3              | 7x7     | 49   |
+| 4              | 9x9     | 81   |
 
 ### 使用例
 
@@ -1583,15 +1674,15 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&spatialIdDe
   -H "Fiware-Service: smartcity"
 ```
 
----
+***
 
 ## GeoJSON 出力
 
-RFC 7946 準拠の GeoJSON FeatureCollection 形式でエンティティを出力できます。
+エンティティは RFC 7946 準拠の GeoJSON FeatureCollection 形式で出力できます。
 
 ### NGSIv2 での使用方法
 
-`options=geojson` パラメータまたは `Accept: application/geo+json` ヘッダーを使用します:
+Use the `options=geojson`パラメータまたは`Accept: application/geo+json`ヘッダーを使用します:
 
 ```http
 # options parameter
@@ -1604,7 +1695,7 @@ Accept: application/geo+json
 
 ### NGSI-LD での使用方法
 
-`format=geojson` パラメータまたは `Accept: application/geo+json` ヘッダーを使用します:
+Use the `format=geojson`パラメータまたは`Accept: application/geo+json`ヘッダーを使用します:
 
 ```http
 # format parameter
@@ -1653,7 +1744,7 @@ Accept: application/geo+json
 
 ### NGSI-LD における @context
 
-NGSI-LD で GeoJSON を出力する場合、`@context` が FeatureCollection レベルに含まれます:
+NGSI-LD で GeoJSON を出力する場合、`@context` は FeatureCollection レベルに含まれます:
 
 ```json
 {
@@ -1694,24 +1785,27 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&options=geo
 
 ### 注意事項
 
-- `location` 属性を持たないエンティティは `geometry: null` として出力されます
-- GeoJSON 出力は `keyValues` オプションと併用できます
-- Polygon、LineString、MultiPoint などのジオメトリタイプがサポートされています
 
----
+* &#x20;属性を持たないエンティティは `location` として出力されます`geometry: null`
+  
+* GeoJSON 出力は `keyValues` オプションと組み合わせて使用できます
+  
+* Polygon、LineString、MultiPoint などのジオメトリタイプがサポートされています
+
+***
 
 ## ベクタータイル
 
-エンティティは XYZ タイル方式に基づいて GeoJSON ベクタータイルとして出力できます。大量のエンティティを地図上に効率的に表示するために最適化されています。
+エンティティは XYZ タイル方式に基づいて GeoJSON ベクタータイルとして出力できます。地図上に大量のエンティティを効率的に表示するために最適化されています。
 
 ### エンドポイント
 
-| エンドポイント | 説明 |
-|----------|-------------|
-| `GET /v2/tiles` | TileJSON メタデータ (NGSIv2) |
-| `GET /v2/tiles/{z}/{x}/{y}.geojson` | GeoJSON タイル (NGSIv2) |
-| `GET /ngsi-ld/v1/tiles` | TileJSON メタデータ (NGSI-LD) |
-| `GET /ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GeoJSON タイル (NGSI-LD) |
+| エンドポイント                                     | 説明                       |
+| ------------------------------------------- | ------------------------ |
+| `GET /v2/tiles`                             | TileJSON メタデータ (NGSIv2)  |
+| `GET /v2/tiles/{z}/{x}/{y}.geojson`         | GeoJSON タイル (NGSIv2)     |
+| `GET /ngsi-ld/v1/tiles`                     | TileJSON メタデータ (NGSI-LD) |
+| `GET /ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GeoJSON タイル (NGSI-LD)    |
 
 ### TileJSON メタデータ
 
@@ -1739,7 +1833,7 @@ curl "http://localhost:3000/v2/tiles" \
 
 ### GeoJSON タイルの取得
 
-XYZ 座標を指定してタイル内のエンティティを GeoJSON 形式で取得します:
+XYZ 座標を指定して、タイル内のエンティティを GeoJSON 形式で取得します:
 
 ```bash
 # Zoom level 14 tile around Tokyo
@@ -1749,10 +1843,10 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson" \
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `type` | エンティティタイプでフィルタリング |
-| `attrs` | 出力する属性をカンマ区切りリストで指定 |
+| パラメータ   | 説明                    |
+| ------- | --------------------- |
+| `type`  | エンティティタイプでフィルタリング     |
+| `attrs` | カンマ区切りリストとして出力する属性を指定 |
 
 **使用例**
 
@@ -1797,7 +1891,7 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 ### クラスタリング
 
-タイル内のエンティティ数が閾値(デフォルト: 1000)を超えた場合、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスター Feature が返されます。
+タイル内のエンティティ数が閾値(デフォルト:1000)を超えると、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスタ Feature が返されます。
 
 **クラスタリング時のレスポンス例**
 
@@ -1834,24 +1928,27 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 **レスポンスヘッダー**
 
-| ヘッダー | 説明 |
-|--------|-------------|
-| `X-Tile-Mode` | `individual` (個別のエンティティ) または `clustered` (クラスタリング) |
-| `X-Total-Count` | タイル内のエンティティの総数 |
+| ヘッダー            | 説明                                                |
+| --------------- | ------------------------------------------------- |
+| `X-Tile-Mode`   | `individual` (個別エンティティ) または `clustered` (クラスタリング) |
+| `X-Total-Count` | タイル内のエンティティの総数                                    |
 
 ### 設定
 
-| 環境変数 | デフォルト | 説明 |
-|----------------------|---------|-------------|
+| 環境変数                       | デフォルト  | 説明                           |
+| -------------------------- | ------ | ---------------------------- |
 | `MAX_ENTITIES_PER_REQUEST` | `1000` | クラスタリングの閾値(この値以上でクラスタリングが発生) |
 
 ### 参考文献
 
-- [TileJSON 3.0 仕様](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
-- [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
-- [XYZ タイル方式](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
 
----
+* [TileJSON 3.0 仕様](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
+  
+* [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
+  
+* [XYZ Tile Scheme](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+
+***
 
 ## 座標参照系 (CRS)
 
@@ -1859,17 +1956,17 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 ### サポートされている CRS
 
-| CRS | EPSG | 説明 | 使用例 |
-|-----|------|-------------|----------|
-| WGS84 | EPSG:4326 | 世界測地系 1984 (デフォルト) | GPS、国際標準 |
-| JGD2011 | EPSG:6668 | 日本測地系 2011 | 日本国内の高精度測量 |
-| Web Mercator | EPSG:3857 | Web メルカトル図法 | Google Maps、OpenStreetMap など |
+| CRS          | EPSG      | 説明                 | ユースケース                       |
+| ------------ | --------- | ------------------ | ---------------------------- |
+| WGS84        | EPSG:4326 | 世界測地系 1984 (デフォルト) | GPS、国際標準                     |
+| JGD2011      | EPSG:6668 | 日本測地系 2011         | 日本における高精度測量                  |
+| Web Mercator | EPSG:3857 | Web メルカトル図法        | Google Maps、OpenStreetMap など |
 
 ### CRS の指定方法
 
 #### NGSIv2
 
-`crs` クエリパラメータを使用して EPSG コードを指定します:
+&#x20;クエリパラメータを使用して EPSG コードを指定します:`crs` query parameter:
 
 ```http
 # Retrieve with JGD2011 coordinates
@@ -1899,7 +1996,7 @@ CRS を指定したリクエストに対するレスポンスには、`Content-C
 Content-Crs: EPSG:6668
 ```
 
-NGSI-LD で URN 形式が指定された場合、URN 形式で返されます:
+NGSI-LD で URN 形式が指定されている場合、URN 形式で返されます:
 
 ```text
 Content-Crs: urn:ogc:def:crs:EPSG::6668
@@ -1950,10 +2047,10 @@ curl "http://localhost:3000/v2/entities/Store1?crs=EPSG:6668" \
 
 ### 座標変換の精度
 
-| 変換 | 精度 |
-|------------|----------|
-| WGS84 ↔ JGD2011 | 数 cm から数十 cm |
-| WGS84 ↔ Web メルカトル | 計算精度に依存(緯度 ±85 度以内) |
+| 変換                   | 精度                  |
+| -------------------- | ------------------- |
+| WGS84 ↔ JGD2011      | 数 cm から数十 cm        |
+| WGS84 ↔ Web Mercator | 計算精度に依存(緯度 ±85 度以内) |
 
 ### 使用例
 
@@ -2010,29 +2107,35 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Landmark&crs=EPSG:6668" \
 
 ### エラー
 
-| エラー | HTTP コード | 説明 |
-|-------|-----------|-------------|
-| Unsupported CRS | 400 | 指定された CRS コードはサポートされていません |
-| Invalid CRS format | 400 | 無効な CRS 形式が指定されました |
-| Coordinates out of range | 400 | Web メルカトルで緯度 ±85 度を超える座標 |
+| エラー            | HTTP コード | 説明                         |
+| -------------- | -------- | -------------------------- |
+| サポートされていない CRS | 400      | 指定された CRS コードはサポートされていません  |
+| 無効な CRS フォーマット | 400      | 無効な CRS フォーマットが指定されました     |
+| 座標が範囲外         | 400      | Web Mercator で緯度±85度を超える座標 |
 
 ### 制限事項
 
-- Web メルカトル (EPSG:3857) は緯度 ±85 度を超える範囲をサポートしていません
-- すべての座標は内部的に WGS84 で保存されます
-- 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリを使用しています
 
-### 参考資料
+* Web Mercator (EPSG:3857) は緯度±85度を超える領域をサポートしていません
+  
+* すべての座標は内部的に WGS84 で保存されます
+  
+* 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリが使用されます
 
-- [OGC API Features CRS Extension](https://docs.ogc.org/is/18-058r1/18-058r1.html)
-- [EPSG Geodetic Parameter Registry](https://epsg.io/)
-- [ETSI NGSI-LD CRS Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.08.01_60/gs_CIM009v010801p.pdf)
+### 参考文献
 
----
 
-## データカタログ API
+* [OGC API Features CRS Extension](https://docs.ogc.org/is/18-058r1/18-058r1.html)
+  
+* [EPSG Geodetic Parameter Registry](https://epsg.io/)
+  
+* [ETSI NGSI-LD CRS Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.08.01_60/gs_CIM009v010801p.pdf)
 
-DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest 互換のエンドポイントを提供します。
+***
+
+## Data Catalog API
+
+DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest 互換エンドポイントを提供します。
 
 ### DCAT-AP カタログ
 
@@ -2040,7 +2143,7 @@ DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest �
 GET /catalog
 ```
 
-カタログ全体を DCAT-AP 形式で JSON-LD として出力します。
+DCAT-AP 形式でカタログ全体を JSON-LD として出力します。
 
 **レスポンス例**
 
@@ -2072,10 +2175,10 @@ DCAT 形式でデータセットの一覧を出力します。
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 取得するデータセット数 |
-| `offset` | スキップするデータセット数 |
+| パラメータ    | 説明             |
+| -------- | -------------- |
+| `limit`  | 取得するデータセットの数   |
+| `offset` | スキップするデータセットの数 |
 
 ### 個別データセット
 
@@ -2095,21 +2198,21 @@ GET /catalog/datasets/{datasetId}/sample
 
 **クエリパラメータ**
 
-| パラメータ | 説明 | デフォルト |
-|-----------|-------------|---------|
-| `limit` | 取得するサンプル数 | 5 |
+| パラメータ   | 説明         | デフォルト |
+| ------- | ---------- | ----- |
+| `limit` | 取得するサンプルの数 | 5     |
 
 ### CKAN 互換 API
 
 CKAN データカタログハーベスターと互換性のある API を提供します。
 
-#### パッケージ一覧
+#### パッケージリスト
 
 ```http
 GET /catalog/ckan/package_list
 ```
 
-すべてのパッケージ(データセット)の ID 一覧を取得します。
+すべてのパッケージ(データセット)の ID リストを取得します。
 
 **レスポンス例**
 
@@ -2149,32 +2252,32 @@ GET /catalog/ckan/package_show?id={package_id}
 }
 ```
 
-#### リソース付きパッケージ一覧
+#### リソース付きパッケージリスト
 
 ```http
 GET /catalog/ckan/current_package_list_with_resources
 ```
 
-リソース情報を含むパッケージの一覧をページネーション形式で取得します。
+リソース情報を含むパッケージのページ分割されたリストを取得します。
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 取得するパッケージ数 |
-| `offset` | スキップするパッケージ数 |
+| パラメータ    | 説明            |
+| -------- | ------------- |
+| `limit`  | 取得するパッケージの数   |
+| `offset` | スキップするパッケージの数 |
 
-詳細は外部連携ドキュメントを参照してください。
+詳細については、外部統合ドキュメントを参照してください。
 
----
+***
 
-## CADDE 連携
+## CADDE 統合
 
-CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの連携機能を提供します。
+CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの統合機能を提供します。
 
 ### 概要
 
-CADDE は、異なるセクター間でのデータ共有を可能にする日本のデータ交換アーキテクチャです。この Context Broker は CADDE コネクタからのリクエストを受け付け、来歴情報を含むレスポンスを返します。
+CADDE は、異なるセクター間でのデータ共有を可能にする日本のデータ交換アーキテクチャです。この Context Broker は CADDE コネクタからのリクエストを受け取り、来歴情報を含むレスポンスを返します。
 
 ### 有効化
 
@@ -2192,52 +2295,52 @@ curl -X PUT "https://api.example.com/admin/cadde" \
   }'
 ```
 
-| 設定項目 | デフォルト値 | 説明 |
-|--------------------|---------|-------------|
-| `enabled` | `false` | CADDE 機能を有効化 |
-| `authEnabled` | `false` | Bearer 認証を有効化 |
-| `defaultProvider` | - | デフォルトのプロバイダ ID |
-| `jwtIssuer` | - | JWT 検証における期待される発行者 (`iss`) クレーム |
-| `jwtAudience` | - | JWT 検証における期待される対象者 (`aud`) クレーム |
-| `jwksUrl` | - | 署名検証用の JWKS エンドポイント URL (HTTPS が必要) |
+| 設定項目              | デフォルト   | 説明                                    |
+| ----------------- | ------- | ------------------------------------- |
+| `enabled`         | `false` | CADDE 機能を有効化                          |
+| `authEnabled`     | `false` | Bearer 認証を有効化                         |
+| `defaultProvider` | -       | デフォルトプロバイダー ID                        |
+| `jwtIssuer`       | -       | JWT 検証のための期待される発行者 (`iss`) クレーム       |
+| `jwtAudience`     | -       | JWT 検証のための期待されるオーディエンス (`aud`) クレーム   |
+| `jwksUrl`         | -       | 署名検証のための JWKS エンドポイント URL (HTTPS が必要) |
 
-設定は MongoDB に保存されるため、デプロイ後に API 経由で動的に変更できます。
+設定は MongoDB に保存されるため、デプロイ後に API を介して動的に変更できます。
 
-### リクエストヘッダ
+### リクエストヘッダー
 
-CADDE コネクタからのリクエストには以下のヘッダが含まれます:
+CADDE コネクターからのリクエストには、以下のヘッダーが含まれます:
 
-| ヘッダ | 必須 | 説明 |
-|--------|----------|-------------|
-| `x-cadde-resource-url` | - | アクセスされるリソースの URL |
-| `x-cadde-resource-api-type` | - | API タイプ (例: `api/ngsi`) |
-| `x-cadde-provider` | - | データプロバイダ ID |
-| `x-cadde-options` | - | 追加オプション (テナントヘッダなど) |
+| ヘッダー                        | 必須 | 説明                      |
+| --------------------------- | -- | ----------------------- |
+| `x-cadde-resource-url`      | -  | アクセスされるリソースの URL        |
+| `x-cadde-resource-api-type` | -  | API タイプ (例: `api/ngsi`) |
+| `x-cadde-provider`          | -  | データプロバイダー ID            |
+| `x-cadde-options`           | -  | 追加オプション (テナントヘッダーなど)    |
 
-### x-cadde-options のフォーマット
+### x-cadde-options フォーマット
 
-テナント情報やその他の詳細は `x-cadde-options` ヘッダで指定できます:
+テナント情報やその他の詳細は、`x-cadde-options` ヘッダーで指定できます:
 
 ```text
 x-cadde-options: Fiware-Service:smartcity, Fiware-ServicePath:/sensors
 ```
 
-このヘッダで指定された値は、通常の HTTP ヘッダよりも優先されます。
+このヘッダーで指定された値は、通常の HTTP ヘッダーよりも優先されます。
 
-### プロヴェナンスレスポンスヘッダ
+### 来歴レスポンスヘッダー
 
-CADDE リクエストへのレスポンスには以下のプロヴェナンスヘッダが含まれます:
+CADDE リクエストへのレスポンスには、以下の来歴ヘッダーが含まれます:
 
-| ヘッダ | 説明 |
-|--------|-------------|
-| `x-cadde-provenance-id` | リクエストの一意識別子 (Fiware-Correlator を使用) |
-| `x-cadde-provenance-timestamp` | レスポンス生成時刻 (ISO 8601 形式) |
-| `x-cadde-provenance-provider` | データプロバイダ ID |
-| `x-cadde-provenance-resource-url` | アクセスされたリソースの URL |
+| ヘッダー                              | 説明                                  |
+| --------------------------------- | ----------------------------------- |
+| `x-cadde-provenance-id`           | リクエストの一意識別子 (Fiware-Correlator を使用) |
+| `x-cadde-provenance-timestamp`    | レスポンス生成時刻 (ISO 8601 形式)             |
+| `x-cadde-provenance-provider`     | データプロバイダー ID                        |
+| `x-cadde-provenance-resource-url` | アクセスされたリソースの URL                    |
 
 ### 認証
 
-`CADDE_AUTH_ENABLED=true` が設定されている場合、CADDE リクエストには Bearer 認証が必要です:
+の場合、`CADDE_AUTH_ENABLED=true`、CADDE リクエストには Bearer 認証が必要です:
 
 ```http
 Authorization: Bearer <token>
@@ -2245,17 +2348,17 @@ Authorization: Bearer <token>
 
 トークンが存在しない場合、`401 Unauthorized` エラーが返されます。
 
-#### JWT 検証 (オプション)
+#### JWT 検証(オプション)
 
-`CADDE_JWKS_URL` を設定すると、Bearer トークンの完全な JWT 検証が有効になります:
+Setting `CADDE_JWKS_URL` を設定すると、Bearer トークンの完全な JWT 検証が有効になります:
 
-| 機能 | 説明 |
-|---------|-------------|
-| **署名検証** | RS256 または ES256 アルゴリズムをサポート。JWKS エンドポイントから公開鍵を自動取得 |
-| **有効期限検証** | `exp` (有効期限) クレームを検証し、期限切れトークンを拒否 |
-| **発行時刻検証** | `iat` (発行時刻) クレームを検証し、未来に発行されたトークンを拒否 |
-| **発行者検証** | `iss` クレームが `CADDE_JWT_ISSUER` が設定されている場合に検証 |
-| **対象者検証** | `aud` クレームが `CADDE_JWT_AUDIENCE` が設定されている場合に検証 |
+| 機能            | 説明                                                              |
+| ------------- | --------------------------------------------------------------- |
+| **署名検証**      | RS256 または ES256 アルゴリズムをサポートします。JWKS エンドポイントから公開鍵を自動的に取得します      |
+| **有効期限検証**    | Validates the `exp`(有効期限)クレームを検証し、期限切れのトークンを拒否します               |
+| **発行時刻検証**    | Validates the `iat`(発行時刻)クレームを検証し、未来に発行されたトークンを拒否します            |
+| **発行者検証**     | Validates the `iss` クレームを検証します(`CADDE_JWT_ISSUER` が設定されている場合)   |
+| **オーディエンス検証** | Validates the `aud` クレームを検証します(`CADDE_JWT_AUDIENCE` が設定されている場合) |
 
 **設定例:**
 
@@ -2277,18 +2380,18 @@ curl -X PUT "https://api.example.com/admin/cadde" \
 
 JWT 検証が失敗した場合、詳細なエラーメッセージが返されます:
 
-| エラー | 説明 |
-|-------|-------------|
-| `Malformed JWT token` | 無効なトークン形式 |
-| `Invalid token signature` | 無効な署名 |
-| `Token has expired` | トークンの有効期限切れ |
-| `Invalid token issuer` | 発行者クレームが一致しない |
-| `Invalid token audience` | 対象者クレームが一致しない |
-| `Unsupported signing algorithm` | サポートされていないアルゴリズム (RS256/ES256 以外) |
-| `Unable to fetch signing keys` | JWKS エンドポイントへのアクセスに失敗 |
-| `Signing key not found` | 指定された kid を持つ鍵が JWKS に存在しない |
+| エラー                             | 説明                               |
+| ------------------------------- | -------------------------------- |
+| `Malformed JWT token`           | 無効なトークン形式                        |
+| `Invalid token signature`       | 無効な署名                            |
+| `Token has expired`             | トークンの有効期限が切れています                 |
+| `Invalid token issuer`          | 発行者クレームが一致しません                   |
+| `Invalid token audience`        | オーディエンスクレームが一致しません               |
+| `Unsupported signing algorithm` | サポートされていないアルゴリズム(RS256/ES256 以外) |
+| `Unable to fetch signing keys`  | JWKS エンドポイントへのアクセスに失敗しました        |
+| `Signing key not found`         | 指定された kid のキーが JWKS に存在しません      |
 
-**注意:** `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます (後方互換性のため)。
+**注意:** If `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます(後方互換性のため)。
 
 ### 使用例
 
@@ -2309,7 +2412,7 @@ curl "http://localhost:3000/v2/entities" \
 
 ### NGSI-LD API での使用
 
-CADDE ヘッダは NGSI-LD API でも使用できます:
+CADDE ヘッダーは NGSI-LD API でも使用できます:
 
 ```bash
 curl "http://localhost:3000/ngsi-ld/v1/entities" \
@@ -2318,33 +2421,38 @@ curl "http://localhost:3000/ngsi-ld/v1/entities" \
   -H "x-cadde-provider: ld-provider" \
   -H "x-cadde-options: Fiware-Service:smartcity"
 ```
+
 ### CADDE Connector v4 API
 
-CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE 設定が有効な場合のみ利用可能、`PUT /admin/cadde` で設定)。
+CADDE コネクタ v4 仕様に準拠した専用エンドポイント(CADDE 設定が有効な場合のみ利用可能。設定は `PUT /admin/cadde` で行います)。
 
-参考: https://github.com/CADDE-sip/connector
+参照: <https://github.com/CADDE-sip/connector>
 
 #### エンドポイント一覧
 
-| メソッド | パス | 説明 |
-|--------|------|-------------|
-| GET | `/cadde/api/v4/catalog` | カタログ検索 (横断検索 / 詳細検索) |
-| GET | `/cadde/api/v4/entities` | NGSI データ交換 |
+| メソッド | パス                       | 説明                |
+| ---- | ------------------------ | ----------------- |
+| GET  | `/cadde/api/v4/catalog`  | カタログ検索(横断検索/詳細検索) |
+| GET  | `/cadde/api/v4/entities` | NGSI データ交換        |
 
-#### カタログ検索 (`/cadde/api/v4/catalog`
+#### カタログ検索(`/cadde/api/v4/catalog`
+
 )
 
-`x-cadde-search` ヘッダーを使用して検索タイプを指定します:
+&#x20;ヘッダーを使用して検索タイプを指定します:`x-cadde-search` ヘッダー:
 
-| 検索タイプ | ヘッダー値 | 説明 |
-|-------------|--------------|-------------|
-| 横断検索 | `x-cadde-search: meta` | CKAN 形式のデータセット一覧を返却 (`q` パラメータによるキーワードフィルタリング) |
-| 詳細検索 | `x-cadde-search: detail` | 個別データセットの詳細を返却 (`id` または `fq` パラメータで指定) |
+| 検索タイプ | ヘッダー値                    | 説明                                               |
+| ----- | ------------------------ | ------------------------------------------------ |
+| 横断検索  | `x-cadde-search: meta`   | CKAN 形式でデータセットリストを返します(`q` パラメータによるキーワードフィルタリング) |
+| 詳細検索  | `x-cadde-search: detail` | 個別データセットの詳細を返します(`id` または `fq` パラメータで指定)         |
 
-CADDE 固有のフィールドがレスポンスに追加されます:
-- `caddec_dataset_id_for_detail`: 詳細検索用のデータセット ID
-- `caddec_provider_id`: プロバイダ ID (`CADDE_DEFAULT_PROVIDER` が設定されている場合)
-- `caddec_resource_type`: リソースタイプ (`api/ngsi`)
+レスポンスには CADDE 固有のフィールドが追加されます:
+
+* `caddec_dataset_id_for_detail`: 詳細検索用のデータセット ID
+  
+* `caddec_provider_id`: プロバイダ ID(`CADDE_DEFAULT_PROVIDER` が設定されている場合)
+  
+* `caddec_resource_type`: リソースタイプ(`api/ngsi`)
 
 ```bash
 # Cross-domain search
@@ -2360,16 +2468,17 @@ curl "http://localhost:3000/cadde/api/v4/catalog?id=sensor" \
   -H "Fiware-Service: smartcity"
 ```
 
-#### NGSI データ交換 (`/cadde/api/v4/entities`
+#### NGSI データ交換(`/cadde/api/v4/entities`
+
 )
 
-`x-cadde-resource-url` ヘッダーからクエリパラメータを解析してエンティティを取得します。
+&#x20;ヘッダーからクエリパラメータを解析してエンティティを取得します。`x-cadde-resource-url` ヘッダーからクエリパラメータを解析してエンティティを取得します。
 
-| ヘッダー | 必須 | 説明 |
-|--------|----------|-------------|
-| `x-cadde-resource-url` | Yes | リソース URL (type、id、q、attrs、limit、offset をクエリパラメータとして含む) |
-| `x-cadde-resource-api-type` | - | レスポンス形式: `api/ngsi` (デフォルト) または `api/ngsi-ld` |
-| `x-cadde-provider` | - | データプロバイダ ID |
+| ヘッダー                        | 必須  | 説明                                                    |
+| --------------------------- | --- | ----------------------------------------------------- |
+| `x-cadde-resource-url`      | Yes | リソース URL(type、id、q、attrs、limit、offset をクエリパラメータとして含む) |
+| `x-cadde-resource-api-type` | -   | レスポンス形式: `api/ngsi`(デフォルト)または `api/ngsi-ld`           |
+| `x-cadde-provider`          | -   | データプロバイダ ID                                           |
 
 ```bash
 # Retrieve entities in NGSIv2 format
@@ -2397,19 +2506,22 @@ CADDE v4 エンドポイントのエラーレスポンスは以下の形式で�
 
 #### 認証
 
-CADDE v4 エンドポイントは GeonicDB 認証 (`requireAuth`) をバイパスします。認証は CADDE JWT 検証 (`processCaddeRequestAsync`) によって処理されます。
+CADDE v4 エンドポイントは GeonicDB 認証(`requireAuth`)をバイパスします。認証は CADDE JWT 検証(`processCaddeRequestAsync`)で処理されます。
 
-### 参考資料
+### 参考
 
-- [CADDE (分野間データ連携基盤)](https://www.data-ex.jp/)
-- [CADDE-sip/connector](https://github.com/CADDE-sip/connector)
-- [DATA-EX](https://data-ex.jp/)
 
----
+* [CADDE(分野間データ連携基盤)](https://www.data-ex.jp/)
+  
+* [CADDE-sip/connector](https://github.com/CADDE-sip/connector)
+  
+* [DATA-EX](https://data-ex.jp/)
+
+***
 
 ## イベントストリーミング
 
-WebSocket API Gateway を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化します。
+WebSocket API Gateway を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true`で有効化。
 
 ### 接続
 
@@ -2419,22 +2531,22 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 
 ### クライアントメッセージ
 
-| アクション | 説明 |
-|--------|-------------|
+| アクション       | 説明                          |
+| ----------- | --------------------------- |
 | `subscribe` | エンティティタイプ / ID パターンでフィルタを設定 |
-| `ping` | キープアライブ (`pong` レスポンス) |
+| `ping`      | キープアライブ(`pong` レスポンス)       |
 
 ### サーバーイベント
 
-| タイプ | 説明 |
-|------|-------------|
+| タイプ             | 説明             |
+| --------------- | -------------- |
 | `entityCreated` | エンティティが作成されました |
 | `entityUpdated` | エンティティが更新されました |
 | `entityDeleted` | エンティティが削除されました |
 
-詳細は [イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
+詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md)を参照してください。
 
----
+***
 
 ## エラーレスポンス
 
@@ -2449,8 +2561,8 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 
 ### NGSI-LD エラーフォーマット (RFC 7807 ProblemDetails)
 
-NGSI-LD API のエラーレスポンスは [RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
-Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` ではなく標準の JSON MIME タイプが使用されます)。
+NGSI-LD API エラーレスポンスは [RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
+Content-Type は `application/json` です(ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` の代わりに標準 JSON MIME タイプが使用されます)。
 
 ```json
 {
@@ -2463,63 +2575,63 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 
 ### HTTP ステータスコード
 
-| コード | 説明 |
-|------|-------------|
-| `200` | 成功 (データあり) |
-| `201` | 正常に作成されました |
-| `204` | 成功 (データなし) |
-| `207` | 部分的な成功 (バッチ操作) |
-| `400` | 不正なリクエスト |
-| `403` | 禁止 (認可エラー) |
-| `404` | リソースが見つかりません |
-| `405` | メソッドが許可されていません (NGSI-LD、`Allow` ヘッダー付き) |
-| `409` | 競合 (既に存在する、など) |
-| `500` | 内部サーバーエラー |
+| コード   | 説明                                     |
+| ----- | -------------------------------------- |
+| `200` | 成功(データあり)                              |
+| `201` | 作成成功                                   |
+| `204` | 成功(データなし)                              |
+| `207` | 部分的成功(バッチ操作)                           |
+| `400` | 不正なリクエスト                               |
+| `403` | 禁止(認証エラー)                              |
+| `404` | リソースが見つかりません                           |
+| `405` | メソッドが許可されていません(NGSI-LD、`Allow` ヘッダーあり) |
+| `409` | 競合(既に存在する、など)                          |
+| `500` | 内部サーバーエラー                              |
 
----
+***
 
 ## 実装状況
 
 ### 実装済み機能
 
-| 機能 | NGSIv2 | NGSI-LD |
-|---------|--------|---------|
-| エンティティ CRUD | Yes | Yes |
-| 属性操作 | Yes | Yes |
-| 属性値の直接取得/更新 | Yes | - |
-| バッチ操作 | Yes | Yes |
-| サブスクリプション (HTTP 通知) | Yes | Yes |
-| サブスクリプション (MQTT 通知) | Yes | Yes |
-| イベントストリーミング (WebSocket) | Yes | Yes |
-| エンティティタイプ | Yes | - |
-| クエリ言語 (q パラメータ) | Yes | Yes |
-| ソート (orderBy, orderDirection) | Yes | Yes |
-| メタデータ制御 (metadata / sysAttrs) | Yes | Yes |
-| 地理クエリ (coveredBy, within, intersects, disjoint) | Yes | Yes |
-| 空間 ID 検索 (ZFXY フォーマット) | Yes | Yes |
-| GeoJSON 出力 | Yes | Yes |
-| 座標参照系 (CRS) 変換 | Yes | Yes |
-| マルチテナンシー | Yes | Yes |
-| ページネーション | Yes | Yes |
-| keyValues フォーマット | Yes | Yes |
-| レジストレーション | Yes | Yes |
-| コンテキストプロバイダー (フェデレーション/クエリ転送) | Yes | Yes |
-| コンテキストプロバイダー (更新転送) | Yes | Yes |
-| CADDE 連携 | Yes | Yes |
-| 認証 API (JWT ベース) | Yes | Yes |
-| ユーザー/テナント管理 API | Yes | Yes |
-| `/version` エンドポイント | Yes | - |
-| `/.well-known/ngsi-ld` | - | Yes |
-| ヘルスチェック (`/health`) | Yes | Yes |
+| 機能                                              | NGSIv2 | NGSI-LD |
+| ----------------------------------------------- | ------ | ------- |
+| Entity CRUD                                     | Yes    | Yes     |
+| 属性操作                                            | Yes    | Yes     |
+| 属性値の直接取得/更新                                     | Yes    | -       |
+| バッチ操作                                           | Yes    | Yes     |
+| サブスクリプション (HTTP 通知)                             | Yes    | Yes     |
+| サブスクリプション (MQTT 通知)                             | Yes    | Yes     |
+| イベントストリーミング (WebSocket)                         | Yes    | Yes     |
+| エンティティタイプ                                       | Yes    | -       |
+| クエリ言語 (q パラメータ)                                 | Yes    | Yes     |
+| ソート (orderBy, orderDirection)                   | Yes    | Yes     |
+| メタデータ制御 (metadata / sysAttrs)                   | Yes    | Yes     |
+| 地理クエリ (coveredBy, within, intersects, disjoint) | Yes    | Yes     |
+| 空間 ID 検索 (ZFXY 形式)                              | Yes    | Yes     |
+| GeoJSON 出力                                      | Yes    | Yes     |
+| 座標参照系 (CRS) 変換                                  | Yes    | Yes     |
+| マルチテナンシー                                        | Yes    | Yes     |
+| ページネーション                                        | Yes    | Yes     |
+| keyValues 形式                                    | Yes    | Yes     |
+| レジストレーション                                       | Yes    | Yes     |
+| コンテキストプロバイダー (フェデレーション/クエリ転送)                   | Yes    | Yes     |
+| コンテキストプロバイダー (更新転送)                             | Yes    | Yes     |
+| CADDE 統合                                        | Yes    | Yes     |
+| 認証 API (JWT ベース)                                | Yes    | Yes     |
+| ユーザー/テナント管理 API                                 | Yes    | Yes     |
+| `/version` エンドポイント                              | Yes    | -       |
+| `/.well-known/ngsi-ld`                          | -      | Yes     |
+| ヘルスチェック (`/health`)                             | Yes    | Yes     |
 
 ### 制限事項
 
-| 機能 | ステータス | 備考 |
-|---------|--------|-------|
-| `near` 地理クエリ (近接検索) | サポート済み | ポイントジオメトリのみ。`orderByDistance=true` による距離ソートと距離情報をサポート |
-| `minDistance` / `maxDistance` | サポート済み | メートル単位で指定 |
+| 機能                            | ステータス | 備考                                                  |
+| ----------------------------- | ----- | --------------------------------------------------- |
+| `near` 地理クエリ (近接検索)           | サポート  | Point ジオメトリのみ; 距離ソートおよび距離情報を `orderByDistance=true` |
+| `minDistance` / `maxDistance` | サポート  | メートル単位で指定                                           |
 
----
+***
 
 ## 使用例
 
@@ -2538,7 +2650,7 @@ curl -X POST "https://api.example.com/v2/entities" \
   }'
 ```
 
-### エンティティを取得する
+### エンティティの取得
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities/Room1" \
@@ -2546,7 +2658,7 @@ curl -X GET "https://api.example.com/v2/entities/Room1" \
   -H "Fiware-ServicePath: /buildings"
 ```
 
-### 条件クエリ
+### 条件付きクエリ
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities?type=Room&q=temperature>25" \
@@ -2560,7 +2672,7 @@ curl -X GET "https://api.example.com/v2/entities?type=Place&georel=coveredBy&geo
   -H "Fiware-Service: smartcity"
 ```
 
-### サブスクリプションを作成する
+### サブスクリプションの作成
 
 ```bash
 curl -X POST "https://api.example.com/v2/subscriptions" \
@@ -2582,7 +2694,7 @@ curl -X POST "https://api.example.com/v2/subscriptions" \
   }'
 ```
 
-### NGSI-LD エンティティを作成する
+### NGSI-LD エンティティの作成
 
 ```bash
 curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
@@ -2596,206 +2708,214 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
   }'
 ```
 
----
+***
 
 ## エンドポイントリファレンス
 
-このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、ステータスコード情報をまとめています。
+このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、およびステータスコード情報を要約します。
 
 ### API カテゴリ
 
-| API カテゴリ | ベースパス | 認証 | Content-Type |
-|--------------|-----------|----------------|--------------|
-| Meta/Health | `/` | 不要*† | `application/json` |
-| Authentication | `/auth` | 不要 | `application/json` |
-| User | `/me` | 必要 | `application/json` |
-| NGSIv2 | `/v2` | 必要* | `application/json` |
-| NGSI-LD | `/ngsi-ld/v1` | 必要* | `application/ld+json` |
-| Admin | `/admin` | 必要 (super_admin / tenant_admin) | `application/json` |
-| Catalog | `/catalog` | 必要* | `application/json` |
+| API カテゴリ       | ベースパス         | 認証                                | Content-Type          |
+| -------------- | ------------- | --------------------------------- | --------------------- |
+| Meta/Health    | `/`           | 不要\*†                             | `application/json`    |
+| Authentication | `/auth`       | 不要                                | `application/json`    |
+| User           | `/me`         | 必要                                | `application/json`    |
+| NGSIv2         | `/v2`         | 必要\*                              | `application/json`    |
+| NGSI-LD        | `/ngsi-ld/v1` | 必要\*                              | `application/ld+json` |
+| Admin          | `/admin`      | 必要 (super\_admin / tenant\_admin) | `application/json`    |
+| Catalog        | `/catalog`    | 必要\*                              | `application/json`    |
 
-\* `AUTH_ENABLED=false` の場合は認証不要
+\* 認証は不要です:`AUTH_ENABLED=false`
 
-† `/statistics`、`/cache/statistics`、`/metrics` は `AUTH_ENABLED=true` の場合に認証が必要
+† `/statistics`、`/cache/statistics`、`/metrics` は認証が必要です:`AUTH_ENABLED=true`
 
-### パブリックエンドポイント (Meta/Health)
+### 公開エンドポイント (メタ/ヘルス)
 
 認証なしでアクセス可能なエンドポイント。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/llms.txt` | GET | API ドキュメント (llms.txt) | 200 | - |
-| `/version` | GET | FIWARE Orion 互換バージョン情報 | 200 | - |
-| `/health` | GET | 基本ヘルスチェック | 200 | - |
-| `/health/live` | GET | Kubernetes liveness プローブ | 200 | - |
-| `/health/ready` | GET | Kubernetes readiness プローブ | 200 | 503 |
-| `/.well-known/ngsi-ld` | GET | NGSI-LD API ディスカバリー | 200 | - |
-| `/api.json` | GET | API リファレンス (JSON) | 200 | - |
-| `/openapi.json` | GET | OpenAPI 3.0 仕様 | 200 | - |
-| `/statistics` | GET | FIWARE Orion 互換統計情報(認証必要) | 200 | 401 |
-| `/cache/statistics` | GET | キャッシュ統計情報(認証必要) | 200 | 401 |
-| `/metrics` | GET | Prometheus メトリクス(認証必要) | 200 | 401 |
-| `/tools.json` | GET | AI ツール定義 (Claude Tool Use / OpenAI Function Calling) | 200 | - |
-| `/.well-known/ai-plugin.json` | GET | AI プラグインマニフェスト | 200 | - |
-| `/mcp` | POST | MCP (Model Context Protocol) Streamable HTTP エンドポイント | 200 | 400, 405, 500 |
-| `/.well-known/agent-card.json` | GET | A2A Agent Card | 200 | - |
+| エンドポイント                        | メソッド | 説明                                                   | 成功  | エラー           |
+| ------------------------------ | ---- | ---------------------------------------------------- | --- | ------------- |
+| `/llms.txt`                    | GET  | API ドキュメント (llms.txt)                                | 200 | -             |
+| `/version`                     | GET  | FIWARE Orion 互換バージョン情報                               | 200 | -             |
+| `/health`                      | GET  | 基本ヘルスチェック                                            | 200 | -             |
+| `/health/live`                 | GET  | Kubernetes liveness プローブ                             | 200 | -             |
+| `/health/ready`                | GET  | Kubernetes readiness プローブ                            | 200 | 503           |
+| `/.well-known/ngsi-ld`         | GET  | NGSI-LD API ディスカバリー                                  | 200 | -             |
+| `/api.json`                    | GET  | API リファレンス (JSON)                                    | 200 | -             |
+| `/openapi.json`                | GET  | OpenAPI 3.0 仕様                                       | 200 | -             |
+| `/statistics`                  | GET  | FIWARE Orion 互換統計情報 (認証が必要)                          | 200 | 401           |
+| `/cache/statistics`            | GET  | キャッシュ統計情報 (認証が必要)                                    | 200 | 401           |
+| `/metrics`                     | GET  | Prometheus メトリクス (認証が必要)                             | 200 | 401           |
+| `/tools.json`                  | GET  | AI ツール定義 (Claude Tool Use / OpenAI Function Calling) | 200 | -             |
+| `/.well-known/ai-plugin.json`  | GET  | AI プラグインマニフェスト                                       | 200 | -             |
+| `/mcp`                         | POST | MCP (Model Context Protocol) Streamable HTTP エンドポイント | 200 | 400, 405, 500 |
+| `/.well-known/agent-card.json` | GET  | A2A Agent Card                                       | 200 | -             |
 
-### AI エージェントエンドポイント (AUTH_ENABLED=true の場合は認証必要)
+### AI エージェントエンドポイント (AUTH\_ENABLED=true の場合は認証が必要)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/a2a` | POST | A2A (Agent-to-Agent) JSON-RPC 2.0 エンドポイント | 200 | 400, 401, 405, 500 |
+| エンドポイント | メソッド | 説明                                        | 成功  | エラー                |
+| ------- | ---- | ----------------------------------------- | --- | ------------------ |
+| `/a2a`  | POST | A2A (Agent-to-Agent) JSON-RPC 2.0 エンドポイント | 200 | 400, 401, 405, 500 |
 
 ### 認証エンドポイント
 
-- `/auth/*` は `AUTH_ENABLED=true` の場合のみ利用可能
-- `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能(常に有効; `OAUTH_ENABLED` は非推奨)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/auth/login` | POST | ユーザーログイン (JWT) | 200 | 400, 401 |
-| `/auth/refresh` | POST | トークンリフレッシュ | 200 | 400, 401 |
-| `/auth/logout` | POST | ログアウト(すべてのセッションを無効化、認証必要) | 204 | 401 |
-| `/auth/nonce` | POST | Nonce + PoW チャレンジによる API キートークン交換 | 200 | 400 |
-| `/oauth/token` | POST | OAuth トークン取得 (M2M: `grant_type=client_credentials`、Browser SDK: `grant_type=api_key`) | 200 | 400, 401 |
+* `/auth/*` は次の場合のみ利用可能`AUTH_ENABLED=true`
+  
+* `/oauth/token` は次の場合に利用可能`AUTH_ENABLED=true` (常に有効;`OAUTH_ENABLED` は非推奨)
+
+| エンドポイント         | メソッド | 説明                                                                                  | 成功  | エラー      |
+| --------------- | ---- | ----------------------------------------------------------------------------------- | --- | -------- |
+| `/auth/login`   | POST | ユーザーログイン (JWT)                                                                      | 200 | 400, 401 |
+| `/auth/refresh` | POST | トークン更新                                                                              | 200 | 400, 401 |
+| `/auth/logout`  | POST | ログアウト (すべてのセッションを無効化、認証が必要)                                                         | 204 | 401      |
+| `/auth/nonce`   | POST | API キートークン交換のための Nonce + PoW チャレンジ                                                  | 200 | 400      |
+| `/oauth/token`  | POST | OAuth トークン取得 (M2M:`grant_type=client_credentials`、Browser SDK:`grant_type=api_key`) | 200 | 400, 401 |
 
 ### SDK
 
-JavaScript SDK は npm パッケージとして提供されています: `npm install @geolonia/geonicdb-sdk`SDK は完全なパブリック API を提供します: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー(`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
+JavaScript SDK は npm パッケージとして利用可能です:`npm install @geolonia/geonicdb-sdk`
+
+SDK は完全な公開 API を提供します:`login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー (`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
 
 ### ユーザーエンドポイント
 
-認証されたユーザーが自分の情報を管理するためのエンドポイントです。
+認証されたユーザーが自分の情報を管理するためのエンドポイント。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | 最小ロール |
-|----------|--------|-------------|---------|-------|--------------|
-| `/me` | GET | 自分のプロフィールを取得 | 200 | 401 | user |
-| `/me/password` | POST | パスワードを変更 | 204 | 400, 401 | user |
+| エンドポイント        | メソッド | 説明           | 成功  | エラー      | 最小ロール |
+| -------------- | ---- | ------------ | --- | -------- | ----- |
+| `/me`          | GET  | 自分のプロフィールを取得 | 200 | 401      | user  |
+| `/me/password` | POST | パスワード変更      | 204 | 400, 401 | user  |
 
 ### NGSIv2 / NGSI-LD エンドポイント
 
-エンドポイントの詳細な仕様については、以下を参照してください:
-- [NGSIv2 API リファレンス](./ngsiv2.md)
-- [NGSI-LD API リファレンス](./ngsild.md)
+詳細なエンドポイント仕様については、以下を参照してください:
+
+* [NGSIv2 API リファレンス](./ngsiv2.md)
+  
+* [NGSI-LD API リファレンス](./ngsild.md)
 
 ### Admin API
 
-テナントとユーザーを管理するための API です。エンドポイントには `super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントスコープのみ)。
+テナントとユーザーを管理するための API です。エンドポイントには、`super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントスコープのみ)。
 
 #### テナント管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/tenants` | GET | テナント一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/tenants` | POST | テナント作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/tenants/{tenantId}` | GET | テナント取得 | 200 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}` | PATCH | テナント更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/tenants/{tenantId}` | DELETE | テナント削除 (`?shred=true` による Crypto-Shredding) | 204 / 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/deletion-report` | GET | 削除レポート取得 | 200 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/activate` | POST | テナント有効化 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/deactivate` | POST | テナント無効化 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/ip-restrictions` | GET | テナント IP 制限取得 | 200 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/ip-restrictions` | PUT | テナント IP 制限更新 | 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | テナント IP 制限削除 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users` | GET | テナントメンバー一覧取得 (tenant_admin: 自テナントのみ) | 200 | 401, 403, 404 | あり (最大: 100) |
-| `/admin/tenants/{tenantId}/users/{userId}` | PUT | テナントにユーザーを追加 (tenant_admin: 自テナントのみ) | 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | テナントからユーザーを削除 (tenant_admin: 自テナントのみ) | 204 | 400, 401, 403, 404 | - |
+| エンドポイント                                     | メソッド   | 説明                                      | 成功        | エラー                     | ページネーション       |
+| ------------------------------------------- | ------ | --------------------------------------- | --------- | ----------------------- | -------------- |
+| `/admin/tenants`                            | GET    | テナント一覧                                  | 200       | 400, 401, 403           | Yes (max: 100) |
+| `/admin/tenants`                            | POST   | テナント作成                                  | 201       | 400, 401, 403, 409      | -              |
+| `/admin/tenants/{tenantId}`                 | GET    | テナント取得                                  | 200       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}`                 | PATCH  | テナント更新                                  | 204       | 400, 401, 403, 404, 409 | -              |
+| `/admin/tenants/{tenantId}`                 | DELETE | テナント削除(Crypto-Shredding: `?shred=true`) | 204 / 200 | 400, 401, 403, 404      | -              |
+| `/admin/tenants/{tenantId}/deletion-report` | GET    | 削除レポート取得                                | 200       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/activate`        | POST   | テナント有効化                                 | 204       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/deactivate`      | POST   | テナント無効化                                 | 204       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/ip-restrictions` | GET    | テナント IP 制限取得                            | 200       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/ip-restrictions` | PUT    | テナント IP 制限更新                            | 200       | 400, 401, 403, 404      | -              |
+| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | テナント IP 制限削除                            | 204       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/users`           | GET    | テナントメンバー一覧(tenant\_admin: 自テナントのみ)      | 200       | 401, 403, 404           | Yes (max: 100) |
+| `/admin/tenants/{tenantId}/users/{userId}`  | PUT    | テナントにユーザーを追加(tenant\_admin: 自テナントのみ)    | 200       | 400, 401, 403, 404      | -              |
+| `/admin/tenants/{tenantId}/users/{userId}`  | DELETE | テナントからユーザーを削除(tenant\_admin: 自テナントのみ)   | 204       | 400, 401, 403, 404      | -              |
 
 #### ユーザー管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/users` | GET | ユーザー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/users` | POST | ユーザー作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/users/{userId}` | GET | ユーザー取得 | 200 | 401, 403, 404 | - |
-| `/admin/users/{userId}` | PATCH | ユーザー更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/users/{userId}` | DELETE | ユーザー削除 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/activate` | POST | ユーザー有効化 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/deactivate` | POST | ユーザー無効化 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/unlock` | POST | ログインロック解除 | 200 | 400, 401, 403, 404 | - |
-| `/admin/users/{userId}/tenants` | GET | ユーザーが所属するテナント一覧取得 (自分自身または super_admin) | 200 | 401, 403 | あり (最大: 100) |
+| エンドポイント                            | メソッド   | 説明                                     | 成功  | エラー                     | ページネーション       |
+| ---------------------------------- | ------ | -------------------------------------- | --- | ----------------------- | -------------- |
+| `/admin/users`                     | GET    | ユーザー一覧                                 | 200 | 400, 401, 403           | Yes (max: 100) |
+| `/admin/users`                     | POST   | ユーザー作成                                 | 201 | 400, 401, 403, 409      | -              |
+| `/admin/users/{userId}`            | GET    | ユーザー取得                                 | 200 | 401, 403, 404           | -              |
+| `/admin/users/{userId}`            | PATCH  | ユーザー更新                                 | 204 | 400, 401, 403, 404, 409 | -              |
+| `/admin/users/{userId}`            | DELETE | ユーザー削除                                 | 204 | 401, 403, 404           | -              |
+| `/admin/users/{userId}/activate`   | POST   | ユーザー有効化                                | 204 | 401, 403, 404           | -              |
+| `/admin/users/{userId}/deactivate` | POST   | ユーザー無効化                                | 204 | 401, 403, 404           | -              |
+| `/admin/users/{userId}/unlock`     | POST   | ログインロック解除                              | 200 | 400, 401, 403, 404      | -              |
+| `/admin/users/{userId}/tenants`    | GET    | ユーザーが所属するテナント一覧(self または super\_admin) | 200 | 401, 403                | Yes (max: 100) |
 
-#### ポリシー管理 (XACML 3.0 認可、super_admin / tenant_admin)
+#### ポリシー管理(XACML 3.0 認可、super\_admin / tenant\_admin)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/policies` | GET | ポリシー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/policies` | POST | ポリシー作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/policies/{policyId}` | GET | ポリシー取得 | 200 | 401, 403, 404 | - |
-| `/admin/policies/{policyId}` | PATCH | ポリシー部分更新 | 200 | 400, 401, 403, 404 | - |
-| `/admin/policies/{policyId}` | PUT | ポリシー置換 | 200 | 400, 401, 403, 404 | - |
-| `/admin/policies/{policyId}` | DELETE | ポリシー削除 | 204 | 401, 403, 404 | - |
-| `/admin/policies/{policyId}/activate` | POST | ポリシー有効化 | 200 | 401, 403, 404 | - |
-| `/admin/policies/{policyId}/deactivate` | POST | ポリシー無効化 | 200 | 401, 403, 404 | - |
+| エンドポイント                                 | メソッド   | 説明       | 成功  | エラー                | ページネーション       |
+| --------------------------------------- | ------ | -------- | --- | ------------------ | -------------- |
+| `/admin/policies`                       | GET    | ポリシー一覧   | 200 | 400, 401, 403      | Yes (max: 100) |
+| `/admin/policies`                       | POST   | ポリシー作成   | 201 | 400, 401, 403, 409 | -              |
+| `/admin/policies/{policyId}`            | GET    | ポリシー取得   | 200 | 401, 403, 404      | -              |
+| `/admin/policies/{policyId}`            | PATCH  | ポリシー部分更新 | 200 | 400, 401, 403, 404 | -              |
+| `/admin/policies/{policyId}`            | PUT    | ポリシー置換   | 200 | 400, 401, 403, 404 | -              |
+| `/admin/policies/{policyId}`            | DELETE | ポリシー削除   | 204 | 401, 403, 404      | -              |
+| `/admin/policies/{policyId}/activate`   | POST   | ポリシー有効化  | 200 | 401, 403, 404      | -              |
+| `/admin/policies/{policyId}/deactivate` | POST   | ポリシー無効化  | 200 | 401, 403, 404      | -              |
 
-ポリシー Target `resources` で利用可能な **リソース属性**:
+**リソース属性** でポリシー Target に利用可能 `resources`:
 
-| attributeId | 説明 | ソース |
-|-------------|-------------|--------|
-| `path` | HTTP リクエストパス (例: `/v2/entities/Room1`) | リクエスト |
-| `tenantService` | テナントサービス名 (`Fiware-Service` ヘッダー) | リクエスト |
-| `servicePath` | ServicePath (`Fiware-ServicePath` ヘッダー) | リクエスト |
-| `scope` | NGSI-LD エンティティスコープ (カンマ区切り) | エンティティコンテキスト |
-| `entityId` | 対象エンティティ ID (例: `Room1`) | エンティティコンテキスト |
-| `entityType` | 対象エンティティタイプ (例: `Room`) | リクエスト (自動抽出) / エンティティコンテキスト |
-| `entityOwner` | エンティティ作成者の userId (`createdBy` フィールド) | エンティティコンテキスト |
+| attributeId     | 説明                                    | ソース                         |
+| --------------- | ------------------------------------- | --------------------------- |
+| `path`          | HTTP リクエストパス(例: `/v2/entities/Room1`) | Request                     |
+| `tenantService` | テナントサービス名(`Fiware-Service` ヘッダー)      | Request                     |
+| `servicePath`   | ServicePath(`Fiware-ServicePath` ヘッダー)     | Request                     |
+| `scope`         | NGSI-LD エンティティスコープ(カンマ区切り)            | Entity context              |
+| `entityId`      | 対象エンティティ ID(例: `Room1`)               | エンティティコンテキスト                |
+| `entityType`    | 対象エンティティタイプ (例: `Room`)               | リクエスト (自動抽出) / エンティティコンテキスト |
+| `entityOwner`   | エンティティ作成者の userId (`createdBy` フィールド) | エンティティコンテキスト                |
 
-> `entityType` は、HTTP リクエストのパスレベルから自動的に抽出されます。`?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから取得され、エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、`scope` は、エンティティレベルの認可チェック(`requireEntityAuthz` 経由)でのみ利用可能です。`scope` は、NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したもので、柔軟なマッチングには `string-regexp` または `glob` を使用してください。
+> `entityType` は、パスレベルで HTTP リクエストから自動的に抽出されます — `?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから — エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、および `scope` は、エンティティレベルの認可チェック (`requireEntityAuthz` 経由) でのみ利用可能です。`scope` は、NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したものです — 柔軟なマッチングには `string-regexp` または `glob` を使用してください。
 
 #### OAuth クライアント管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/oauth-clients` | GET | OAuth クライアント一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/oauth-clients` | POST | OAuth クライアント作成 | 201 | 400, 401, 403 | - |
-| `/admin/oauth-clients/{clientId}` | GET | OAuth クライアント取得 | 200 | 401, 403, 404 | - |
-| `/admin/oauth-clients/{clientId}` | PATCH | OAuth クライアント更新 | 200 | 400, 401, 403, 404 | - |
-| `/admin/oauth-clients/{clientId}` | DELETE | OAuth クライアント削除 | 204 | 401, 403, 404 | - |
+| エンドポイント                           | メソッド   | 説明             | 成功  | エラー                | ページネーション       |
+| --------------------------------- | ------ | -------------- | --- | ------------------ | -------------- |
+| `/admin/oauth-clients`            | GET    | OAuth クライアント一覧 | 200 | 400, 401, 403      | Yes (max: 100) |
+| `/admin/oauth-clients`            | POST   | OAuth クライアント作成 | 201 | 400, 401, 403      | -              |
+| `/admin/oauth-clients/{clientId}` | GET    | OAuth クライアント取得 | 200 | 401, 403, 404      | -              |
+| `/admin/oauth-clients/{clientId}` | PATCH  | OAuth クライアント更新 | 200 | 400, 401, 403, 404 | -              |
+| `/admin/oauth-clients/{clientId}` | DELETE | OAuth クライアント削除 | 204 | 401, 403, 404      | -              |
 
 #### セルフサービス OAuth クライアント管理
 
-ユーザーは自分自身の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアント。オプションの `policyId` により、クライアントを既存の XACML ポリシーにバインドできます。
+ユーザーは自身の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアント。オプションの `policyId` は、クライアントを既存の XACML ポリシーにバインドします。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/me/oauth-clients` | GET | 自分の OAuth クライアント一覧取得 | 200 | 400, 401 | あり (最大: 100) |
-| `/me/oauth-clients` | POST | 自分の OAuth クライアント作成 | 201 | 400, 401, 403 | - |
-| `/me/oauth-clients/{clientId}` | PATCH | 自分の OAuth クライアント更新 (部分更新) | 200 | 400, 401, 403, 404 | - |
-| `/me/oauth-clients/{clientId}` | DELETE | 自分の OAuth クライアント削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/oauth-clients/{clientId}/regenerate-secret` | POST | 自分のクライアントシークレット再生成 | 200 | 400, 401, 403, 404 | - |
+| エンドポイント                                          | メソッド   | 説明                       | 成功  | エラー                | ページネーション       |
+| ------------------------------------------------ | ------ | ------------------------ | --- | ------------------ | -------------- |
+| `/me/oauth-clients`                              | GET    | 自身の OAuth クライアント一覧       | 200 | 400, 401           | Yes (max: 100) |
+| `/me/oauth-clients`                              | POST   | 自身の OAuth クライアント作成       | 201 | 400, 401, 403      | -              |
+| `/me/oauth-clients/{clientId}`                   | PATCH  | 自身の OAuth クライアント更新 (部分的) | 200 | 400, 401, 403, 404 | -              |
+| `/me/oauth-clients/{clientId}`                   | DELETE | 自身の OAuth クライアント削除       | 204 | 400, 401, 403, 404 | -              |
+| `/me/oauth-clients/{clientId}/regenerate-secret` | POST   | 自身のクライアントシークレット再生成       | 200 | 400, 401, 403, 404 | -              |
 
 #### API キー管理
 
-`X-Api-Key` ヘッダーによる認証用の API キーを管理します。新しいキーはプレーン UUID 形式(`randomUUID()`)を使用します。既存の `gdb_` プレフィックス付きキーは引き続き有効です。保存時は SHA-256 でハッシュ化され、平文キーは作成時と更新時のみ返されます。一覧取得/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドにより、キーを既存の XACML ポリシーにバインドできます(バインドされたポリシーのターゲットは評価時にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト(api_key = All Deny)にフォールバックします。
+&#x20;ヘッダー経由の認証用 API キーを管理します。新しいキーはプレーン UUID 形式 (`X-Api-Key` ヘッダー経由の認証用 API キーを管理します。新しいキーはプレーン UUID 形式 (`randomUUID()`) を使用します。`gdb_` プレフィックスを持つ既存のキーは有効なままです。ストレージには SHA-256 ハッシュ化されます。プレーンテキストキーは作成時とリフレッシュ時にのみ返されます。一覧/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドは、キーを既存の XACML ポリシーにバインドします (バインドされたポリシーのターゲットは評価中にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト (api\_key = All Deny) にフォールバックします。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/api-keys` | POST | API キー作成 | 201 | 400, 401, 403 | - |
-| `/admin/api-keys` | GET | API キー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/api-keys/{keyId}` | GET | API キー取得 | 200 | 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}` | PATCH | API キー更新 | 204 | 400, 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}` | DELETE | API キー削除 | 204 | 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}/refresh` | POST | API キー更新 (再生成) | 200 | 401, 403, 404 | - |
+| エンドポイント                           | メソッド   | 説明                 | 成功  | エラー                | ページネーション       |
+| --------------------------------- | ------ | ------------------ | --- | ------------------ | -------------- |
+| `/admin/api-keys`                 | POST   | API キー作成           | 201 | 400, 401, 403      | -              |
+| `/admin/api-keys`                 | GET    | API キー一覧           | 200 | 400, 401, 403      | Yes (max: 100) |
+| `/admin/api-keys/{keyId}`         | GET    | API キー取得           | 200 | 401, 403, 404      | -              |
+| `/admin/api-keys/{keyId}`         | PATCH  | API キー更新           | 204 | 400, 401, 403, 404 | -              |
+| `/admin/api-keys/{keyId}`         | DELETE | API キー削除           | 204 | 401, 403, 404      | -              |
+| `/admin/api-keys/{keyId}/refresh` | POST   | API キーリフレッシュ (再生成) | 200 | 401, 403, 404      | -              |
 
-#### セルフサービス API キー管理ユーザーは自分の API キーを管理できます。1 ユーザーにつき最大 5 つのキーまで作成可能です。
+#### セルフサービス API キー管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/me/api-keys` | POST | 自分の API キーを作成 | 201 | 400, 401, 403 | - |
-| `/me/api-keys` | GET | 自分の API キーを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
-| `/me/api-keys/{keyId}` | PATCH | 自分の API キーを更新(部分更新) | 200 | 400, 401, 403, 404 | - |
-| `/me/api-keys/{keyId}` | DELETE | 自分の API キーを削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/api-keys/{keyId}/refresh` | POST | 自分の API キーをリフレッシュ(再生成) | 200 | 401, 403, 404 | - |
+ユーザーは自分の API キーを管理できます。ユーザーあたり最大 5 個のキーまでです。
+
+| エンドポイント                        | メソッド   | 説明                 | 成功  | エラー                | ページネーション       |
+| ------------------------------ | ------ | ------------------ | --- | ------------------ | -------------- |
+| `/me/api-keys`                 | POST   | 自分の API キーを作成      | 201 | 400, 401, 403      | -              |
+| `/me/api-keys`                 | GET    | 自分の API キーを一覧表示    | 200 | 400, 401, 403      | Yes (max: 100) |
+| `/me/api-keys/{keyId}`         | PATCH  | 自分の API キーを更新(部分)  | 200 | 400, 401, 403, 404 | -              |
+| `/me/api-keys/{keyId}`         | DELETE | 自分の API キーを削除      | 204 | 400, 401, 403, 404 | -              |
+| `/me/api-keys/{keyId}/refresh` | POST   | 自分の API キーを更新(再生成) | 200 | 401, 403, 404      | -              |
 
 #### CADDE 設定管理
 
-API を介して CADDE (分野間データ連携基盤) の設定を管理します。設定は MongoDB に保存され、環境変数は不要です。
+API 経由で CADDE(分野間データ連携基盤)設定を管理します。設定は MongoDB に保存され、環境変数は不要です。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/cadde` | GET | CADDE 設定を取得 | 200 | 401, 403 | - |
-| `/admin/cadde` | PUT | CADDE 設定を更新(upsert) | 200 | 400, 401, 403 | - |
-| `/admin/cadde` | DELETE | CADDE 設定を削除(無効化) | 204 | 401, 403 | - |
+| エンドポイント        | メソッド   | 説明                  | 成功  | エラー           | ページネーション |
+| -------------- | ------ | ------------------- | --- | ------------- | -------- |
+| `/admin/cadde` | GET    | CADDE 設定を取得         | 200 | 401, 403      | -        |
+| `/admin/cadde` | PUT    | CADDE 設定を更新(upsert) | 200 | 400, 401, 403 | -        |
+| `/admin/cadde` | DELETE | CADDE 設定を削除(無効化)    | 204 | 401, 403      | -        |
 
 **リクエストボディ (PUT)**
 
@@ -2810,58 +2930,58 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 }
 ```
 
-| フィールド | 型 | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `enabled` | boolean | Yes | CADDE 機能を有効/無効化 |
-| `authEnabled` | boolean | Yes | Bearer 認証を有効/無効化 |
-| `defaultProvider` | string | - | デフォルトのプロバイダー ID |
-| `jwtIssuer` | string | - | JWT の issuer クレーム検証値 |
-| `jwtAudience` | string | - | JWT の audience クレーム検証値 |
-| `jwksUrl` | string | - | JWKS 公開鍵エンドポイント URL (HTTPS 必須) |
+| フィールド             | 型       | 必須  | 説明                             |
+| ----------------- | ------- | --- | ------------------------------ |
+| `enabled`         | boolean | Yes | CADDE 機能を有効化/無効化               |
+| `authEnabled`     | boolean | Yes | Bearer 認証を有効化/無効化              |
+| `defaultProvider` | string  | -   | デフォルトプロバイダー ID                 |
+| `jwtIssuer`       | string  | -   | JWT 発行者クレーム検証値                 |
+| `jwtAudience`     | string  | -   | JWT オーディエンスクレーム検証値             |
+| `jwksUrl`         | string  | -   | JWKS 公開鍵エンドポイント URL (HTTPS 必須) |
 
 #### ルールエンジン管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/rules` | GET | ルールを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
-| `/rules` | POST | ルールを作成 | 201 | 400, 401, 403, 409 | - |
-| `/rules/{ruleId}` | GET | ルールを取得 | 200 | 401, 403, 404 | - |
-| `/rules/{ruleId}` | PATCH | ルールを更新 | 204 | 400, 401, 403, 404 | - |
-| `/rules/{ruleId}` | DELETE | ルールを削除 | 204 | 401, 403, 404 | - |
-| `/rules/{ruleId}/activate` | POST | ルールを有効化 | 200 | 401, 403, 404 | - |
-| `/rules/{ruleId}/deactivate` | POST | ルールを無効化 | 200 | 401, 403, 404 | - |
+| エンドポイント                      | メソッド   | 説明       | 成功  | エラー                | ページネーション       |
+| ---------------------------- | ------ | -------- | --- | ------------------ | -------------- |
+| `/rules`                     | GET    | ルールを一覧表示 | 200 | 400, 401, 403      | Yes (max: 100) |
+| `/rules`                     | POST   | ルールを作成   | 201 | 400, 401, 403, 409 | -              |
+| `/rules/{ruleId}`            | GET    | ルールを取得   | 200 | 401, 403, 404      | -              |
+| `/rules/{ruleId}`            | PATCH  | ルールを更新   | 204 | 400, 401, 403, 404 | -              |
+| `/rules/{ruleId}`            | DELETE | ルールを削除   | 204 | 401, 403, 404      | -              |
+| `/rules/{ruleId}/activate`   | POST   | ルールを有効化  | 200 | 401, 403, 404      | -              |
+| `/rules/{ruleId}/deactivate` | POST   | ルールを無効化  | 200 | 401, 403, 404      | -              |
 
 ### カスタムデータモデル API
 
-テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要で、XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールがテナント内のカスタムデータモデルを管理できます。
+テナント固有のカスタムデータモデルを管理するための API。JWT 認証が必要で、XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールが自身のテナント内でカスタムデータモデルを管理できます。
 
-**関連ドキュメント**: [SMART_DATA_MODELS.md](../features/smart-data-models.md)
+**関連ドキュメント**: [SMART\_DATA\_MODELS.md](../features/smart-data-models.md)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/custom-data-models` | GET | カスタムデータモデルの一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/custom-data-models` | POST | カスタムデータモデルの作成 | 201 | 400, 401, 403, 409 | - |
-| `/custom-data-models/{type}` | GET | カスタムデータモデルの取得 | 200 | 401, 403, 404 | - |
-| `/custom-data-models/{type}` | PATCH | カスタムデータモデルの更新 | 200 | 400, 401, 403, 404 | - |
-| `/custom-data-models/{type}` | DELETE | カスタムデータモデルの削除 | 204 | 401, 403, 404 | - |
+| エンドポイント                      | メソッド   | 説明              | 成功  | エラー                | ページネーション     |
+| ---------------------------- | ------ | --------------- | --- | ------------------ | ------------ |
+| `/custom-data-models`        | GET    | カスタムデータモデルの一覧取得 | 200 | 400, 401, 403      | はい (最大: 100) |
+| `/custom-data-models`        | POST   | カスタムデータモデルの作成   | 201 | 400, 401, 403, 409 | -            |
+| `/custom-data-models/{type}` | GET    | カスタムデータモデルの取得   | 200 | 401, 403, 404      | -            |
+| `/custom-data-models/{type}` | PATCH  | カスタムデータモデルの更新   | 200 | 400, 401, 403, 404 | -            |
+| `/custom-data-models/{type}` | DELETE | カスタムデータモデルの削除   | 204 | 401, 403, 404      | -            |
 
 #### エンティティの検証
 
-カスタムデータモデルが定義されている場合、エンティティの作成または更新時に自動的に検証が実行されます。検証は `isActive: true` を持つモデルにのみ適用されます。
+カスタムデータモデルが定義されると、エンティティの作成または更新時に自動的に検証が実行されます。検証は、`isActive: true` を持つモデルにのみ適用されます。
 
 **検証チェック:**
 
-| チェック | 説明 |
-|-------|-------------|
-| 追加プロパティ | `additionalProperties: false` の場合、`propertyDetails` で定義されていない属性は拒否されます (デフォルト: `true` — 任意の属性を許可) |
-| 必須フィールド | `required: true` を持つ属性が存在するかどうか |
-| 型チェック | `valueType` に基づく型検証 (string, number, integer, boolean, array, object, GeoJSON) |
-| minLength / maxLength | 文字列長の制約 |
-| minimum / maximum | 数値範囲の制約 |
-| pattern | 正規表現パターンマッチ |
-| enum | 許可された値のリスト |
+| チェック                  | 説明                                                                                                                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 追加プロパティ               |  の場合、`additionalProperties: false` で定義されていない属性は拒否されます (デフォルト: `propertyDetails` — 任意の属性を許可)`true` — allows any attributes)                 |
+| 必須フィールド               |  を持つ属性が存在するかどうか`required: true` are present                                                                                                |
+| 型チェック                 |  に基づく型の検証 (string, number, integer, boolean, array, object, GeoJSON)`valueType` (string, number, integer, boolean, array, object, GeoJSON) |
+| minLength / maxLength | 文字列長の制約                                                                                                                                    |
+| minimum / maximum     | 数値範囲の制約                                                                                                                                    |
+| pattern               | 正規表現パターンマッチ                                                                                                                                |
+| enum                  | 許可される値のリスト                                                                                                                                 |
 
-検証失敗時は `400 Bad Request` が返されます:
+検証失敗時は `400 Bad Request` を返します:
 
 ```json
 {
@@ -2872,11 +2992,11 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 #### 自動 JSON Schema 生成
 
-カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。また、`jsonSchema` を手動で指定することも可能です。
+カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。`jsonSchema` を手動で指定することも可能です。
 
-#### プロパティ @context (JSON-LD 語彙マッピング)
+#### @context プロパティ (JSON-LD 語彙マッピング)
 
-`propertyDetails` の各プロパティには、JSON-LD 語彙マッピング用の HTTP(S) URL を指定できるオプションの `@context` フィールドを含めることができます。これにより、自動生成された URI の代わりに、よく知られた語彙 (例: schema.org) を使用できます。
+&#x20;の各プロパティには、JSON-LD 語彙マッピングのためのオプションの `propertyDetails` フィールドを含めることができます (HTTP(S) URL)。これにより、自動生成される URI の代わりに、よく知られた語彙 (例: schema.org) を使用できます。`@context` field with an HTTP(S) URL for JSON-LD vocabulary mapping. This allows using well-known vocabularies (e.g., schema.org) instead of auto-generated URIs.
 
 ```json
 {
@@ -2896,67 +3016,81 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 }
 ```
 
-- `@context` を持つプロパティ → 指定された URL が JSON-LD コンテキストで使用されます
-- `@context` を持たないプロパティ → 自動生成された URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
-- プロパティ URI はエンティティタイプに依存しません (同じプロパティ名はテナント内で同じ URI を共有します)
-- `@context` は HTTP(S) URL である必要があります (URN は受け付けません)
 
-#### @context 解決の拡張
+* &#x20;を持つプロパティ → 指定された URL が JSON-LD コンテキストで使用されます
+  
+`@context` → the specified URL is used in the JSON-LD context
+  
+* &#x20;を持たないプロパティ → 自動生成される URL (`@context`)
+  
+`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
+  
+* プロパティ URI はエンティティタイプに依存しません (同じプロパティ名はテナント内で同じ URI を共有します)
+  
+* `@context` は HTTP(S) URL である必要があります (URN は受け付けられません)
 
-NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはエンティティの `@context` に自動的に含まれます (コアコンテキストと一緒に配列として返されます)。
+#### @context 解決拡張
+
+NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストは自動的にエンティティの `@context` に含まれます (コアコンテキストと共に配列として返されます)。
 
 ### カタログ API
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/catalog` | GET | DCAT-AP カタログの取得 | 200 | 401 | - |
-| `/catalog/datasets` | GET | データセットの一覧取得 | 200 | 400, 401 | あり (最大: 1000) |
-| `/catalog/datasets/{datasetId}` | GET | データセットの取得 | 200 | 401, 404 | - |
-| `/catalog/datasets/{datasetId}/sample` | GET | サンプルデータの取得 | 200 | 401, 404 | - |
+| エンドポイント                                | メソッド | 説明              | 成功  | エラー      | ページネーション      |
+| -------------------------------------- | ---- | --------------- | --- | -------- | ------------- |
+| `/catalog`                             | GET  | DCAT-AP カタログの取得 | 200 | 401      | -             |
+| `/catalog/datasets`                    | GET  | データセットの一覧取得     | 200 | 400, 401 | はい (最大: 1000) |
+| `/catalog/datasets/{datasetId}`        | GET  | データセットの取得       | 200 | 401, 404 | -             |
+| `/catalog/datasets/{datasetId}/sample` | GET  | サンプルデータの取得      | 200 | 401, 404 | -             |
 
 ### ベクタータイル API
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/v2/tiles` | GET | TileJSON メタデータの取得 (NGSIv2) | 200 | 401 |
-| `/v2/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルの取得 (NGSIv2) | 200 | 400, 401 |
-| `/ngsi-ld/v1/tiles` | GET | TileJSON メタデータの取得 (NGSI-LD) | 200 | 401 |
-| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルの取得 (NGSI-LD) | 200 | 400, 401 |
+| エンドポイント                                 | メソッド | 説明                          | 成功  | エラー      |
+| --------------------------------------- | ---- | --------------------------- | --- | -------- |
+| `/v2/tiles`                             | GET  | TileJSON メタデータの取得 (NGSIv2)  | 200 | 401      |
+| `/v2/tiles/{z}/{x}/{y}.geojson`         | GET  | GeoJSON タイルの取得 (NGSIv2)     | 200 | 400, 401 |
+| `/ngsi-ld/v1/tiles`                     | GET  | TileJSON メタデータの取得 (NGSI-LD) | 200 | 401      |
+| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET  | GeoJSON タイルの取得 (NGSI-LD)    | 200 | 400, 401 |
 
-### イベントストリーミング API
+### Event Streaming API
 
-WebSocket を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化されます。
+WebSocket を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true`で有効化されます。
 
-| エンドポイント | プロトコル | 説明 |
-|----------|----------|-------------|
-| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントのストリーム配信 (認証は `Authorization` ヘッダー経由で送信) |
+| エンドポイント                                                                   | プロトコル     | 説明                                                |
+| ------------------------------------------------------------------------- | --------- | ------------------------------------------------- |
+| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントをストリーミング(認証は`Authorization`ヘッダー経由で送信) |
 
-詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
+詳細については、[Event Streaming Documentation](../features/subscriptions.md)を参照してください。
 
-### アクセス許可の概要
+### アクセス権限の概要
 
-| API カテゴリ | user | tenant_admin | super_admin |
-|--------------|------|--------------|-------------|
-| パブリックエンドポイント | Yes | Yes | Yes |
-| `/auth/*` | Yes | Yes | Yes |
-| `/me/*` | Yes | Yes | Yes |
-| `/statistics`、`/metrics`、`/cache/statistics` | Yes | Yes | Yes |
-| `/v2/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/ngsi-ld/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/catalog/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/admin/policies`、`/admin/policy-sets` | No | Yes (自テナント) | Yes (全テナント) |
-| `/admin/*` (その他) | No | No | Yes |
-| `/custom-data-models` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/rules` | No | Yes (自テナント) | Denied (403) |
-| WebSocket | Yes (自テナント) | Yes (自テナント) | Denied (403) |
+| API カテゴリ                                     | user        | tenant\_admin | super\_admin |
+| -------------------------------------------- | ----------- | ------------- | ------------ |
+| 公開エンドポイント                                    | Yes         | Yes           | Yes          |
+| `/auth/*`                                    | Yes         | Yes           | Yes          |
+| `/me/*`                                      | Yes         | Yes           | Yes          |
+| `/statistics`、`/metrics`、`/cache/statistics` | Yes         | Yes           | Yes          |
+| `/v2/*`                                      | Yes (自テナント) | Yes (自テナント)   | Denied (403) |
+| `/ngsi-ld/*`                                 | Yes (自テナント) | Yes (自テナント)   | Denied (403) |
+| `/catalog/*`                                 | Yes (自テナント) | Yes (自テナント)   | Denied (403) |
+| `/admin/policies`、`/admin/policy-sets`       | No          | Yes (自テナント)   | Yes (全テナント)  |
+| `/admin/*`(その他)                              | No          | No            | Yes          |
+| `/custom-data-models`                        | Yes (自テナント) | Yes (自テナント)   | Denied (403) |
+| `/rules`                                     | No          | Yes (自テナント)   | Denied (403) |
+| WebSocket                                    | Yes (自テナント) | Yes (自テナント)   | Denied (403) |
 
----
+***
 
 ## 関連リンク
 
-- [FIWARE NGSI v2 仕様](https://fiware.github.io/specifications/ngsiv2/stable/)
-- [ETSI NGSI-LD 仕様](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf)
-- [FIWARE Orion Context Broker ドキュメント](https://fiware-orion.readthedocs.io/)
-- [IPA 空間 ID ガイドライン](https://www.ipa.go.jp/digital/architecture/guidelines/4dspatio-temporal-guideline.html)
-- [デジタル庁 空間 ID](https://www.digital.go.jp/policies/mobility_and_infrastructure/spatial-id)
-- [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
+
+* [FIWARE NGSI v2 仕様](https://fiware.github.io/specifications/ngsiv2/stable/)
+  
+* [ETSI NGSI-LD 仕様](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf)
+  
+* [FIWARE Orion Context Broker ドキュメント](https://fiware-orion.readthedocs.io/)
+  
+* [IPA 空間 ID ガイドライン](https://www.ipa.go.jp/digital/architecture/guidelines/4dspatio-temporal-guideline.html)
+  
+* [デジタル庁空間 ID](https://www.digital.go.jp/policies/mobility_and_infrastructure/spatial-id)
+  
+* [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)

--- a/docs/ja/api-reference/ngsild.md
+++ b/docs/ja/api-reference/ngsild.md
@@ -171,7 +171,8 @@ Content-Type: application/ld+json
 ```
 
 **レスポンス**
-- ステータス: `201 Created`- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関係なく)
+- ステータス: `201 Created`
+- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関係なく)
 - ヘッダー: `Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Room:001`> **注意**: エンティティ ID はテナントとServicePathスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成すると `409 AlreadyExists` が返されます。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
 #
@@ -463,7 +464,8 @@ Content-Type: application/ld+json
 ```
 
 **レスポンス**
-- すべて成功: `201 Created`- 部分的に成功: `207 Multi-Status`#
+- すべて成功: `201 Created`
+- 部分的に成功: `207 Multi-Status`#
 
 ### バッチアップサート
 
@@ -488,7 +490,8 @@ POST /ngsi-ld/v1/entityOperations/update
 ```
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的に成功: `207 Multi-Status`#
+- すべて成功: `204 No Content`
+- 部分的に成功: `207 Multi-Status`#
 
 ### バッチ削除
 
@@ -507,7 +510,8 @@ Content-Type: application/json
 ```
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的に成功: `207 Multi-Status`#
+- すべて成功: `204 No Content`
+- 部分的に成功: `207 Multi-Status`#
 
 ### エンティティパージ
 
@@ -525,7 +529,8 @@ Content-Type: application/json
 | `type` | string | 削除するエンティティタイプ (必須) |
 
 **レスポンス**
-- 成功: `204 No Content`- タイプが指定されていない: `400 Bad Request`#
+- 成功: `204 No Content`
+- タイプが指定されていない: `400 Bad Request`#
 
 ### バッチクエリ
 
@@ -912,7 +917,8 @@ NGSI-LD では、エンドポイント URI に `mqtt://` または `mqtts://` �
 - `watchedAttributes` と `timeInterval` は相互排他的です。両方を同時に指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.8.1)
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/subscriptions/{subscriptionId}`#
+- ステータス: `201 Created`
+- ヘッダー: `Location: /ngsi-ld/v1/subscriptions/{subscriptionId}`#
 
 ### サブスクリプション一覧
 
@@ -1031,7 +1037,8 @@ Content-Type: application/ld+json
 | `mode` | string | - | モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`) |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/csourceRegistrations/{registrationId}`#
+- ステータス: `201 Created`
+- ヘッダー: `Location: /ngsi-ld/v1/csourceRegistrations/{registrationId}`#
 
 ### レジストレーション一覧の取得
 
@@ -1324,7 +1331,8 @@ Content-Type: application/ld+json
 | `isActive` | boolean | - | アクティブ状態 (デフォルト: true) |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}`#
+- ステータス: `201 Created`
+- ヘッダー: `Location: /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}`#
 
 ### CSR サブスクリプションリストの取得
 
@@ -1416,7 +1424,8 @@ Content-Type: application/json
 ```
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/jsonldContexts/{contextId}`#
+- ステータス: `201 Created`
+- ヘッダー: `Location: /ngsi-ld/v1/jsonldContexts/{contextId}`#
 
 ### JSON-LD Context リストの取得
 
@@ -1551,7 +1560,8 @@ ETSI NGSI-LD 互換 Context Broker API。
 
 ### 共通仕様
 
-- **Content-Type**: `application/ld+json` または `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
+- **Content-Type**: `application/ld+json` または `application/json`
+- **認証**: `AUTH_ENABLED=true` の場合は必須
 - **テナント分離**: `NGSILD-Tenant` または `Fiware-Service` ヘッダー
 - **ページネーション**: `limit`/`offset` パラメータ、総数は常に `NGSILD-Results-Count` ヘッダーで返されます
 - **OPTIONS メソッド**: すべての NGSI-LD エンドポイントは OPTIONS メソッドをサポートします。`Allow` および `Accept-Patch` ヘッダーと共に 204 レスポンスを返します

--- a/docs/ja/api-reference/ngsiv2.md
+++ b/docs/ja/api-reference/ngsiv2.md
@@ -5,11 +5,13 @@ outline: deep
 ---
 # NGSIv2 API
 
-> このドキュメントは[API.md](./endpoints.md)から分割されました。メインの API 仕様については、[API.md](./endpoints.md)を参照してください。
+> このドキュメントは [API.md](./endpoints.md) から分割されました。メインの API 仕様については、[API.md](./endpoints.md) を参照してください。
 
----
+***
 
-## エンティティ操作### エンティティの一覧取得
+## エンティティ操作
+
+### エンティティ一覧取得
 
 ```http
 GET /v2/entities
@@ -17,40 +19,42 @@ GET /v2/entities
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `id` | string | エンティティ ID でフィルタ (複数の値をカンマ区切りリストで指定可能) | - |
-| `limit` | integer | 取得する結果の数 (最大: 1000) | 20 |
-| `offset` | integer | オフセット (ページネーション用) | 0 |
-| `orderBy` | string | ソート条件 (`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順指定可能 (例: `!temperature`) | - |
-| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張** (公式仕様は `!` プレフィックス方式のみサポート) | `asc` |
-| `type` | string | エンティティタイプでフィルタ | - |
-| `typePattern` | string | エンティティタイプの正規表現パターン | - |
-| `idPattern` | string | エンティティ ID の正規表現パターン | - |
-| `q` | string | 属性値でフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
-| `mq` | string | メタデータでフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
-| `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張** (公式仕様では `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
-| `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries)を参照) | - |
-| `geometry` | string | ジオメトリタイプ | - |
-| `coords` | string | 座標 (緯度,経度 形式、セミコロン区切り) | - |
-| `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search)を参照) | - |
-| `spatialIdDepth` | integer | 空間 ID 階層展開の深さ (0-4) | 0 |
-| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs)を参照) | `EPSG:4326` |
-| `options` | string | `keyValues`、`values`、`count`、`geojson`、`sysAttrs`、`unique` | - |
+| パラメータ            | 型       | 説明                                                                                                      | デフォルト       |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------- | ----------- |
+| `id`             | string  | エンティティ ID でフィルタ(複数の値をカンマ区切りリストで指定可能)                                                                    | -           |
+| `limit`          | integer | 取得する結果の数(最大: 1000)                                                                                      | 20          |
+| `offset`         | integer | オフセット(ページネーション用)                                                                                        | 0           |
+| `orderBy`        | string  | ソート条件(`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順指定(例: `!temperature`) | -           |
+| `orderDirection` | string  | ソート方向(`asc`、`desc`)。**GeonicDB 拡張**(公式仕様は `!` プレフィックス方式のみサポート)                                          | `asc`       |
+| `type`           | string  | エンティティタイプでフィルタ                                                                                          | -           |
+| `typePattern`    | string  | エンティティタイプの正規表現パターン                                                                                      | -           |
+| `idPattern`      | string  | エンティティ ID の正規表現パターン                                                                                     | -           |
+| `q`              | string  | 属性値でフィルタ([クエリ言語](./endpoints.md#query-language) 参照)                                                     | -           |
+| `mq`             | string  | メタデータでフィルタ([クエリ言語](./endpoints.md#query-language) 参照)                                                   | -           |
+| `attrs`          | string  | 取得する属性名(カンマ区切り)                                                                                         | -           |
+| `metadata`       | string  | メタデータ出力制御(`on`、`off`)。**GeonicDB 拡張**(公式仕様は `*` ワイルドカード等を含むカンマ区切り名前リストを使用)                              | `on`        |
+| `georel`         | string  | ジオクエリ演算子([ジオクエリ](./endpoints.md#geo-queries) 参照)                                                        | -           |
+| `geometry`       | string  | ジオメトリタイプ                                                                                                | -           |
+| `coords`         | string  | 座標(緯度,経度形式、セミコロン区切り)                                                                                    | -           |
+| `spatialId`      | string  | 空間 ID でフィルタ(ZFXY 形式)([空間 ID 検索](./endpoints.md#spatial-id-search) 参照)                                   | -           |
+| `spatialIdDepth` | integer | 空間 ID 階層展開の深さ(0-4)                                                                                      | 0           |
+| `crs`            | string  | 座標参照系([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs) 参照)                                 | `EPSG:4326` |
+| `options`        | string  | `keyValues`、`values`、`count`、`geojson`、`sysAttrs`、`unique`                                              | -           |
 
 **組み込み属性**
 
-`attrs` パラメータは、ユーザー定義属性に加えて、以下の組み込み属性をサポートします:
+The `attrs` パラメータは、ユーザー定義属性に加えて以下の組み込み属性をサポートします:
 
-| 組み込み属性 | 型 | 説明 |
-|---|---|---|
-| `dateCreated` | DateTime | エンティティ作成タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateModified` | DateTime | 最終更新タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateExpires` | DateTime | 一時エンティティの有効期限タイムスタンプ |
-| `servicePath` | Text | エンティティが保存されているServicePath (作成時の `Fiware-ServicePath` ヘッダー値) |
+| 組み込み属性         | 型        | 説明                                                  |
+| -------------- | -------- | --------------------------------------------------- |
+| `dateCreated`  | DateTime | エンティティ作成タイムスタンプ(`options=sysAttrs` 経由でも利用可能)        |
+| `dateModified` | DateTime | 最終更新タイムスタンプ(`options=sysAttrs` 経由でも利用可能)            |
+| `dateExpires`  | DateTime | 一時エンティティの有効期限タイムスタンプ                                |
+| `servicePath`  | Text     | エンティティが保存されているServicePath(`Fiware-ServicePath` ヘッダ値、作成時) |
 
-例: `GET /v2/entities?attrs=temperature,servicePath`**レスポンス例**
+例: `GET /v2/entities?attrs=temperature,servicePath`
+
+**レスポンス例**
 
 ```json
 [
@@ -71,7 +75,7 @@ GET /v2/entities
 ]
 ```
 
-**keyValues 形式** (`options=keyValues`)
+**keyValues 形式**(`options=keyValues`)
 
 ```json
 [
@@ -84,11 +88,11 @@ GET /v2/entities
 ]
 ```
 
-**count オプション** (`options=count`)
+**count オプション**(`options=count`)
 
-レスポンスに `Fiware-Total-Count` ヘッダーが追加されます。
+The `Fiware-Total-Count` ヘッダがレスポンスに追加されます。
 
-**geojson オプション** (`options=geojson` または `Accept: application/geo+json` ヘッダー)
+**geojson オプション**(`options=geojson` または `Accept: application/geo+json` ヘッダ)
 
 レスポンスを GeoJSON FeatureCollection として返します。
 
@@ -119,7 +123,7 @@ curl "http://localhost:3000/v2/entities?type=Store" \
 }
 ```
 
-レスポンスヘッダーには `Content-Type: application/geo+json` が設定されます。
+レスポンスヘッダーには`Content-Type: application/geo+json`が設定されます。
 
 ### エンティティの作成
 
@@ -129,9 +133,9 @@ POST /v2/entities
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `options` | string | `upsert`: エンティティが既に存在する場合は更新。`keyValues`: リクエストボディを keyValues 形式として解釈 |
+| パラメータ     | 型      | 説明                                                                        |
+| --------- | ------ | ------------------------------------------------------------------------- |
+| `options` | string | `upsert`: エンティティが既に存在する場合は更新します。`keyValues`: リクエストボディを keyValues 形式で解釈します |
 
 **リクエストボディ**
 
@@ -150,7 +154,7 @@ POST /v2/entities
 }
 ```
 
-**keyValues 形式入力** (`options=keyValues`)
+**keyValues 形式の入力** (`options=keyValues`)
 
 ```json
 {
@@ -166,9 +170,14 @@ POST /v2/entities
 エンティティが存在しない場合は作成され (`201 Created`)、既に存在する場合はその属性が更新されます (`204 No Content`)。
 
 **レスポンス**
-- ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
-- ステータス: `409 AlreadyExists` 同じ ID のエンティティが既に存在する場合 (タイプに関わらず)
-- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID はテナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension)を参照してください。
+
+* ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
+  
+* ステータス: `409 AlreadyExists` 同じ ID を持つエンティティが既に存在する場合 (型に関係なく)
+  
+* ヘッダー: `Location: /v2/entities/Room1?type=Room`
+
+> **GeonicDB 拡張機能 — エンティティ ID の一意性**: エンティティ ID はテナントとServicePathのスコープ内で一意です。同じ ID で異なる型のエンティティを作成することは許可されず、`409 AlreadyExists` が返されます。これは、異なる型で同じ ID のエンティティを許可する NGSIv2 仕様とは異なります。詳細については、[エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
 ### 単一エンティティの取得
 
@@ -178,11 +187,11 @@ GET /v2/entities/{entityId}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ (オプションのフィルタ; エンティティ ID は一意であるため、タイプの曖昧さ解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
-| `attrs` | string | 取得する属性名 (カンマ区切り) |
-| `options` | string | `keyValues`、`values` |
+| パラメータ     | 型      | 説明                                                                                                                                       |
+| --------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`    | string | エンティティ型 (オプションのフィルター。エンティティ ID は一意であるため、型の曖昧性解消は不要になりました — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
+| `attrs`   | string | 取得する属性名 (カンマ区切り)                                                                                                                         |
+| `options` | string | `keyValues`、`values`                                                                                                                     |
 
 ### エンティティの更新 (PATCH)
 
@@ -194,9 +203,9 @@ PATCH /v2/entities/{entityId}/attrs
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| パラメータ  | 型      | 説明      |
+| ------ | ------ | ------- |
+| `type` | string | エンティティ型 |
 
 **リクエストボディ**
 
@@ -209,38 +218,44 @@ PATCH /v2/entities/{entityId}/attrs
 }
 ```
 
-**レスポンス**: `204 No Content`### エンティティの更新 (PUT)
+**レスポンス**: `204 No Content`
+
+### エンティティの更新 (PUT)
 
 ```http
 PUT /v2/entities/{entityId}/attrs
 ```
 
-すべての属性を置き換えます (指定されていない属性は削除されます)。
+すべての属性を置き換えます(指定されていない属性は削除されます)。
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
+| パラメータ  | 型      | 説明        |
+| ------ | ------ | --------- |
 | `type` | string | エンティティタイプ |
 
-**レスポンス**: `204 No Content`### 属性の追加 (POST)
+**レスポンス**: `204 No Content`
+
+### 属性の追加 (POST)
 
 ```http
 POST /v2/entities/{entityId}/attrs
 ```
 
-新しい属性を追加します (既存の属性は上書きされます)。
+新しい属性を追加します(既存の属性は上書きされます)。
 
-`options=append` が指定された場合、既存の属性は上書きされず、新しい属性のみが追加されます (厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
+When `options=append` を指定すると、既存の属性は上書きされず、新しい属性のみが追加されます(厳格追加モード)。すでに存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
-| `options` | string | `append`: 既存の属性の上書きを禁止 (厳密な追加モード) |
+| パラメータ     | 型      | 説明                              |
+| --------- | ------ | ------------------------------- |
+| `type`    | string | エンティティタイプ                       |
+| `options` | string | `append`: 既存の属性の上書きを禁止(厳格追加モード) |
 
-**レスポンス**: `204 No Content`### エンティティの削除
+**レスポンス**: `204 No Content`
+
+### エンティティの削除
 
 ```http
 DELETE /v2/entities/{entityId}
@@ -248,15 +263,19 @@ DELETE /v2/entities/{entityId}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
+| パラメータ  | 型      | 説明        |
+| ------ | ------ | --------- |
 | `type` | string | エンティティタイプ |
 
-**レスポンス**: `204 No Content`---
+**レスポンス**: `204 No Content`
 
-## 属性の操作### エンティティの属性を取得
+***
 
-エンティティのすべての属性を取得します (`id` および `type` フィールドは含まれません)。
+## 属性操作
+
+### エンティティ属性の取得
+
+エンティティのすべての属性を取得します(`id` と `type` フィールドは含まれません)。
 
 ```http
 GET /v2/entities/{entityId}/attrs
@@ -264,12 +283,12 @@ GET /v2/entities/{entityId}/attrs
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `type` | string | エンティティタイプ | - |
-| `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`) | `on` |
-| `options` | string | `keyValues`、`values`、`sysAttrs` | - |
+| パラメータ      | 型      | 説明                              | デフォルト |
+| ---------- | ------ | ------------------------------- | ----- |
+| `type`     | string | エンティティタイプ                       | -     |
+| `attrs`    | string | 取得する属性名(カンマ区切り)                 | -     |
+| `metadata` | string | メタデータ出力制御(`on`、`off`)           | `on`  |
+| `options`  | string | `keyValues`、`values`、`sysAttrs` | -     |
 
 **レスポンス例**
 
@@ -297,7 +316,7 @@ GET /v2/entities/{entityId}/attrs
 }
 ```
 
-> **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` および `type` フィールドが含まれません。属性のみが必要な場合に使用してください。
+> **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` と `type` フィールドが含まれません。属性のみが必要な場合にこれを使用してください。
 
 ### 単一属性の取得
 
@@ -307,8 +326,8 @@ GET /v2/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
+| パラメータ  | 型      | 説明        |
+| ------ | ------ | --------- |
 | `type` | string | エンティティタイプ |
 
 **レスポンス例**
@@ -329,8 +348,8 @@ PUT /v2/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
+| パラメータ  | 型      | 説明        |
+| ------ | ------ | --------- |
 | `type` | string | エンティティタイプ |
 
 **リクエストボディ**
@@ -342,7 +361,9 @@ PUT /v2/entities/{entityId}/attrs/{attrName}
 }
 ```
 
-**レスポンス**: `204 No Content`### 単一属性の削除
+**レスポンス**: `204 No Content`
+
+### 単一属性の削除
 
 ```http
 DELETE /v2/entities/{entityId}/attrs/{attrName}
@@ -350,36 +371,38 @@ DELETE /v2/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
+| パラメータ  | 型      | 説明        |
+| ------ | ------ | --------- |
 | `type` | string | エンティティタイプ |
 
-**レスポンス**: `204 No Content`### 属性値を直接取得
+**レスポンス**: `204 No Content`
+
+### 属性値の直接取得
 
 ```http
 GET /v2/entities/{entityId}/attrs/{attrName}/value
 ```
 
-属性の値のみを取得します (型とメタデータは含まれません)。
+属性の値のみを取得します(型とメタデータは含まれません)。
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
+| パラメータ  | 型      | 説明        |
+| ------ | ------ | --------- |
 | `type` | string | エンティティタイプ |
 
 **レスポンス**
 
 値の型に応じて異なる Content-Type で返されます:
 
-| 値の型 | Content-Type | 例 |
-|------------|--------------|---------|
-| 文字列 | `text/plain` | `hello world` |
-| 数値 | `text/plain` | `23.5` |
-| 真偽値 | `text/plain` | `true` |
-| null | `text/plain` | `null` |
-| オブジェクト | `application/json` | `{"lat": 35.68, "lon": 139.76}` |
-| 配列 | `application/json` | `[1, 2, 3]` |
+| 値の型     | Content-Type       | 例                               |
+| ------- | ------------------ | ------------------------------- |
+| String  | `text/plain`       | `hello world`                   |
+| Number  | `text/plain`       | `23.5`                          |
+| Boolean | `text/plain`       | `true`                          |
+| null    | `text/plain`       | `null`                          |
+| Object  | `application/json` | `{"lat": 35.68, "lon": 139.76}` |
+| Array   | `application/json` | `[1, 2, 3]`                     |
 
 **使用例**
 
@@ -394,7 +417,8 @@ curl "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -H "Fiware-Service: smartcity"
 # Response: {"type":"Point","coordinates":[139.76,35.68]} (Content-Type: application/json)
 ```
-### 属性値の直接更新
+
+### 属性値を直接更新
 
 ```http
 PUT /v2/entities/{entityId}/attrs/{attrName}/value
@@ -404,18 +428,18 @@ PUT /v2/entities/{entityId}/attrs/{attrName}/value
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| パラメータ  | 型      | 説明      |
+| ------ | ------ | ------- |
+| `type` | string | エンティティ型 |
 
 **リクエスト**
 
 値の解釈は Content-Type によって異なります:
 
-| Content-Type | 解釈 |
-|--------------|----------------|
-| `application/json` | JSON としてパース |
-| `text/plain` | プリミティブ値 (`null`、`true`、`false`、数値) または文字列 |
+| Content-Type       | 解釈                                                |
+| ------------------ | ------------------------------------------------- |
+| `application/json` | JSON として解析                                        |
+| `text/plain`       | プリミティブ値 (`null`、`true`、`false`、number) または string |
 
 **使用例**
 
@@ -433,13 +457,15 @@ curl -X PUT "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -d '{"type":"Point","coordinates":[140.0,36.0]}'
 ```
 
-**レスポンス**: `204 No Content`**注**: この操作では、既存の属性の型やメタデータは変更されず、保持されます。
+**レスポンス**: `204 No Content`
 
----
+**注**: この操作は既存の属性の型やメタデータを変更しません — それらは保持されます。
+
+***
 
 ## バッチ操作
 
-> **注**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100、SAM パラメータ `MaxBatchSize` で最大 10,000 まで設定可能)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
+> **注**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 件のエンティティを処理できます (デフォルト: 100、SAM パラメータで最大 10,000 まで設定可能)。この制限を超えるリクエストは `MaxBatchSize` SAM パラメータで最大 10,000 まで設定可能)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
 
 ### バッチ更新
 
@@ -469,16 +495,19 @@ POST /v2/op/update
 
 **actionType の種類**
 
-| アクション | 説明 |
-|--------|-------------|
-| `append` | 既存エンティティの属性を追加/更新 |
-| `appendStrict` | 既存エンティティに新しい属性を追加 (既存属性が存在する場合はエラーを返す) |
-| `update` | 既存の属性のみを更新 (エンティティが存在しない場合はエラー) |
-| `replace` | すべての属性を置換 |
-| `delete` | エンティティまたは属性を削除 |
+| アクション          | 説明                                     |
+| -------------- | -------------------------------------- |
+| `append`       | 既存エンティティの属性を追加/更新                      |
+| `appendStrict` | 既存エンティティに新しい属性を追加(既存の属性が存在する場合はエラーを返す) |
+| `update`       | 既存の属性のみを更新(エンティティが存在しない場合はエラー)         |
+| `replace`      | すべての属性を置換                              |
+| `delete`       | エンティティまたは属性を削除                         |
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的成功/エラー: `200 OK` とエラー詳細
+
+* すべて成功:`204 No Content`
+  
+* 部分的な成功/エラー:`200 OK`とエラー詳細
 
 ```json
 {
@@ -522,13 +551,13 @@ POST /v2/op/query
 
 **レスポンス**: エンティティの配列
 
-### 通知の受信
+### 通知を受信
 
 ```http
 POST /v2/op/notify
 ```
 
-外部 Context Broker からの通知を受信し、append でエンティティを処理します (存在しない場合は作成、既に存在する場合は更新)。
+外部 Context Broker から通知を受信し、append でエンティティを処理します(存在しない場合は作成、既に存在する場合は更新)。
 
 **リクエストボディ**
 
@@ -545,12 +574,18 @@ POST /v2/op/notify
 }
 ```
 
-- `subscriptionId`: 必須 - 通知をトリガーしたサブスクリプション ID
-- `data`: 必須 - NGSIv2 正規化形式のエンティティの配列
 
-**レスポンス**: `200 OK`---
+* `subscriptionId`: 必須 - 通知をトリガーしたサブスクリプション ID
+  
+* `data`: 必須 - NGSIv2 正規化形式のエンティティの配列
 
-## サブスクリプション### サブスクリプションの作成
+**レスポンス**: `200 OK`
+
+***
+
+## サブスクリプション
+
+### サブスクリプションの作成
 
 ```http
 POST /v2/subscriptions
@@ -609,25 +644,25 @@ POST /v2/subscriptions
 
 **httpCustom フィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `url` | string | ✓ | 通知送信先 URL |
-| `method` | string | - | HTTP メソッド(GET、POST、PUT、PATCH、DELETE)。デフォルト: POST |
-| `headers` | object | - | カスタム HTTP ヘッダー |
-| `qs` | object | - | クエリ文字列パラメータ(`${...}` マクロ置換をサポート) |
-| `payload` | string | - | リクエストボディテンプレート(`${...}` マクロ置換をサポート) |
+| フィールド     | タイプ    | 必須 | 説明                                                    |
+| --------- | ------ | -- | ----------------------------------------------------- |
+| `url`     | string | ✓  | 通知先 URL                                               |
+| `method`  | string | -  | HTTP メソッド (GET, POST, PUT, PATCH, DELETE)。デフォルト: POST |
+| `headers` | object | -  | カスタム HTTP ヘッダー                                        |
+| `qs`      | object | -  | クエリ文字列パラメータ (`${...}` マクロ置換をサポート)                     |
+| `payload` | string | -  | リクエストボディテンプレート (`${...}` マクロ置換をサポート)                  |
 
 **マクロ置換**
 
-`${...}` 構文を使用して `payload` および `qs` の値にエンティティデータを埋め込むことができます:
+&#x20;構文を使用して、`${...}` の構文を使用して、`payload` と `qs` の値にエンティティデータを埋め込むことができます:
 
-| マクロ | 置換値 |
-|-------|-------------------|
-| `${id}` | エンティティ ID |
-| `${type}` | エンティティタイプ |
-| `${attrName}` | 属性値(正規化された属性から `.value` を抽出) |
+| マクロ           | 置換値                           |
+| ------------- | ----------------------------- |
+| `${id}`       | エンティティ ID                     |
+| `${type}`     | エンティティタイプ                     |
+| `${attrName}` | 属性値 (正規化された属性から `.value` を抽出) |
 
-存在しない属性は文字列 `null` に置き換えられます。マクロは attrs/exceptAttrs フィルターが適用される前の完全なエンティティに対して評価されます。
+存在しない属性は文字列 `null` に置き換えられます。マクロは attrs/exceptAttrs フィルタが適用される前の完全なエンティティに対して評価されます。
 
 **MQTT 通知の例**
 
@@ -658,14 +693,14 @@ POST /v2/subscriptions
 
 **MQTT 通知設定**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `url` | string | ✓ | MQTT ブローカー URL (`mqtt://` または `mqtts://`) |
-| `topic` | string | ✓ | 通知送信先トピック |
-| `qos` | integer | - | QoS レベル(0、1、2)。デフォルト: 0 |
-| `retain` | boolean | - | メッセージ保持フラグ。デフォルト: false |
-| `user` | string | - | 認証ユーザー名 |
-| `passwd` | string | - | 認証パスワード |
+| フィールド    | 型       | 必須 | 説明                                       |
+| -------- | ------- | -- | ---------------------------------------- |
+| `url`    | string  | ✓  | MQTT ブローカー URL(`mqtt://` または `mqtts://`) |
+| `topic`  | string  | ✓  | 通知送信先トピック                                |
+| `qos`    | integer | -  | QoS レベル(0, 1, 2)。デフォルト:0                 |
+| `retain` | boolean | -  | メッセージ保持フラグ。デフォルト:false                   |
+| `user`   | string  | -  | 認証ユーザー名                                  |
+| `passwd` | string  | -  | 認証パスワード                                  |
 
 **リクエストボディ**
 
@@ -697,21 +732,26 @@ POST /v2/subscriptions
 
 **attrsFormat タイプ**
 
-| フォーマット | 説明 |
-|--------|-------------|
+| フォーマット       | 説明                      |
+| ------------ | ----------------------- |
 | `normalized` | 標準 NGSIv2 フォーマット(デフォルト) |
-| `keyValues` | 簡略化されたキーバリューフォーマット |
+| `keyValues`  | 簡易キー・バリューフォーマット         |
 
-**通知属性のフィルタリング**
+**通知属性フィルタリング**
 
-| フィールド | タイプ | 説明 |
-|-------|------|-------------|
-| `attrs` | string[] | 通知に含める属性名のリスト |
-| `exceptAttrs` | string[] | 通知から除外する属性名のリスト |
-| `onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせることができます。 |
+| フィールド              | 型         | 説明                                                                       |
+| ------------------ | --------- | ------------------------------------------------------------------------ |
+| `attrs`            | string\[] | 通知に含める属性名のリスト                                                            |
+| `exceptAttrs`      | string\[] | 通知から除外する属性名のリスト                                                          |
+| `onlyChangedAttrs` | boolean   | もし `true` なら、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせることができます。 |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /v2/subscriptions/{subscriptionId}`### サブスクリプションの一覧取得
+
+* ステータス:`201 Created`
+  
+* ヘッダー:`Location: /v2/subscriptions/{subscriptionId}`
+
+### サブスクリプション一覧取得
 
 ```http
 GET /v2/subscriptions
@@ -719,19 +759,19 @@ GET /v2/subscriptions
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
-| `status` | string | ステータスでフィルタリング(`active`、`inactive`) | - |
+| パラメータ    | 型       | 説明                                 | デフォルト |
+| -------- | ------- | ---------------------------------- | ----- |
+| `limit`  | integer | 取得する結果の数                           | 20    |
+| `offset` | integer | オフセット                              | 0     |
+| `status` | string  | ステータスでフィルタリング(`active`、`inactive`) | -     |
 
-### サブスクリプションの取得
+### サブスクリプション取得
 
 ```http
 GET /v2/subscriptions/{subscriptionId}
 ```
 
-### サブスクリプションの更新
+### サブスクリプション更新
 
 ```http
 PATCH /v2/subscriptions/{subscriptionId}
@@ -745,24 +785,27 @@ PATCH /v2/subscriptions/{subscriptionId}
 }
 ```
 
-**レスポンス**: `204 No Content`
+**レスポンス**:`204 No Content`
+
 ### サブスクリプションの削除
 
 ```http
 DELETE /v2/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`
 
-認証が有効になっている場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
+### 所有権検証 (GeonicDB 拡張)
 
----
+認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
 
-## 登録
+***
 
-登録は外部コンテキストプロバイダを登録し、エンティティ情報のソースを管理します。
+## レジストレーション
 
-### 登録の作成
+レジストレーションは外部コンテキストプロバイダーを登録し、エンティティ情報のソースを管理します。
+
+### レジストレーションの作成
 
 ```http
 POST /v2/registrations
@@ -791,18 +834,23 @@ POST /v2/registrations
 
 **リクエストフィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `description` | string | - | 登録の説明 |
-| `dataProvided.entities` | array | ✓ | 対象エンティティ (id、idPattern、type) |
-| `dataProvided.attrs` | array | - | 提供する属性名 |
-| `provider.http.url` | string | ✓ | プロバイダ URL |
-| `expires` | string | - | 有効期限 (ISO 8601 形式) |
-| `status` | string | - | ステータス (`active` / `inactive`)。デフォルト: `active` |
-| `mode` | string | - | 転送モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`)。NGSI-LD 互換拡張 |
+| フィールド                   | 型      | 必須 | 説明                                                                        |
+| ----------------------- | ------ | -- | ------------------------------------------------------------------------- |
+| `description`           | string | -  | レジストレーションの説明                                                              |
+| `dataProvided.entities` | array  | ✓  | 対象エンティティ (id、idPattern、type)                                              |
+| `dataProvided.attrs`    | array  | -  | 提供する属性名                                                                   |
+| `provider.http.url`     | string | ✓  | プロバイダー URL                                                                |
+| `expires`               | string | -  | 有効期限 (ISO 8601 形式)                                                        |
+| `status`                | string | -  | ステータス (`active` / `inactive`)。デフォルト: `active`                             |
+| `mode`                  | string | -  | 転送モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`)。NGSI-LD 互換拡張 |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /v2/registrations/{registrationId}`### 登録の一覧取得
+
+* ステータス: `201 Created`
+  
+* ヘッダー: `Location: /v2/registrations/{registrationId}`
+
+### レジストレーション一覧
 
 ```http
 GET /v2/registrations
@@ -810,10 +858,10 @@ GET /v2/registrations
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
+| パラメータ    | 型       | 説明       | デフォルト |
+| -------- | ------- | -------- | ----- |
+| `limit`  | integer | 取得する結果の数 | 20    |
+| `offset` | integer | オフセット    | 0     |
 
 **レスポンス例**
 
@@ -854,25 +902,29 @@ PATCH /v2/registrations/{registrationId}
 }
 ```
 
-**レスポンス**: `204 No Content`### 登録の削除
+**レスポンス**: `204 No Content`
+
+### 登録の削除
 
 ```http
 DELETE /v2/registrations/{registrationId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
+### 所有権検証 (GeonicDB 拡張)
 
----
+認証が有効な場合(`AUTH_ENABLED=true`)、登録の更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
+
+***
 
 ## フェデレーション (クエリ転送 / 更新転送)
 
-登録情報に基づいて、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合して返します。また、更新も転送します。
+登録に基づいて、GeonicDB はクエリを外部コンテキストプロバイダーに転送し、結果を統合し、更新を転送します。
 
 ### フェデレーションの仕組み
 
-エンティティをクエリする際、一致する登録情報が存在する場合、そのプロバイダーにも並行してクエリが送信され、結果がマージされて返されます。
+エンティティをクエリする際、一致する登録が存在する場合、クエリはそのプロバイダーにも並列に送信され、結果がマージされて返されます。
 
 ```text
 Client → Context Broker
@@ -886,14 +938,15 @@ Client → Context Broker
 
 ### 登録モード
 
-| モード | 動作 |
-|------|----------|
-| `inclusive` | ローカルとリモートの両方の結果を返します (デフォルト) |
-| `exclusive` | リモートの結果のみを返します (ローカルデータは無視されます) |
-| `redirect` | 303 リダイレクト URL を返します |
-| `auxiliary` | ローカルデータが優先され、リモートは不足データを補完します |
+| モード         | 動作                                |
+| ----------- | --------------------------------- |
+| `inclusive` | ローカルとリモートの両方の結果を返します (デフォルト)      |
+| `exclusive` | リモートの結果のみを返します (ローカルデータは無視されます)   |
+| `redirect`  | 303 リダイレクト URL を返します              |
+| `auxiliary` | ローカルデータが優先され、リモートが不足しているデータを補完します |
 
 ### フェデレーションの例
+
 
 1. 外部プロバイダーを登録します:
 
@@ -913,7 +966,7 @@ curl -X POST "http://localhost:3000/v2/registrations" \
   }'
 ```
 
-2. クエリ時にフェデレーションが自動的に行われます:
+2\. クエリ実行時にフェデレーションが自動的に行われます:
 
 ```bash
 curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
@@ -924,36 +977,36 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 ### 更新転送
 
-エンティティを更新または削除する際、一致する登録情報が存在する場合、更新もそのプロバイダーに並行して転送されます。
+エンティティを更新または削除する際、一致する登録が存在する場合、更新もそのプロバイダーに並列に転送されます。
 
-**サポートされる更新操作**
+**サポートされている更新操作**
 
-| 操作 | 説明 |
-|-----------|-------------|
-| エンティティ属性の更新 | `PATCH /v2/entities/{id}/attrs` |
-| エンティティ属性の追加 | `POST /v2/entities/{id}/attrs` |
-| エンティティ属性の置換 | `PUT /v2/entities/{id}/attrs` |
-| エンティティの削除 | `DELETE /v2/entities/{id}` |
-| 属性の削除 | `DELETE /v2/entities/{id}/attrs/{attr}` |
+| 操作          | 説明                                      |
+| ----------- | --------------------------------------- |
+| エンティティ属性を更新 | `PATCH /v2/entities/{id}/attrs`         |
+| エンティティ属性を追加 | `POST /v2/entities/{id}/attrs`          |
+| エンティティ属性を置換 | `PUT /v2/entities/{id}/attrs`           |
+| エンティティを削除   | `DELETE /v2/entities/{id}`              |
+| 属性を削除       | `DELETE /v2/entities/{id}/attrs/{attr}` |
 
 **モード別の更新動作**
 
-| モード | 動作 |
-|------|----------|
-| `inclusive` | ローカルとリモートの両方を更新します |
-| `exclusive` | リモートのみを更新します (ローカルは更新されません) |
-| `redirect` | 303 リダイレクト URL を返します (ローカルは更新されません) |
-| `auxiliary` | ローカルのみを更新します (リモートは読み取り専用) |
+| モード         | 動作                                  |
+| ----------- | ----------------------------------- |
+| `inclusive` | ローカルとリモートの両方を更新します                  |
+| `exclusive` | リモートのみを更新します (ローカルは更新されません)         |
+| `redirect`  | 303 リダイレクト URL を返します (ローカルは更新されません) |
+| `auxiliary` | ローカルのみを更新します (リモートは読み取り専用)          |
 
 ### エラー処理
 
-| シナリオ | 動作 |
-|----------|----------|
-| プロバイダー接続失敗 | 警告をログに記録し、ローカル結果のみを返します |
-| プロバイダータイムアウト | 警告をログに記録し、ローカル結果のみを返します |
-| 排他モードですべてのプロバイダーが失敗 | 502 エラーを返します (オプション) |
+| シナリオ                | 動作                       |
+| ------------------- | ------------------------ |
+| プロバイダー接続失敗          | 警告をログに記録し、ローカルの結果のみを返します |
+| プロバイダータイムアウト        | 警告をログに記録し、ローカルの結果のみを返します |
+| 排他モードですべてのプロバイダーが失敗 | 502 エラーを返します (オプション)     |
 
----
+***
 
 ## エンティティタイプ
 
@@ -965,10 +1018,10 @@ GET /v2/types
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `options=count` | エンティティ数を含めます |
-| `options=values` | 属性の詳細を含めます |
+| パラメータ            | 説明          |
+| ---------------- | ----------- |
+| `options=count`  | エンティティ数を含める |
+| `options=values` | 属性の詳細を含める   |
 
 **レスポンス例**
 
@@ -1004,62 +1057,62 @@ GET /v2/types/{typeName}
 }
 ```
 
----
+***
 
-## HTTP キャッシュコントロール
+## HTTP キャッシュ制御
 
-GET エンドポイントは、エンドポイントのクラスごとにキャッシュ関連のヘッダーを返します:
+GET エンドポイントはエンドポイントクラスごとにキャッシュ関連ヘッダーを返します:
 
-### データエンドポイント (エンティティ、サブスクリプション、登録) — 完全な RFC 7232 + RFC 7234 サポート
+### データエンドポイント (entities、subscriptions、registrations) — RFC 7232 + RFC 7234 の完全サポート
 
-| ヘッダー | 値 | 目的 |
-|--------|-------|---------|
-| `ETag` | `W/"..."` | 弱いバリデーター。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
-| `Last-Modified` | RFC 1123 HTTP-date | 結果セット内の最新の `modifiedAt` のタイムスタンプ。 |
-| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュ向けのテナント + 認証 + コンテンツネゴシエーション分離。 |
+| ヘッダー            | 値                                                                      | 目的                                                                                                                                                                                                                      |
+| --------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETag`          | `W/"..."`                                                              | 弱いバリデーター。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープの混合。単一: `modifiedAt` のハッシュとスコープの混合。 |
+| `Last-Modified` | RFC 1123 HTTP-date                                                     | 結果セット内の最新の `modifiedAt` のタイムスタンプ。                                                                                                                                                                                       |
+| `Cache-Control` | `private, no-cache`                                                    | `private` は共有 / 中間キャッシュストレージをブロックします; `no-cache` はプライベートキャッシュからの再検証を強制します。                                                                                                                                              |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュのためのテナント + 認証 + コンテンツネゴシエーションの分離。                                                                                                                                                                                |
 
 条件付きリクエストがサポートされています:
 
-| リクエストヘッダー | 動作 |
-|----------------|----------|
-| `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified` (空のボディ) を返します。 |
-| `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。 |
-| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします。 |
+| リクエストヘッダー                        | 動作                                                    |
+| -------------------------------- | ----------------------------------------------------- |
+| `If-None-Match: <ETag>`          | 一致した場合、`304 Not Modified` (空のボディ) を返します。              |
+| `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。                          |
+| `Cache-Control: no-store`        | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします。 |
 
-### メタエンドポイント (タイプ) — Cache-Control + Vary のみ (ETag なし / 304 なし)
+### メタエンドポイント (types) — Cache-Control + Vary のみ (ETag なし / 304 なし)
 
-| ヘッダー | 値 | 目的 |
-|--------|-------|---------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` | バックグラウンド再検証を伴う短期キャッシング。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証分離。 |
+| ヘッダー            | 値                                                                      | 目的                         |
+| --------------- | ---------------------------------------------------------------------- | -------------------------- |
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120`                               | バックグラウンド再検証を伴う短期キャッシング。    |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証の分離。 |
 
-メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしていません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
+メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
 
 完全なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
 
----
+***
 
 ## HTTP エラーレスポンス
 
-| ステータスコード | エラーコード | 説明 |
-|-------------|------------|-------------|
-| 400 | BadRequest | 無効なリクエストパラメータまたはボディ |
-| 400 | InvalidModification | 無効な属性変更 (例: id や type の変更) |
-| 401 | Unauthorized | 認証が必要、またはトークンが無効 |
-| 403 | Forbidden | 権限不足 |
-| 404 | NotFound | エンティティ、サブスクリプションなどが見つかりません |
-| 405 | MethodNotAllowed | HTTP メソッドが許可されていません |
-| 409 | AlreadyExists | エンティティが既に存在します (POST 作成時) |
-| 409 | TooManyResults | 複数のエンティティが一致しました (type が指定されていない場合) |
-| 411 | ContentLengthRequired | Content-Length ヘッダーが必要です |
-| 413 | RequestEntityTooLarge | リクエストボディが大きすぎます |
-| 415 | UnsupportedMediaType | サポートされていない Content-Type |
-| 422 | Unprocessable | エンティティフォーマットが無効です |
-| 429 | TooManyRequests | レート制限を超過しました |
-| 500 | InternalError | 内部サーバーエラー |
+| ステータスコード | エラーコード                | 説明                                 |
+| -------- | --------------------- | ---------------------------------- |
+| 400      | BadRequest            | 無効なリクエストパラメータまたはボディ                |
+| 400      | InvalidModification   | 無効な属性の変更(例: id または type の変更)       |
+| 401      | Unauthorized          | 認証が必要、またはトークンが無効                   |
+| 403      | Forbidden             | 権限が不足しています                         |
+| 404      | NotFound              | エンティティ、サブスクリプションなどが見つかりません         |
+| 405      | MethodNotAllowed      | HTTP メソッドが許可されていません                |
+| 409      | AlreadyExists         | エンティティが既に存在します(POST 作成時)           |
+| 409      | TooManyResults        | 複数のエンティティが一致しました(type が指定されていない場合) |
+| 411      | ContentLengthRequired | Content-Length ヘッダーが必要です           |
+| 413      | RequestEntityTooLarge | リクエストボディが大きすぎます                    |
+| 415      | UnsupportedMediaType  | サポートされていない Content-Type            |
+| 422      | Unprocessable         | エンティティの形式が無効です                     |
+| 429      | TooManyRequests       | レート制限を超過しました                       |
+| 500      | InternalError         | 内部サーバーエラー                          |
 
-**エラーレスポンスフォーマット**
+**エラーレスポンス形式**
 
 ```json
 {
@@ -1068,69 +1121,74 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 }
 ```
 
----
+***
 
 ## エンドポイントリファレンス
 
-FIWARE NGSIv2 互換の Context Broker API です。
+FIWARE NGSIv2 互換 Context Broker API。
 
 ### 共通仕様
 
-- **Content-Type**: `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
-- **テナント分離**: `Fiware-Service` ヘッダーによるテナント分離
-- **ページネーション**: `limit`/`offset` パラメータを使用。総数を取得するには `options=count` を使用
+
+* **Content-Type**: `application/json`
+  
+* **認証**: 以下の場合に必須 `AUTH_ENABLED=true`
+  
+* **テナント分離**: `Fiware-Service` ヘッダーによるテナント分離
+  
+* **ページネーション**: `limit`/`offset` パラメータ; 総数を取得するには `options=count` を使用
 
 ### エンティティ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/entities` | GET | エンティティ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/entities` | POST | エンティティの作成 | 201 | 400, 401, 409, 415 | - |
-| `/v2/entities/{entityId}` | GET | エンティティの取得 | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}` | DELETE | エンティティの削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | GET | 属性のみを取得 (id/type フィールドなし) | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | PATCH | 属性の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | POST | 属性の追加 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | PUT | 属性の置換 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | GET | 属性の取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | PUT | 属性の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | DELETE | 属性の削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET | 属性値の取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT | 属性値の更新 | 204 | 400, 401, 404, 415 | - |
+| エンドポイント                                          | メソッド   | 説明                       | 成功  | エラー                | ページネーション     |
+| ------------------------------------------------ | ------ | ------------------------ | --- | ------------------ | ------------ |
+| `/v2/entities`                                   | GET    | エンティティ一覧                 | 200 | 400, 401           | ✅ (最大: 1000) |
+| `/v2/entities`                                   | POST   | エンティティ作成                 | 201 | 400, 401, 409, 415 | -            |
+| `/v2/entities/{entityId}`                        | GET    | エンティティ取得                 | 200 | 400, 401, 404      | -            |
+| `/v2/entities/{entityId}`                        | DELETE | エンティティ削除                 | 204 | 401, 404           | -            |
+| `/v2/entities/{entityId}/attrs`                  | GET    | 属性のみ取得 (id/type フィールドなし) | 200 | 400, 401, 404      | -            |
+| `/v2/entities/{entityId}/attrs`                  | PATCH  | 属性更新                     | 204 | 400, 401, 404, 415 | -            |
+| `/v2/entities/{entityId}/attrs`                  | POST   | 属性追加                     | 204 | 400, 401, 404, 415 | -            |
+| `/v2/entities/{entityId}/attrs`                  | PUT    | 属性置換                     | 204 | 400, 401, 404, 415 | -            |
+| `/v2/entities/{entityId}/attrs/{attrName}`       | GET    | 属性取得                     | 200 | 401, 404           | -            |
+| `/v2/entities/{entityId}/attrs/{attrName}`       | PUT    | 属性更新                     | 204 | 400, 401, 404, 415 | -            |
+| `/v2/entities/{entityId}/attrs/{attrName}`       | DELETE | 属性削除                     | 204 | 401, 404           | -            |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET    | 属性値取得                    | 200 | 401, 404           | -            |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT    | 属性値更新                    | 204 | 400, 401, 404, 415 | -            |
 
 ### タイプ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/types` | GET | タイプ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/types/{typeName}` | GET | タイプ詳細の取得 | 200 | 401, 404 | - |
+| エンドポイント                | メソッド | 説明      | 成功  | エラー      | ページネーション     |
+| ---------------------- | ---- | ------- | --- | -------- | ------------ |
+| `/v2/types`            | GET  | タイプ一覧   | 200 | 400, 401 | ✅ (最大: 1000) |
+| `/v2/types/{typeName}` | GET  | タイプ詳細取得 | 200 | 401, 404 | -            |
 
 ### サブスクリプション操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/subscriptions` | GET | サブスクリプション一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/subscriptions` | POST | サブスクリプションの作成 | 201 | 400, 401, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | GET | サブスクリプションの取得 | 200 | 401, 404 | - |
-| `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプションの更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプションの削除 | 204 | 401, 404 | - |
+| エンドポイント                              | メソッド   | 説明          | 成功  | エラー                | ページネーション     |
+| ------------------------------------ | ------ | ----------- | --- | ------------------ | ------------ |
+| `/v2/subscriptions`                  | GET    | サブスクリプション一覧 | 200 | 400, 401           | ✅ (最大: 1000) |
+| `/v2/subscriptions`                  | POST   | サブスクリプション作成 | 201 | 400, 401, 415      | -            |
+| `/v2/subscriptions/{subscriptionId}` | GET    | サブスクリプション取得 | 200 | 401, 404           | -            |
+| `/v2/subscriptions/{subscriptionId}` | PATCH  | サブスクリプション更新 | 204 | 400, 401, 404, 415 | -            |
+| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプション削除 | 204 | 401, 404           | -            |
 
-### 登録操作(フェデレーション)
+### 登録操作 (フェデレーション)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/registrations` | GET | 登録一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/registrations` | POST | 登録の作成 | 201 | 400, 401, 415 | - |
-| `/v2/registrations/{registrationId}` | GET | 登録の取得 | 200 | 401, 404 | - |
-| `/v2/registrations/{registrationId}` | PATCH | 登録の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/registrations/{registrationId}` | DELETE | 登録の削除 | 204 | 401, 404 | - |
+| エンドポイント                              | メソッド   | 説明   | 成功  | エラー                | ページネーション     |
+| ------------------------------------ | ------ | ---- | --- | ------------------ | ------------ |
+| `/v2/registrations`                  | GET    | 登録一覧 | 200 | 400, 401           | ✅ (最大: 1000) |
+| `/v2/registrations`                  | POST   | 登録作成 | 201 | 400, 401, 415      | -            |
+| `/v2/registrations/{registrationId}` | GET    | 登録取得 | 200 | 401, 404           | -            |
+| `/v2/registrations/{registrationId}` | PATCH  | 登録更新 | 204 | 400, 401, 404, 415 | -            |
+| `/v2/registrations/{registrationId}` | DELETE | 登録削除 | 204 | 401, 404           | -            |
 
 ### バッチ操作
 
-> **注意**: バッチ操作(クエリを除く)は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています(デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
+> **注意**: バッチ操作 (クエリを除く) は 1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています (デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/op/update` | POST | バッチ更新(最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
-| `/v2/op/query` | POST | バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
-| `/v2/op/notify` | POST | 通知の受信 | 200 | 400, 401, 415 | - |
+| エンドポイント         | メソッド | 説明                           | 成功  | エラー           | ページネーション     |
+| --------------- | ---- | ---------------------------- | --- | ------------- | ------------ |
+| `/v2/op/update` | POST | バッチ更新 (最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | -            |
+| `/v2/op/query`  | POST | バッチクエリ                       | 200 | 400, 401, 415 | ✅ (最大: 1000) |
+| `/v2/op/notify` | POST | 通知受信                         | 200 | 400, 401, 415 | -            |

--- a/docs/ja/changelog.md
+++ b/docs/ja/changelog.md
@@ -10,1196 +10,2326 @@ outline: deep
 このフォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.1.0/) に基づいており、
 このプロジェクトは [Semantic Versioning](https://semver.org/lang/ja/) に準拠しています。
 
-## [Unreleased]
+## \[Unreleased]
+
+## \[0.8.0] — 2026-05-05
 
 ### 2026-05-05
-- **修正**: SDK の `db.request()` が空ボディ + JSON Content-Type のレスポンスで `SyntaxError: Unexpected end of JSON input` を投げて落ちる問題 (issue #1145) (#1146)
-  - 背景: NGSI-LD `POST /entities` (201) など仕様上ボディが空のレスポンスでも、サーバ実装は `Content-Type: application/ld+json` を付けて返している。SDK 側 `db.request()` は Content-Type が `json` を含むと無条件に `res.json()` を呼ぶため、空ボディで SyntaxError を投げていた (`db.createEntity` 等の専用メソッドは body を読まないので影響なし、`db.request()` 経由で同パスを叩くと壊れる、という非対称が問題)
-  - 修正: `db.request()` を空ボディに堅牢化。`Content-Length: 0` を短絡 + `text()` で先に読んで空文字なら null を返す形に変更
-  - 追加: `tests/unit/sdk/index.test.ts` に 201 + 空 body + JSON Content-Type / Content-Length: 0 の 2 件の regression テスト
-  - 残課題: NGSI-LD spec / RFC 9110 上は空ボディに `Content-Type` を付けない方が望ましい。サーバ側 (`entities.controller.ts` ほか) は別 issue で spec 準拠化する
-- 🚨 **破壊的変更**: Custom Data Models の `valueType` 入力契約導入により観測可能な挙動変更が 3 点 (issue #1131) (#1147)
-  - **未知の `valueType` を含む Custom Data Model の作成は 400 で拒否される**: 旧は任意文字列を受理して後段で silent skip。新は Zod の preprocess + enum で正準形 (9 値) に解決できないと作成時に 400。`String` / `GeoJSON` / `text` / `int` / `bool` / `json` / `geo` / `GeoJSON Point` 等の旧 alias は **入力時に自動正規化されるので影響なし**。完全に未知の値 (タイポ等) のみ影響を受ける
-  - **既存モデルに未知 `valueType` が残っている場合、エンティティ書き込みが 400 になる**: 旧は `validation.service` の switch default で silent skip (fail-open) → 不正データも保存可。新は `Unsupported valueType '<v>' in data model definition` で ValidationError (fail-closed)。API 経由で作成された既存モデルは preprocess を当時通っていれば該当しない。**影響を受けるのは直接 DB に書き込まれた壊れたモデルのみ**。リリース前に `propertyDetails.*.valueType` を点検して未知値の有無を確認することを推奨
-  - **`datetime` / `uri` valueType の値が新たにバリデーションされる**: 旧は該当 case が無く skip (= どんな文字列も保存可)。新は `datetime` が **RFC 3339 strict** (T リテラル + 秒必須 + タイムゾーン必須)、`uri` が `URL` コンストラクタで形式検証。`schema-generator.service.ts` が出力する JSON Schema の `format: 'date-time'` (RFC 3339) と検証ルールが整合する
-  - SemVer: 観測可能な挙動変更を含むため **minor バンプ (0.8.0)** を推奨
-- **修正**: Custom Data Models の `valueType` に入力契約を導入し、コンポーネント間の挙動の食い違いを解消 (issue #1131) (#1147)
-  - 背景: #595 で `validation.service` の case mismatch を `toLowerCase()` で吸収したが、Zod スキーマには enum 制約がなく、`schema-generator` / `mcp tool` は依然として小文字厳密一致だったため、PascalCase / 独自表記 (`'GeoJSON Point'`) / タイポを silent skip するか挙動分岐するかが箇所ごとに違っていた
-  - 修正:
-    - **`src/core/custom-data-models/value-type.ts`** を新設し `VALUE_TYPES` 9 値 (`string`, `number`, `integer`, `boolean`, `array`, `object`, `geojson`, `uri`, `datetime`) と `normalizeValueType()` を single source of truth として提供
-    - **Zod スキーマ** (`ExtendedPropertyDetailSchema.valueType`) を `preprocess(toLowerCase + alias) → z.enum(VALUE_TYPES)` に変更。後方互換: `String` / `GeoJSON` / `text` / `int` / `bool` / `json` / `geo` / `GeoJSON Point` 等を入力時に自動正規化、未知値は 400
-    - **`validation.service.ts`** が `normalizeValueType` を経由するように変更し、`uri` / `datetime` のケースを追加。未知 valueType は silent skip ではなく `logger.warn` を出すように変更
-    - **`schema-generator.service.ts`** / **MCP tool (`config.tools.ts`)** も `normalizeValueType` 経由で正規化してから switch するように変更
-    - **OpenAPI 例** (`meta.controller.ts`): `'GeoJSON Point'` → `'geojson'` に修正
-    - **`docs/INSTRUCTION.md`** のフィールド表で `valueType` の正準形と alias の扱いを明記
-  - 追加: `tests/unit/core/custom-data-models/value-type.test.ts` (純粋関数の網羅), `custom-data-model.schemas.test.ts` の `property valueType enum (#1131)` セクション (canonical 9 値受理 + alias preprocess + 未知値拒否)
-- 🚨 **破壊的変更**: `POST /ngsi-ld/v1/entityOperations/upsert` で既存エンティティの `scope` が反映されるようになる (issue #1133) (#1148)
-  - 旧: リクエストボディに `scope` が含まれていてもサーバ側で silently drop されていた (バグ)
-  - 新: NGSI-LD §5.6.10 / §5.6.4 仕様どおり scope も置換 / 反映される
-  - 影響: GET したエンティティのレスポンスをそのまま再 upsert する round-trip パターンを使っているクライアントは、これまで無視されていた `scope` がそのまま反映される。元データと同じ scope を返している限り no-op だが、レスポンスの `scope` を加工してから送り戻していた場合は要点検
-  - SemVer: バグ修正の側面が強いが「これまで無視されていたフィールドが反映される」という観測可能な挙動変更
-- **修正**: `POST /ngsi-ld/v1/entityOperations/upsert` で既存エンティティの `scope` が silently drop されていた問題 (issue #1133) (#1148)
-  - 背景: `batch.controller.ts` の upsert は、既存エンティティに対して `replaceEntityAttributes(tenant, id, entity.attributes)` と **`attributes` だけ** を渡しており、リクエストボディに含まれる `scope` (および `expiresAt`) はサーバ側で 204 / 207 で成功扱いになる一方で実際には反映されない silent failure を起こしていた。NGSI-LD 1.6 §5.6.10 (Upsert) で `options=replace` は §5.6.4 (Replace Entity) 等価とされ、scope を含む全置換が期待される
-  - 修正:
-    - **`entity.repository.update()`** の options に `scope?: string[] | null` を追加 (encrypted / non-encrypted 両 path)
-    - **`entity.service.updateEntityAttributes()` / `replaceEntityAttributes()`** に `scope` オプションを追加し repository へ伝搬
-    - **`batch.controller.ts` の `batchUpsert`**: 既存エンティティ更新時に `entity.scope` を service に渡す (replace / merge 両モード)
-  - 後方互換: `entity.scope === undefined` (リクエストボディに scope を含めない場合) は既存値を維持。明示配列で置換、`null` でフィールドを unset
-  - 追加: `batch.controller.test.ts` に regression テスト 2 件 (replace / merge 両モードで scope が `entity.service` に伝搬されることを保証)
-- 🚨 **破壊的変更 (軽微)**: SDK の URL クエリ文字列のエンコーディングが微妙に変わる (#1149)
-  - 旧: `encodeURIComponent` でフィールドごとに直列化
-  - 新: `URLSearchParams` ベースに refactor (DRY 化のため)
-  - 影響を受ける文字: 半角スペース `%20` → `+` / `'` 素通し → `%27` / `!` `*` `(` `)` `~` 素通し → `%21` `%2A` `%28` `%29` `%7E`
-  - サーバ側 (GeonicDB 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
-  - 公開メソッドのシグネチャは追加のみで完全後方互換 (新パラメータはすべて optional)
-- **改善**: SDK のクエリパラメータ表面を NGSI-LD §5.7.2 (Query Entities) に揃えて拡充 (issue #1132) (#1149)
-  - 背景: `db.getEntities()` 等は `type / limit / offset / q` の 4 パラメータしか URL に乗せておらず、サーバが実装している `scopeQ` / `georel` / `geometry` / `coordinates` / `attrs` / `pick` / `omit` / `lang` / `orderBy` / `count` 等を SDK 経由で使えなかった。実アプリで scope に基づくフィルタが必要になり (geonicdb-gis 関連)、SDK を諦めて `db.request()` で素のパスを組み立てる回避が必要だった
-  - 修正:
-    - **`src/sdk/types.ts`**: `GetEntitiesParams` を拡張し `scopeQ`, `georel`, `geometry`, `coordinates`, `attrs`, `pick`, `omit`, `lang`, `orderBy`, `orderDirection`, `orderByDistance`, `count`, `geoproperty` を追加。`CountEntitiesParams` / `GetTemporalEntitiesParams` / `SubscribeOptions` / `SubscriptionMessage` にも `scopeQ` を追加
-    - **`src/sdk/index.ts`**: `URLSearchParams` ベースの汎用ビルダ `buildPathWithParams()` を導入し、`buildEntitiesPath()` / `count()` / `getTemporalEntities()` を全て経由させる。今後パラメータ追加は型に書くだけで自動的に URL に乗る (一箇所追加すれば終わるよう DRY 化)
-    - **`src/sdk/websocket.ts`**: `subscribe(options)` が `scopeQ` を受け、サブスクリプションメッセージに添える (サーバ側未対応バージョンでは無視される)
-    - **`src/sdk/README.md`**: `getEntities()` の例にコメント形式で全パラメータを列挙
-  - 後方互換: 既存呼び出し (`{ type, limit, offset, q }` のみ) は完全に動作。新パラメータは optional 追加
-  - 追加: `tests/unit/sdk/index.test.ts` に regression テスト 3 件
 
-## [0.7.1] — 2026-05-02
+
+* **修正**: SDK の `db.request()` が空ボディ + JSON Content-Type のレスポンスで `SyntaxError: Unexpected end of JSON input` を投げて落ちる問題 (issue #1145) (#1146)
+  
+  * 背景: NGSI-LD `POST /entities` (201) など仕様上ボディが空のレスポンスでも、サーバ実装は `Content-Type: application/ld+json` を付けて返している。SDK 側 `db.request()` は Content-Type が `json` を含むと無条件に `res.json()` を呼ぶため、空ボディで SyntaxError を投げていた (`db.createEntity` 等の専用メソッドは body を読まないので影響なし、`db.request()` 経由で同パスを叩くと壊れる、という非対称が問題)
+    
+  * 修正: `db.request()` を空ボディに堅牢化。`Content-Length: 0` を短絡 + `text()` で先に読んで空文字なら null を返す形に変更
+    
+  * 追加: `tests/unit/sdk/index.test.ts` に 201 + 空 body + JSON Content-Type / Content-Length: 0 の 2 件の regression テスト
+    
+  * 残課題: NGSI-LD spec / RFC 9110 上は空ボディに `Content-Type` を付けない方が望ましい。サーバ側 (`entities.controller.ts` ほか) は別 issue で spec 準拠化する
+    
+* 🚨 **破壊的変更**: Custom Data Models の `valueType` 入力契約導入により観測可能な挙動変更が 3 点 (issue #1131) (#1147)
+  
+  * **未知の `valueType` を含む Custom Data Model の作成は 400 で拒否される**: 旧は任意文字列を受理して後段で silent skip。新は Zod の preprocess + enum で正準形 (9 値) に解決できないと作成時に 400。`String` / `GeoJSON` / `text` / `int` / `bool` / `json` / `geo` / `GeoJSON Point` 等の旧 alias は **入力時に自動正規化されるので影響なし**。完全に未知の値 (タイポ等) のみ影響を受ける
+    
+  * **既存モデルに未知 `valueType` が残っている場合、エンティティ書き込みが 400 になる**: 旧は `validation.service` の switch default で silent skip (fail-open) → 不正データも保存可。新は `Unsupported valueType '<v>' in data model definition` で ValidationError (fail-closed)。API 経由で作成された既存モデルは preprocess を当時通っていれば該当しない。**影響を受けるのは直接 DB に書き込まれた壊れたモデルのみ**。リリース前に `propertyDetails.*.valueType` を点検して未知値の有無を確認することを推奨
+    
+  * **`datetime` / `uri` valueType の値が新たにバリデーションされる**: 旧は該当 case が無く skip (= どんな文字列も保存可)。新は `datetime` が **RFC 3339 strict** (T リテラル + 秒必須 + タイムゾーン必須)、`uri` が `URL` コンストラクタで形式検証。`schema-generator.service.ts` が出力する JSON Schema の `format: 'date-time'` (RFC 3339) と検証ルールが整合する
+    
+  * SemVer: 観測可能な挙動変更を含むため **minor バンプ (0.8.0)** を推奨
+    
+* **修正**: Custom Data Models の `valueType` に入力契約を導入し、コンポーネント間の挙動の食い違いを解消 (issue #1131) (#1147)
+  
+  * 背景: #595 で `validation.service` の case mismatch を `toLowerCase()` で吸収したが、Zod スキーマには enum 制約がなく、`schema-generator` / `mcp tool` は依然として小文字厳密一致だったため、PascalCase / 独自表記 (`'GeoJSON Point'`) / タイポを silent skip するか挙動分岐するかが箇所ごとに違っていた
+    
+  * 修正:
+    
+    * **`src/core/custom-data-models/value-type.ts`** を新設し `VALUE_TYPES` 9 値 (`string`, `number`, `integer`, `boolean`, `array`, `object`, `geojson`, `uri`, `datetime`) と `normalizeValueType()` を single source of truth として提供
+      
+    * **Zod スキーマ** (`ExtendedPropertyDetailSchema.valueType`) を `preprocess(toLowerCase + alias) → z.enum(VALUE_TYPES)` に変更。後方互換: `String` / `GeoJSON` / `text` / `int` / `bool` / `json` / `geo` / `GeoJSON Point` 等を入力時に自動正規化、未知値は 400
+      
+    * **`validation.service.ts`** が `normalizeValueType` を経由するように変更し、`uri` / `datetime` のケースを追加。未知 valueType は silent skip ではなく `logger.warn` を出すように変更
+      
+    * **`schema-generator.service.ts`** / **MCP tool (`config.tools.ts`)** も `normalizeValueType` 経由で正規化してから switch するように変更
+      
+    * **OpenAPI 例** (`meta.controller.ts`): `'GeoJSON Point'` → `'geojson'` に修正
+      
+    * **`docs/INSTRUCTION.md`** のフィールド表で `valueType` の正準形と alias の扱いを明記
+      
+  * 追加: `tests/unit/core/custom-data-models/value-type.test.ts` (純粋関数の網羅), `custom-data-model.schemas.test.ts` の `property valueType enum (#1131)` セクション (canonical 9 値受理 + alias preprocess + 未知値拒否)
+    
+* 🚨 **破壊的変更**: `POST /ngsi-ld/v1/entityOperations/upsert` で既存エンティティの `scope` が反映されるようになる (issue #1133) (#1148)
+  
+  * 旧: リクエストボディに `scope` が含まれていてもサーバ側で silently drop されていた (バグ)
+    
+  * 新: NGSI-LD §5.6.10 / §5.6.4 仕様どおり scope も置換 / 反映される
+    
+  * 影響: GET したエンティティのレスポンスをそのまま再 upsert する round-trip パターンを使っているクライアントは、これまで無視されていた `scope` がそのまま反映される。元データと同じ scope を返している限り no-op だが、レスポンスの `scope` を加工してから送り戻していた場合は要点検
+    
+  * SemVer: バグ修正の側面が強いが「これまで無視されていたフィールドが反映される」という観測可能な挙動変更
+    
+* **修正**: `POST /ngsi-ld/v1/entityOperations/upsert` で既存エンティティの `scope` が silently drop されていた問題 (issue #1133) (#1148)
+  
+  * 背景: `batch.controller.ts` の upsert は、既存エンティティに対して `replaceEntityAttributes(tenant, id, entity.attributes)` と **`attributes` だけ** を渡しており、リクエストボディに含まれる `scope` (および `expiresAt`) はサーバ側で 204 / 207 で成功扱いになる一方で実際には反映されない silent failure を起こしていた。NGSI-LD 1.6 §5.6.10 (Upsert) で `options=replace` は §5.6.4 (Replace Entity) 等価とされ、scope を含む全置換が期待される
+    
+  * 修正:
+    
+    * **`entity.repository.update()`** の options に `scope?: string[] | null` を追加 (encrypted / non-encrypted 両 path)
+      
+    * **`entity.service.updateEntityAttributes()` / `replaceEntityAttributes()`** に `scope` オプションを追加し repository へ伝搬
+      
+    * **`batch.controller.ts` の `batchUpsert`**: 既存エンティティ更新時に `entity.scope` を service に渡す (replace / merge 両モード)
+      
+  * 後方互換: `entity.scope === undefined` (リクエストボディに scope を含めない場合) は既存値を維持。明示配列で置換、`null` でフィールドを unset
+    
+  * 追加: `batch.controller.test.ts` に regression テスト 2 件 (replace / merge 両モードで scope が `entity.service` に伝搬されることを保証)
+    
+* 🚨 **破壊的変更 (軽微)**: SDK の URL クエリ文字列のエンコーディングが微妙に変わる (#1149)
+  
+  * 旧: `encodeURIComponent` でフィールドごとに直列化
+    
+  * 新: `URLSearchParams` ベースに refactor (DRY 化のため)
+    
+  * 影響を受ける文字: 半角スペース `%20` → `+` / `'` 素通し → `%27` / `!` `*` `(` `)` `~` 素通し → `%21` `%2A` `%28` `%29` `%7E`
+    
+  * サーバ側 (GeonicDB 本体) は両形式を解釈するので **通常は実害なし**。プロキシ / WAF が strict matching している環境では影響しうる
+    
+  * 公開メソッドのシグネチャは追加のみで完全後方互換 (新パラメータはすべて optional)
+    
+* **改善**: SDK のクエリパラメータ表面を NGSI-LD §5.7.2 (Query Entities) に揃えて拡充 (issue #1132) (#1149)
+  
+  * 背景: `db.getEntities()` 等は `type / limit / offset / q` の 4 パラメータしか URL に乗せておらず、サーバが実装している `scopeQ` / `georel` / `geometry` / `coordinates` / `attrs` / `pick` / `omit` / `lang` / `orderBy` / `count` 等を SDK 経由で使えなかった。実アプリで scope に基づくフィルタが必要になり (geonicdb-gis 関連)、SDK を諦めて `db.request()` で素のパスを組み立てる回避が必要だった
+    
+  * 修正:
+    
+    * **`src/sdk/types.ts`**: `GetEntitiesParams` を拡張し `scopeQ`, `georel`, `geometry`, `coordinates`, `attrs`, `pick`, `omit`, `lang`、`orderBy`、`orderDirection`、`orderByDistance`、`count`、`geoproperty` を追加。`CountEntitiesParams` / `GetTemporalEntitiesParams` / `SubscribeOptions` / `SubscriptionMessage` にも `scopeQ` を追加
+      
+    * **`src/sdk/index.ts`**: `URLSearchParams` ベースの汎用ビルダ `buildPathWithParams()` を導入し、`buildEntitiesPath()` / `count()` / `getTemporalEntities()` を全て経由させる。今後パラメータ追加は型に書くだけで自動的に URL に乗る (一箇所追加すれば終わるよう DRY 化)
+      
+    * **`src/sdk/websocket.ts`**: `subscribe(options)` が `scopeQ` を受け、サブスクリプションメッセージに添える (サーバ側未対応バージョンでは無視される)
+      
+    * **`src/sdk/README.md`**: `getEntities()` の例にコメント形式で全パラメータを列挙
+      
+  * 後方互換: 既存呼び出し (`{ type, limit, offset, q }` のみ) は完全に動作。新パラメータは optional 追加
+    
+  * 追加: `tests/unit/sdk/index.test.ts` に regression テスト 3 件
+
+## \[0.7.1] — 2026-05-02
 
 ### 2026-05-02
-- **修正**: SDK 公開パッケージの d.ts root が strict tsconfig で named import を解決できない問題 (issue #1127)
-  - 背景: PR #1124 (#1118 の修正) で `geonicdb.d.ts` を `export * from './index'` の wildcard re-export に変更したが、`src/sdk/package.json` の `files: ["geonicdb.*"]` は **意図的な single-file 配信** (#877) のため `./index.d.ts` 等の per-file d.ts は npm パッケージに含まれない。strict tsconfig (`verbatimModuleSyntax`、`strict` 等) の consumer から見ると wildcard が空に解決され、`AuthorizationError` を含む全 named export が消えていた (locus サンプル開発で `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` がモジュール解決エラーになり発覚)
-  - 修正: `scripts/build-sdk.ts` の d.ts 生成を hardcoded export 列挙形式に戻した。ただし TypeScript AST (`typescript` の `createSourceFile`) で `src/sdk/index.ts` を走査して export 一覧を **build 時に自動収集** するため、新規 export 追加時に build-sdk.ts を後追い修正する必要なし (drift 自動防止)
-  - **検証強化** (回帰防止): 既存の `dist/sdk/` 直読みではなく、`npm pack` の tarball を抽出した上で
-    - 公開ファイルから `geonicdb.d.ts` / `geonicdb.{cjs,mjs,iife.js}` が含まれていることを検証
-    - **strict tsconfig 環境を再現** した consumer プロジェクトを `tmpdir` に組み立て、`tsc --project` で実コンパイルし、各エラークラス / public type の named import (`import { ... }` および `import type { ... }`) が **TS2614 にならないこと** を assertion
-    - 公開 d.ts に `export * from` 形式が混入しないことを正規表現で禁止
-    - `src/sdk/index.ts` ソースの export 名と公開 d.ts の export 名が一致することを drift guard で検証
-  - ドキュメント: `docs/SDK.md` / `src/sdk/README.md` に「TypeScript」節を追加し、strict tsconfig でも named import が解決できる旨を明記
 
-## [0.7.0] — 2026-05-02
+
+* **修正**: SDK 公開パッケージの d.ts root が strict tsconfig で named import を解決できない問題 (issue #1127)
+  
+  * 背景: PR #1124 (#1118 の修正) で `geonicdb.d.ts` を `export * from './index'` の wildcard re-export に変更したが、`src/sdk/package.json` の `files: ["geonicdb.*"]` は **意図的な single-file 配信** (#877) のため `./index.d.ts` 等の per-file d.ts は npm パッケージに含まれない。strict tsconfig (`verbatimModuleSyntax`、`strict` 等) の consumer から見ると wildcard が空に解決され、`AuthorizationError` を含む全 named export が消えていた (locus サンプル開発で `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` がモジュール解決エラーになり発覚)
+    
+  * 修正: `scripts/build-sdk.ts` の d.ts 生成を hardcoded export 列挙形式に戻した。ただし TypeScript AST (`typescript` の `createSourceFile`) で `src/sdk/index.ts` を走査して export 一覧を **build 時に自動収集** するため、新規 export 追加時に build-sdk.ts を後追い修正する必要なし (drift 自動防止)
+    
+  * **検証強化** (回帰防止): 既存の `dist/sdk/` 直読みではなく、`npm pack` の tarball を抽出した上で
+    
+    * 公開ファイルから `geonicdb.d.ts` / `geonicdb.{cjs,mjs,iife.js}` が含まれていることを検証
+      
+    * **strict tsconfig 環境を再現** した consumer プロジェクトを `tmpdir` に組み立て、`tsc --project` で実コンパイルし、各エラークラス / public type の named import (`import { ... }` および `import type { ... }`) が **TS2614 にならないこと** を assertion
+      
+    * 公開 d.ts に `export * from` 形式が混入しないことを正規表現で禁止
+      
+    * `src/sdk/index.ts` ソースの export 名と公開 d.ts の export 名が一致することを drift guard で検証
+      
+  * ドキュメント: `docs/SDK.md` / `src/sdk/README.md` に「TypeScript」節を追加し、strict tsconfig でも named import が解決できる旨を明記
+
+## \[0.7.0] — 2026-05-02
 
 ### 2026-05-02
-- **改善**: ReactiveCore Rules の SLO 超過に対する協調キャンセルを実装 (issue #1122) (#1123)
-  - 背景: PR #1121 で導入した `RuleProcessorFunction` の `Promise.race` ベースの soft timeout は、wait を打ち切るだけで `ruleEngine.processEntityChange()` の裏での実行は継続していた。Lambda hard timeout (30s) で最終的に止まるが、SLO (`MAX_RULE_EXECUTION_TIME_MS = 5s`) を超えた処理が走り続け、意図しない entity 作成 / webhook 発火を起こし得た (CodeRabbit 指摘)
-  - 対応: `RuleEngineService.processEntityChange(event, signal?)` に optional `AbortSignal` を追加。ルール評価ループ・アクション実行ループの境界で `signal.throwIfAborted()` をチェックし、新しいルール / アクションの開始を阻止する。`executeWebhookAction` は `AbortSignal.any([外部 signal, 内部 timeout signal])` で外部 signal と既存の内部 timeout を合成し、HTTP fetch も中断するようにした
-  - `handlers/rules/processor.ts` で `AbortController` を作成し、SLO 超過で `controller.abort()` を呼ぶ。span 上は abort されたかを区別して ERROR を記録 (`aborted` フラグを log に出す)
-  - 既存の `entity.service` / `temporal.service` の各メソッドへの signal threading は影響範囲が広いため別 issue に切り出し、本対応では「ループ境界で次の処理を始めない」までを保証する。in-flight の DB 操作は完走させる
-  - 関連: `src/core/rules/rule-engine.service.ts`、`src/handlers/rules/processor.ts`、`tests/unit/core/rules/rule-engine.service.test.ts` (signal 経由の協調キャンセル 4 ケース追加)、`tests/unit/handlers/rules/processor.test.ts` (signal 経由の abort/log/span 検証 2 ケース追加)
-- **修正**: SDK 公開 d.ts (`@geolonia/geonicdb-sdk` の `geonicdb.d.ts`) からエラークラスが silently 落ちていた問題 (issue #1118) (#1124)
-  - 原因: `scripts/build-sdk.ts` が `geonicdb.d.ts` を hardcoded な export 列挙で書き出しており、`src/sdk/index.ts` で `errors.ts` から再エクスポートしている `GeonicDBError` / `AuthenticationError` / `AuthorizationError` / `NotFoundError` / `ConflictError` / `ValidationError` / `RateLimitError` / `NetworkError` が含まれていなかった。runtime バンドル (cjs / mjs) では正しく export されていたが、TypeScript からは `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` でモジュール解決エラーになっていた
-  - 修正: `scripts/build-sdk.ts` の d.ts 生成を `export * from './index'; export { default } from './index';` に変更し、`src/sdk/index.ts` の named export を全て自動転送する。今後 index に export を追加してもこのスクリプトの修正は不要
-  - 回帰防止: `tests/unit/sdk/build-artifacts.test.ts` を新設。`geonicdb.d.ts` が wildcard 形式であること、`index.d.ts` でエラークラスが `errors.ts` から re-export 形で公開されていること、runtime CJS / ESM 両バンドルでエラークラスが constructor として呼び出せ Error サブクラスかつ `GeonicDBError` を共通基底とすることを検証 (ESM は子プロセス経由で評価)
-- **追加**: ReactiveCore Rules のアクションテンプレートで `${now()}` / `${uuid()}` 等の関数を呼べるようにした (issue #1120) (#1125)
-  - 背景: 既存の `${path}` 解決は `entity.id` / `attribute.<name>.value` / `trigger.*` のみを参照する path 限定で、サーバー時刻や一意 ID を生成する手段がなかった。`urn:ngsi-ld:ActivityLog:${entity.id}` のような決定的な entityId しか作れず、同一エンティティの複数回 update から派生 entity を生成すると id 衝突で 2 回目以降が失敗していた
-  - 修正: `rule-engine.service.ts` の `substituteTemplate` を拡張し、`${name(args)}` 形式を関数呼び出しとして解釈する。実装した関数は副作用なし・外部 I/O なしの whitelist のみ:
-    - `${now()}` / `${now('iso')}` → ISO 8601 タイムスタンプ
-    - `${now('unix')}` → UNIX 秒
-    - `${now('unix-ms')}` → UNIX ミリ秒
-    - `${uuid()}` → RFC 4122 v4 UUID
-  - 安全性: 引数パーサは単純なクォート付き文字列リテラルのみ受け付ける。未対応の関数名・フォーマットは literal として残し warn ログを出す (発火を止めない)
-  - ドキュメント: `docs/REACTIVCORE_RULES.md` の Template Variables セクションに「Template Functions」サブセクションを追加。append-only ActivityLog の実用例も掲載
-  - テスト: `rule-engine.service.test.ts` の `template substitution` describe に 10 シナリオを追加 (各関数の戻り値形式、複数関数の同時展開、path 参照との混在、未知関数 / 不正フォーマットの literal 保持、`createEntity` での `${uuid()}` 一意性)
+
+
+* **改善**: ReactiveCore Rules の SLO 超過に対する協調キャンセルを実装 (issue #1122) (#1123)
+  
+  * 背景: PR #1121 で導入した `RuleProcessorFunction` の `Promise.race` ベースの soft timeout は、wait を打ち切るだけで `ruleEngine.processEntityChange()` の裏での実行は継続していた。Lambda hard timeout (30s) で最終的に止まるが、SLO (`MAX_RULE_EXECUTION_TIME_MS = 5s`) を超えた処理が走り続け、unintended な entity 作成 / webhook 発火を起こし得た (CodeRabbit 指摘)
+    
+  * 対応: `RuleEngineService.processEntityChange(event, signal?)` に optional `AbortSignal` を追加。ルール評価ループ・アクション実行ループの境界で `signal.throwIfAborted()` をチェックし、新しいルール / アクションの開始を阻止する。`executeWebhookAction` は `AbortSignal.any([外部 signal, 内部 timeout signal])` で外部 signal と既存の内部 timeout を合成し、HTTP fetch も中断するようにした
+    
+  * `handlers/rules/processor.ts` で `AbortController` を作成し、SLO 超過で `controller.abort()` を呼ぶ。span 上は abort されたかを区別して ERROR を記録 (`aborted` フラグを log に出す)
+    
+  * 既存の `entity.service` / `temporal.service` の各メソッドへの signal threading は影響範囲が広いため別 issue に切り出し、本対応では「ループ境界で次の処理を始めない」までを保証する。in-flight の DB 操作は完走させる
+    
+  * 関連: `src/core/rules/rule-engine.service.ts`、`src/handlers/rules/processor.ts`、`tests/unit/core/rules/rule-engine.service.test.ts` (signal 経由の協調キャンセル 4 ケース追加)、`tests/unit/handlers/rules/processor.test.ts` (signal 経由の abort/log/span 検証 2 ケース追加)
+    
+* **修正**: SDK 公開 d.ts (`@geolonia/geonicdb-sdk` の `geonicdb.d.ts`) からエラークラスが silently 落ちていた問題 (issue #1118) (#1124)
+  
+  * 原因: `scripts/build-sdk.ts` が `geonicdb.d.ts` を hardcoded な export 列挙で書き出しており、`src/sdk/index.ts` で `errors.ts` から再エクスポートしている `GeonicDBError` / `AuthenticationError` / `AuthorizationError` / `NotFoundError` / `ConflictError` / `ValidationError` / `RateLimitError` / `NetworkError` が含まれていなかった。runtime バンドル (cjs / mjs) では正しく export されていたが、TypeScript からは `import { AuthorizationError } from '@geolonia/geonicdb-sdk'` でモジュール解決エラーになっていた
+    
+  * 修正: `scripts/build-sdk.ts` の d.ts 生成を `export * from './index'; export { default } from './index';` に変更し、`src/sdk/index.ts` の named export を全て自動転送する。今後 index に export を追加してもこのスクリプトの修正は不要
+    
+  * 回帰防止: `tests/unit/sdk/build-artifacts.test.ts` を新設。`geonicdb.d.ts` が wildcard 形式であること、`index.d.ts` でエラークラスが `errors.ts` から re-export 形で公開されていること、runtime CJS / ESM 両バンドルでエラークラスが constructor として呼び出せ Error サブクラスかつ `GeonicDBError` を共通基底とすることを検証 (ESM は子プロセス経由で評価)
+    
+* **追加**: ReactiveCore Rules のアクションテンプレートで `${now()}` / `${uuid()}` 等の関数を呼べるようにした (issue #1120) (#1125)
+  
+  * 背景: 既存の `${path}` 解決は `entity.id` / `attribute.<name>.value` / `trigger.*` のみを参照する path 限定で、サーバー時刻や一意 ID を生成する手段がなかった。`urn:ngsi-ld:ActivityLog:${entity.id}` のような決定的な entityId しか作れず、同一エンティティの複数回 update から派生 entity を生成すると id 衝突で 2 回目以降が失敗していた
+    
+  * 修正: `rule-engine.service.ts` の `substituteTemplate` を拡張し、`${name(args)}` 形式を関数呼び出しとして解釈する。実装した関数は副作用なし・外部 I/O なしの whitelist のみ:
+    
+    * `${now()}` / `${now('iso')}` → ISO 8601 タイムスタンプ
+      
+    * `${now('unix')}` → UNIX 秒
+      
+    * `${now('unix-ms')}` → UNIX ミリ秒
+      
+    * `${uuid()}` → RFC 4122 v4 UUID
+      
+  * 安全性: 引数パーサは単純なクォート付き文字列リテラルのみ受け付ける。未対応の関数名・フォーマットは literal として残し warn ログを出す (発火を止めない)
+    
+  * ドキュメント: `docs/REACTIVCORE_RULES.md` の Template Variables セクションに「Template Functions」サブセクションを追加。append-only ActivityLog の実用例も掲載
+    
+  * テスト: `rule-engine.service.test.ts` の `template substitution` describe に 10 シナリオを追加 (各関数の戻り値形式、複数関数の同時展開、path 参照との混在、未知関数 / 不正フォーマットの literal 保持、`createEntity` での `${uuid()}` 一意性)
 
 ### 2026-05-01
-- **修正**: 本番 (Lambda) で ReactiveCore Rules が一切発火しない問題 (issue #1119) (#1121)
-  - 原因: `entity.service` から EventBridge へ publish される `EntityCreated/Updated/Deleted` イベントを listen する Rule consumer Lambda が `infrastructure/template.yaml` に存在せず、Rules 発火経路が `ChangeStreamProcessorFunction` の `Schedule: rate(1 minute)` 起動 → MongoDB Change Stream tail だけに依存していた。本番 Lambda 環境ではこの経路が静かに失敗しており Rules が一切実行されなかった (locus サンプル開発時に発覚)
-  - 修正: 新規 Lambda `RuleProcessorFunction` (`src/handlers/rules/processor.ts`) を SubscriptionMatcher と同じ EventBridgeRule で `EntityCreated/Updated/Deleted` を listen させ、`RuleEngineService.processEntityChange` を駆動する。`ChangeStreamProcessorFunction` 側からは rule engine 呼び出しを撤去 (二重発火防止)
-  - **E2E でこのバグを検出できなかった反省を反映**: 既存の `tests/e2e/support/rule-execution-helper.ts` (`triggerRuleExecution`) が `ruleEngine.processEntityChange` を直接呼んでおり EventBridge 経路を完全にスキップしていたため、template.yaml の配線喪失を E2E で気付けなかった。以下の検出策を追加:
-    - `tests/e2e/support/hooks.ts` に `@rules-auto-fire` タグ専用ブリッジを追加。`getLocalEventBus().on('entityChange', ...)` で本番 handler `handlers/rules/processor.handler` を直接呼び、entity 作成 API → EventBridge 相当 → RuleProcessor Lambda → ruleEngine の経路を丸ごと貫通させる
-    - `tests/e2e/features/auth/rules-auto-fire.feature` で「entity 作成 API のみで Rule action が自動実行される」シナリオを 2 つ追加 (`triggerRuleExecution` を介さない再現テスト)
-    - `tests/unit/infrastructure/sam-template.test.ts` で `infrastructure/template.yaml` の最小構造を検証 (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction が EventBridgeRule で 3 種の detail-type を listen していることを機械的に確認)
-    - `tests/unit/handlers/rules/processor.test.ts` で新規 handler 単体の挙動 (3 種イベント委譲・secondary region スキップ・エラー握り潰し・タイムアウト) を検証
-  - 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
 
-## [0.6.0] — 2026-05-01
+
+* **修正**: 本番 (Lambda) で ReactiveCore Rules が一切発火しない問題 (issue #1119) (#1121)
+  
+  * 原因: `entity.service` から EventBridge へ publish される `EntityCreated/Updated/Deleted` イベントを listen する Rule consumer Lambda が `infrastructure/template.yaml` に存在せず、Rules 発火経路が `ChangeStreamProcessorFunction` の `Schedule: rate(1 minute)` 起動 → MongoDB Change Stream tail だけに依存していた。本番 Lambda 環境ではこの経路が静かに失敗しており Rules が一切実行されなかった (locus サンプル開発時に発覚)
+    
+  * 修正: 新規 Lambda `RuleProcessorFunction` (`src/handlers/rules/processor.ts`) を SubscriptionMatcher と同じ EventBridgeRule で `EntityCreated/Updated/Deleted` を listen させ、`RuleEngineService.processEntityChange` を駆動する。`ChangeStreamProcessorFunction` 側からは rule engine 呼び出しを撤去 (二重発火防止)
+    
+  * **E2E でこのバグを検出できなかった反省を反映**: 既存の `tests/e2e/support/rule-execution-helper.ts` (`triggerRuleExecution`) が `ruleEngine.processEntityChange` を直接呼んでおり EventBridge 経路を完全にスキップしていたため、template.yaml の配線喪失を E2E で気付けなかった。以下の検出策を追加:
+    
+    * `tests/e2e/support/hooks.ts` に `@rules-auto-fire` タグ専用ブリッジを追加。`getLocalEventBus().on('entityChange', ...)` で本番 handler `handlers/rules/processor.handler` を直接呼び、entity 作成 API → EventBridge 相当 → RuleProcessor Lambda → ruleEngine の経路を丸ごと貫通させる
+      
+    * `tests/e2e/features/auth/rules-auto-fire.feature` で「entity 作成 API のみで Rule action が自動実行される」シナリオを 2 つ追加 (`triggerRuleExecution` を介さない再現テスト)
+      
+    * `tests/unit/infrastructure/sam-template.test.ts` で `infrastructure/template.yaml` の最小構造を検証 (RuleProcessorFunction / SubscriptionMatcherFunction / WsBroadcastFunction が EventBridgeRule で 3 種の detail-type を listen していることを機械的に確認)
+      
+    * `tests/unit/handlers/rules/processor.test.ts` で新規 handler 単体の挙動 (3 種イベント委譲・secondary region スキップ・エラー握り潰し・タイムアウト) を検証
+      
+  * 関連: `src/handlers/rules/processor.ts` (新規)、`src/handlers/streams/change-stream.ts` (rule engine 呼び出しを除去)、`infrastructure/template.yaml` (`RuleProcessorFunction` 追加)、`tests/e2e/support/hooks.ts` / `tests/e2e/features/auth/rules-auto-fire.feature` / `tests/unit/infrastructure/sam-template.test.ts` / `tests/unit/handlers/rules/processor.test.ts`
+
+## \[0.6.0] — 2026-05-01
 
 ### 2026-05-01
-- **認可**: WebSocket 配信時の XACML AuthzRequest に `entityOwner` / `entityId` を inject (issue #1107) (#1116)
-  - `src/handlers/websocket/broadcaster.ts` の `filterByAuthz` と `src/core/streaming/local-ws-server.ts` の `broadcastEventAsync` を改修。各コネクションに対する `authorizeWs()` 呼び出しに、配信対象 entity の `entityOwner` (createdBy) / `entityId` / `entityType` を渡す。これまで `entityType` のみだったため、「**自分が所有する entity の更新だけ受信する**」per-user 通知フィルタが XACML カスタムポリシーで書けなかった
-  - これに伴い `EntityChangeEvent.entity` に optional な `owner?: string` を追加。`entity.service.ts` の publish 経路 (CREATE/UPDATE/DELETE 各種) で entity の `createdBy` を transparent に伝播する。`InternalEntity.createdBy` も追加 (内部用; NGSI トランスフォーマでは出力されない)
-  - `WsEntityContext` インターフェースを `policy.pip.ts` に追加。`buildWsAuthzRequest` / `authorizeWs` の 5 番目の引数を `entityType?: string` から `entityContext?: WsEntityContext` (`{ entityType?, entityId?, entityOwner? }`) に変更。`WS ⊂ GET` 評価時に entityOwner も両方の AuthzRequest に inject される
-  - 認可キャッシュキーを `role:policyId` → `role:policyId:userId` に拡張。`subject.userId == entityOwner` 形式のポリシーは role/policyId が同じでも userId 単位で decision が分岐するため。同一ユーザーがマルチデバイス接続している場合のみキャッシュ再利用される
-  - 新しいユースケース: 「自分宛のイベントだけ受信」(チャット、通知)、「自分が所有する entity の subscribe」(マイページフィード)、locus サンプルの「自分が編集した GeoJSON の activity だけ流れる」フィード等が XACML カスタムポリシーで実現可能
-  - 関連: `src/infrastructure/eventbridge/client.ts` (`EntityChangeEvent.entity.owner`)、`src/core/entities/entity.types.ts` (`InternalEntity.createdBy`)、`src/core/entities/entity.repository.ts` (`toInternalEntity` 経由で createdBy 伝搬)、`src/core/entities/entity.service.ts` (CREATE/UPDATE/DELETE 各 publish で `entity.owner` を inject)、`src/core/auth/policy/policy.pip.ts` (`WsEntityContext`、`buildWsAuthzRequest`、`authorizeWs`)、`src/handlers/websocket/broadcaster.ts` / `src/core/streaming/local-ws-server.ts` (キャッシュキー + entityOwner 引き渡し)、`docs/AUTH.md` / `docs/EVENT_STREAMING.md` 追記、`tests/unit/core/auth/policy/policy.pip.test.ts` / `tests/unit/handlers/websocket/broadcaster.test.ts` / `tests/unit/core/entities/entity.service.test.ts` (happy / unhappy 計 12 ケース追加)、`tests/e2e/features/common/websocket.feature` (owner-based WS フィルタの 1 シナリオ追加)
-- **ReactiveCore Rules**: `eventType` 条件を追加 (issue #1103) (#1115)
-  - Rule の `conditions` に `{type: "eventType", eventTypes: ["create" | "update" | "delete"]}` を指定できるようにした。EntityCreated / EntityUpdated / EntityDeleted の発火元を Rule 側でフィルタできる。サンプルアプリ `geonicdb-locus` (GeoJSON コラボ編集) の「作成時のみ ActivityLog を生成」「削除時のみクリーンアップ」というよくあるパターンが直接書けるようになる
-  - これまで `change` 条件 (`changedAttributes` 参照) では CREATE と DELETE を区別できず (両者とも `changedAttributes` が undefined)、自然な書き方ができなかった
-  - 既存の `entityType` / `value` / `change` / `and` / `or` / `not` などと自由に組み合わせ可能。`{type: "not", condition: {type: "eventType", eventTypes: ["delete"]}}` で「削除以外」も書ける
-  - 関連: `src/core/rules/rule.types.ts` (`EventTypeCondition` / `RuleEventType` 追加)、`src/core/rules/rule-engine.service.ts` (`evaluateEventTypeCondition` 追加 — `EntityCreated`→`create` 等のマッピング)、`src/api/shared/schemas/rule.schemas.ts` (`EventTypeConditionSchema` を discriminatedUnion に追加)、`docs/REACTIVCORE_RULES.md` 追記、`tests/unit/core/rules/rule-engine.service.test.ts` / `tests/unit/api/shared/schemas/rule.schemas.test.ts` (happy / unhappy シナリオ追加)、`tests/e2e/features/auth/rules.feature` (発火・非発火・複数指定・バリデーションのシナリオ追加)
-- **ReactiveCore Rules**: CEL 評価コンテキストに `previous.attribute.<name>` を露出 (issue #1106) (#1114)
-  - `src/core/rules/rule-engine.service.ts` の `evaluateCelExpressionCondition` で、`RuleEvaluationContext.previousEntity` の属性を `previous.attribute.<name>.value` / `previous.attribute.<name>.type` として CEL 環境にバインド。これまで `previousEntity` は内部的に保持されていたが CEL からは参照できなかった
-  - 振る舞い: `EntityCreated` 時 `previous.attribute` は空オブジェクト (`{}`)、`EntityUpdated` 時は更新前の属性スナップショット、`EntityDeleted` 時は最終状態。空オブジェクトに対する直接プロパティ参照 (`previous.attribute.x.value`) は CEL が `No such key` を throw するため、`has()` ガードを推奨 (例: `has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30`)
-  - これにより「閾値クロス検出」「`draft` → `published` 等の状態遷移検出」「設定変更の監査ログ」「idempotent 更新の誤発火回避」など、現在値だけでは表現できないルールが直接記述可能になる。`change` 条件タイプの「何から何に変化したか不明」「同値再 update で誤発火」という限界を補完する
-  - `docs/REACTIVCORE_RULES.md` の CEL Context Variables 表に `previous.attribute.<name>.value` / `.type` の行と `has()` ガードの注意書き、及び 4 種の使用例 (閾値クロス・状態遷移・新規属性追加検出・型変化検出) を追加
-  - テスト: `tests/unit/core/rules/rule-engine.service.test.ts` に 12 ケース追加 (Boolean 状態遷移 / 閾値クロス成功 + 既に超過時の発火抑制 / 値変化 / `draft→published` ワークフロー / EntityCreated 時 `has(previous.*)` が false / has ガードによる安全なスキップ / 直接アクセスでの catch / EntityDeleted 時の previous 露出 / 新規追加属性検出 / type フィールドアクセス)。E2E は `tests/e2e/features/auth/rules.feature` に閾値クロス・状態遷移の 2 シナリオを追加
-- **SDK**: anonymous モードを追加 (issue #1105) (#1113)
-  - `new GeonicDB({ anonymous: true, tenant, baseUrl })` で token 取得・`Authorization` ヘッダ送信を完全にスキップしてリクエストできるようにした。サーバー側 (`optionalAuth`) で `role: 'anonymous'` として通り、`anonymous` ロールに対する XACML カスタムポリシーが認可判定する。GeoJSON 公開ビューア / BI ダッシュボード / 公的データ可視化のような「未登録閲覧者にも公開リソースを返したい」公開アプリで、ログインフォームを挟まずに SDK が使えるようになる
-  - `apiKey` と同時指定はコンストラクタで throw (token 取得経路と相互排他)。`login()` / `setCredentials()` で認証付きへ昇格でき、`logout()` で再び anonymous へ戻る (`db.isAnonymous()` で現在状態を確認可能)
-  - anonymous リクエストの 401 / 403 はトークン再取得ループに入らず透過。XACML Deny がそのまま呼び出し側に届く
-  - WebSocket は `connect()` 時点で明示的に throw (サーバー `local-ws-server.ts` が token 必須)。WS の anonymous 対応は別 issue へ送る
-  - 関連: `src/sdk/auth.ts` (`AuthManager._anonymous` / `isAnonymous()` / `request()` 分岐)、`src/sdk/index.ts` (オプション透過 / `db.isAnonymous()`)、`src/sdk/types.ts` (`GeonicDBOptions.anonymous`)、`src/sdk/websocket.ts` (anonymous 時の `connect()` ガード)、`tests/unit/sdk/auth.test.ts` / `tests/unit/sdk/index.test.ts` (happy 4 / unhappy 5 シナリオ追加)、`docs/SDK.md`、`src/sdk/README.md`- **認可**: NGSI-LD Subscription 作成時に購読対象属性を XACML AuthzRequest へ inject (issue #1104) (#1112)
-  - `POST /ngsi-ld/v1/subscriptions` の認可判定で、これまで `body.type === "Subscription"` がそのまま `resource.entityType` に乗っていた問題を修正。代わりに `entities[]` 各要素から購読対象の `entityType` / `entityId` / `entityIdPattern` を抽出し、`notification.endpoint.uri` を `resource.notificationEndpoint` として inject する (#1112)
-  - `entities[]` が複数要素を持つ場合は **all-Permit セマンティクス**で評価。1 件でも非許可 (Deny / NotApplicable / Indeterminate) があれば全体を Deny する。最初の要素だけ許可しておけば後続を抜けられる、という抜け穴を防ぐ (#1112)
-  - 新しい resource 属性で「`anonymous` は `entityType=ActivityLog` の購読のみ許可」「`notificationEndpoint` が `https://*.example.com/**` の subscription のみ許可 (SSRF / データ持ち出し対策)」のような型ベース・URI ベース制御が XACML カスタムポリシーで書けるようになる (#1112)
-  - 関連: `src/core/auth/policy/policy.types.ts` (AuthzRequest.resource 拡張)、`src/core/auth/policy/policy.pip.ts` (`extractSubscriptionAuthzAttributes` / `buildSubscriptionAuthzRequests` 追加)、`src/core/auth/policy/policy.pdp.ts` (`entityIdPattern` / `notificationEndpoint` 属性対応)、`src/api/shared/middleware/authz.middleware.ts` (subscription 用 all-Permit 評価パス)、`docs/AUTH.md` 追記 (#1112)
-  - locus サンプルアプリ (#1103) で「ActivityLog 以外の subscription を弾く」厳密ポリシーが書けるようになる (#1112)
-- **セキュリティ**: PoW 難易度を 4 → 16 ビットに引き上げ (issue #1093) (#1110)
-  - `src/config/defaults.ts` の `PROOF_OF_WORK.DIFFICULTY` を `4` → `16` に変更。平均 SHA256 計算回数 16 → 65,536 で GPU バースト bot の単発成功コストを引き上げ
-  - 1 次防御は IP / OAuth client_id ベースのレート制限 (#1075)。PoW は副次防御だが、4 ビットでは最新 GPU で数 μs で解けるため抑止力として弱く、16 ビットへ引き上げ
-  - SDK (`src/sdk/pow.ts`) は `difficulty` パラメータ可変対応済 (`MAX_ITERATIONS=1M`、Web Crypto バッチ処理) のためクライアント互換性影響なし。サーバ側 `MAX_PROOF_VALUE: 1_000_000` 内で 99.99999% の確率で proof が見つかる
-  - テスト: `tests/unit/core/auth/pow/pow.service.test.ts` の `default difficulty` 期待値と探索条件 (先頭 16 ビット 0) を更新
-- **セキュリティ**: `MONGODB_ENFORCE_SECRETS=true` で `MONGODB_URI` 環境変数経路を fail-closed に禁止 (issue #1086) (#1111)
-  - `src/infrastructure/mongodb/client.ts` の `getMongoUriAsync()` を改修。`HA.SECRETS_MANAGER.MONGODB_ENFORCE_SECRETS` (env 由来、`@config/defaults`) が真のとき:
-    - `MONGODB_URI_ARN` 未設定なら起動時に throw (ARN 必須)
+
+
+* **認可**: WebSocket 配信時の XACML AuthzRequest に `entityOwner` / `entityId` を inject (issue #1107) (#1116)
+  
+  * `src/handlers/websocket/broadcaster.ts` の `filterByAuthz` と `src/core/streaming/local-ws-server.ts` の `broadcastEventAsync` を改修。各コネクションに対する `authorizeWs()` 呼び出しに、配信対象 entity の `entityOwner` (createdBy) / `entityId` / `entityType` を渡す。これまで `entityType` のみだったため、「**自分が所有する entity の更新だけ受信する**」per-user 通知フィルタが XACML カスタムポリシーで書けなかった
+    
+  * これに伴い `EntityChangeEvent.entity` に optional な `owner?: string` を追加。`entity.service.ts` の publish 経路 (CREATE/UPDATE/DELETE 各種) で entity の `createdBy` を transparent に伝播する。`InternalEntity.createdBy` も追加 (内部用; NGSI トランスフォーマでは出力されない)
+    
+  * `WsEntityContext` インターフェースを `policy.pip.ts` に追加。`buildWsAuthzRequest` / `authorizeWs` の 5 番目の引数を `entityType?: string` から `entityContext?: WsEntityContext` (`{ entityType?, entityId?, entityOwner? }`) に変更。`WS ⊂ GET` 評価時に entityOwner も両方の AuthzRequest に inject される
+    
+  * 認可キャッシュキーを `role:policyId` → `role:policyId:userId` に拡張。`subject.userId == entityOwner` 形式のポリシーは role/policyId が同じでも userId 単位で decision が分岐するため。同一ユーザーがマルチデバイス接続している場合のみキャッシュ再利用される
+    
+  * 新しいユースケース: 「自分宛のイベントだけ受信」(チャット, 通知)、「自分が所有する entity の subscribe」(マイページフィード)、locus サンプルの「自分が編集した GeoJSON の activity だけ流れる」フィード等が XACML カスタムポリシーで実現可能
+    
+  * 関連: `src/infrastructure/eventbridge/client.ts` (`EntityChangeEvent.entity.owner`)、`src/core/entities/entity.types.ts` (`InternalEntity.createdBy`)、`src/core/entities/entity.repository.ts` (`toInternalEntity` 経由で createdBy 伝搬)、`src/core/entities/entity.service.ts` (CREATE/UPDATE/DELETE 各 publish で `entity.owner` を inject)、`src/core/auth/policy/policy.pip.ts` (`WsEntityContext`, `buildWsAuthzRequest`, `authorizeWs`)、`src/handlers/websocket/broadcaster.ts` / `src/core/streaming/local-ws-server.ts` (キャッシュキー + entityOwner 引き渡し)、`docs/AUTH.md` / `docs/EVENT_STREAMING.md` 追記、`tests/unit/core/auth/policy/policy.pip.test.ts` / `tests/unit/handlers/websocket/broadcaster.test.ts` / `tests/unit/core/entities/entity.service.test.ts` (happy / unhappy 計 12 ケース追加)、`tests/e2e/features/common/websocket.feature` (owner-based WS フィルタの 1 シナリオ追加)
+    
+* **ReactiveCore Rules**: `eventType` 条件を追加 (issue #1103) (#1115)
+  
+  * Rule の `conditions` に `{type: "eventType", eventTypes: ["create" | "update" | "delete"]}` を指定できるようにした。EntityCreated / EntityUpdated / EntityDeleted の発火元を Rule 側でフィルタできる。サンプルアプリ `geonicdb-locus` (GeoJSON コラボ編集) の「作成時のみ ActivityLog を生成」「削除時のみクリーンアップ」というよくあるパターンが直接書けるようになる
+    
+  * これまで `change` 条件 (`changedAttributes` 参照) では CREATE と DELETE を区別できず (両者とも `changedAttributes` が undefined)、自然な書き方ができなかった
+    
+  * 既存の `entityType` / `value` / `change` / `and` / `or` / `not` などと自由に組み合わせ可能。`{type: "not", condition: {type: "eventType", eventTypes: ["delete"]}}` で「削除以外」も書ける
+    
+  * 関連: `src/core/rules/rule.types.ts` (`EventTypeCondition` / `RuleEventType` 追加)、`src/core/rules/rule-engine.service.ts` (`evaluateEventTypeCondition` 追加 — `EntityCreated`→`create` 等のマッピング)、`src/api/shared/schemas/rule.schemas.ts` (`EventTypeConditionSchema` を discriminatedUnion に追加)、`docs/REACTIVCORE_RULES.md` 追記、`tests/unit/core/rules/rule-engine.service.test.ts` / `tests/unit/api/shared/schemas/rule.schemas.test.ts` (happy / unhappy シナリオ追加)、`tests/e2e/features/auth/rules.feature` (発火・非発火・複数指定・バリデーションのシナリオ追加)
+    
+* **ReactiveCore Rules**: CEL 評価コンテキストに `previous.attribute.<name>` を露出 (issue #1106) (#1114)
+  
+  * `src/core/rules/rule-engine.service.ts` の `evaluateCelExpressionCondition` で、`RuleEvaluationContext.previousEntity` の属性を `previous.attribute.<name>.value` / `previous.attribute.<name>.type` として CEL 環境にバインド。これまで `previousEntity` は内部的に保持されていたが CEL からは参照できなかった
+    
+  * 振る舞い: `EntityCreated` 時 `previous.attribute` は空オブジェクト (`{}`)、`EntityUpdated` 時は更新前の属性スナップショット、`EntityDeleted` 時は最終状態。空オブジェクトに対する直接プロパティ参照 (`previous.attribute.x.value`) は CEL が `No such key` を throw するため、`has()` ガードを推奨 (例: `has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30`)
+    
+  * これにより「閾値クロス検出」「`draft` → `published` 等の状態遷移検出」「設定変更の監査ログ」「idempotent 更新の誤発火回避」など、現在値だけでは表現できないルールが直接記述可能になる。`change` 条件タイプの「何から何に変化したか不明」「同値再 update で誤発火」という限界を補完する
+    
+  * `docs/REACTIVCORE_RULES.md` の CEL Context Variables 表に `previous.attribute.<name>.value` / `.type` の行と `has()` ガードの注意書き、及び 4 種の使用例 (閾値クロス・状態遷移・新規属性追加検出・型変化検出) を追加
+    
+  * テスト: `tests/unit/core/rules/rule-engine.service.test.ts` に 12 ケース追加 (Boolean 状態遷移 / 閾値クロス成功 + 既に超過時の発火抑制 / 値変化 / `draft→published` ワークフロー / EntityCreated 時 `has(previous.*)` が false / has ガードによる安全なスキップ / 直接アクセスでの catch / EntityDeleted 時の previous 露出 / 新規追加属性検出 / type フィールドアクセス)。E2E は `tests/e2e/features/auth/rules.feature` に閾値クロス・状態遷移の 2 シナリオを追加
+    
+* **SDK**: anonymous モードを追加 (issue #1105) (#1113)
+  
+  * `new GeonicDB({ anonymous: true, tenant, baseUrl })` で token 取得・`Authorization` ヘッダ送信を完全にスキップしてリクエストできるようにした。サーバー側 (`optionalAuth`) で `role: 'anonymous'` として通り、`anonymous` ロールに対する XACML カスタムポリシーが認可判定する。GeoJSON 公開ビューア / BI ダッシュボード / 公的データ可視化のような「未登録閲覧者にも公開リソースを返したい」公開アプリで、ログインフォームを挟まずに SDK が使えるようになる
+    
+  * `apiKey` と同時指定はコンストラクタで throw (token 取得経路と相互排他)。`login()` / `setCredentials()` で認証付きへ昇格でき、`logout()` で再び anonymous へ戻る (`db.isAnonymous()` で現在状態を確認可能)
+    
+  * anonymous リクエストの 401 / 403 はトークン再取得ループに入らず透過。XACML Deny がそのまま呼び出し側に届く
+    
+  * WebSocket は `connect()` 時点で明示的に throw (サーバー `local-ws-server.ts` が token 必須)。WS の anonymous 対応は別 issue へ送る
+    
+  * 関連: `src/sdk/auth.ts` (`AuthManager._anonymous` / `isAnonymous()` / `request()` 分岐), `src/sdk/index.ts` (オプション透過 / `db.isAnonymous()`), `src/sdk/types.ts` (`GeonicDBOptions.anonymous`), `src/sdk/websocket.ts` (anonymous 時の `connect()` ガード), `tests/unit/sdk/auth.test.ts` / `tests/unit/sdk/index.test.ts` (happy 4 / unhappy 5 シナリオ追加)、`docs/SDK.md`、`src/sdk/README.md`
+    
+* **認可**: NGSI-LD Subscription 作成時に購読対象属性を XACML AuthzRequest へ inject (issue #1104) (#1112)
+  
+  * `POST /ngsi-ld/v1/subscriptions` の認可判定で、これまで `body.type === "Subscription"` がそのまま `resource.entityType` に乗っていた問題を修正。代わりに `entities[]` 各要素から購読対象の `entityType` / `entityId` / `entityIdPattern` を抽出し、`notification.endpoint.uri` を `resource.notificationEndpoint` として inject する (#1112)
+    
+  * `entities[]` が複数要素を持つ場合は **all-Permit セマンティクス**で評価。1 件でも非許可 (Deny / NotApplicable / Indeterminate) があれば全体を Deny する。最初の要素だけ許可しておけば後続を抜けられる、という抜け穴を防ぐ (#1112)
+    
+  * 新しい resource 属性で「`anonymous` は `entityType=ActivityLog` の購読のみ許可」「`notificationEndpoint` が `https://*.example.com/**` の subscription のみ許可 (SSRF / データ持ち出し対策)」のような型ベース・URI ベース制御が XACML カスタムポリシーで書けるようになる (#1112)
+    
+  * 関連: `src/core/auth/policy/policy.types.ts` (AuthzRequest.resource 拡張)、`src/core/auth/policy/policy.pip.ts` (`extractSubscriptionAuthzAttributes` / `buildSubscriptionAuthzRequests` 追加)、`src/core/auth/policy/policy.pdp.ts` (`entityIdPattern` / `notificationEndpoint` 属性対応)、`src/api/shared/middleware/authz.middleware.ts` (subscription 用 all-Permit 評価パス)、`docs/AUTH.md` 追記 (#1112)
+    
+  * locus サンプルアプリ (#1103) で「ActivityLog 以外の subscription を弾く」厳密ポリシーが書けるようになる (#1112)
+    
+* **セキュリティ**: PoW 難易度を 4 → 16 ビットに引き上げ (issue #1093) (#1110)
+  
+  * `src/config/defaults.ts` の `PROOF_OF_WORK.DIFFICULTY` を `4` → `16` に変更。平均 SHA256 計算回数 16 → 65,536 で GPU バースト bot の単発成功コストを引き上げ
+    
+  * 1 次防御は IP / OAuth client\_id ベースのレート制限 (#1075)。PoW は副次防御だが、4 ビットでは最新 GPU で数 μs で解けるため抑止力として弱く、16 ビットへ引き上げ
+    
+  * SDK (`src/sdk/pow.ts`) は `difficulty` パラメータ可変対応済 (`MAX_ITERATIONS=1M`、Web Crypto バッチ処理) のためクライアント互換性影響なし。サーバ側 `MAX_PROOF_VALUE: 1_000_000` 内で 99.99999% の確率で proof が見つかる
+    
+  * テスト: `tests/unit/core/auth/pow/pow.service.test.ts` の `default difficulty` 期待値と探索条件 (先頭 16 ビット 0) を更新
+    
+* **セキュリティ**: `MONGODB_ENFORCE_SECRETS=true` で `MONGODB_URI` 環境変数経路を fail-closed に禁止 (issue #1086) (#1111)
+  
+  * `src/infrastructure/mongodb/client.ts` の `getMongoUriAsync()` を改修。`HA.SECRETS_MANAGER.MONGODB_ENFORCE_SECRETS` (env 由来、`@config/defaults`) が真のとき:
+    
+    * `MONGODB_URI_ARN` 未設定なら起動時に throw (ARN 必須)
+      
+    * ARN 設定済だが Secrets Manager 取得失敗時も throw (env フォールバックなし)
+      
+  * SAM template (`infrastructure/template.yaml`) の `ApiHandlerFunction` Environment で `MONGODB_ENFORCE_SECRETS: 'true'` を設定し、Lambda 本番デプロイをデフォルト hardened 化。Docker Smoke E2E / ローカル `npm start` / dev/test では未設定のまま env URI で起動可能。Docker / EC2 で本番運用する場合は運用者が明示的に `MONGODB_ENFORCE_SECRETS=true` を設定する
+    
+  * 当初 `NODE_ENV=production` で判定 → Docker Smoke E2E が壊れる → `AWS_LAMBDA_FUNCTION_NAME` 判定に変更 → CodeRabbit 指摘で「ランタイム種別ではなく中央設定 flag に」と最終的に再変更
+    
+  * メモリダンプ / CloudWatch ログ汚染で平文認証情報が露出する経路を塞ぐ fail-closed 設計。`docs/SECURITY.md` に挙動マトリクスを追記
+    
+  * テスト: `tests/unit/infrastructure/mongodb.test.ts` に `getMongoUriAsync` の 5 ケース (enforce + ARN 未設定・enforce + fetch 失敗・enforce + secret 取得・unset env フォールバック × 2) を追加
 
 ### 2026-04-30
-- **セキュリティ**: Lambda IAM の `kms:CreateKey` に Condition を追加し用途・タグを強制 (issue #1071) (#1108)
-  - `infrastructure/template.yaml` の `ApiHandlerFunction.Policies` 内 `kms:CreateKey` Statement に `Condition` を追加: `kms:KeyUsage = ENCRYPT_DECRYPT` / `kms:KeySpec = SYMMETRIC_DEFAULT` / `aws:RequestTag/geonicdb:purpose = envelope-encryption` を強制し、未知タグキーは `ForAllValues:StringEquals` の `aws:TagKeys` で `geonicdb:tenantId` / `geonicdb:purpose` のみに制限。`Null: aws:RequestTag/geonicdb:tenantId = false` で tenant 所有情報のないキー作成を禁止
-  - `Resource` は AWS 仕様上 `kms:CreateKey` (new-resource action) では `'*'` 必須のため変更しない。代わりに `kms:TagResource` を別 Statement として `arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*` で許可し、`CreateKeyCommand` の `Tags` パラメータ適用に必要な権限を Region/Account 制限付きで付与
-  - 実コード (`src/infrastructure/kms/key-manager.ts createTenantKey()`) は既に上記タグ・KeyUsage・KeySpec で発行しているため非破壊。compromised Lambda が署名鍵・非対称鍵・無タグキー・tenantId 不明のキーを量産する経路を抑止
-- **セキュリティ**: API Gateway `GatewayResponses` の `Access-Control-Allow-Origin` を Parameter 化 (issue #1088) (#1108)
-  - 新 Parameter `GatewayResponseAllowOrigin` を追加 (デフォルト `*` で互換維持)。`infrastructure/template.yaml` の `DEFAULT_4XX` / `DEFAULT_5XX` で `!Sub "'${GatewayResponseAllowOrigin}'"` を参照
-  - 本番デプロイ時は `--parameter-overrides GatewayResponseAllowOrigin='https://app.example.com'` で許可 origin に限定可能。Lambda 経由の通常応答は `src/api/shared/middleware/cors.middleware.ts` の origin echo back + `tenant.allowedOrigins` で制御 (#1069 で導入済)
-  - これにより Lambda が呼ばれない API Gateway 直返しエラー応答経由でのエラーボディ漏洩経路 (任意 origin からの fetch) を本番で塞げるようにする
-- **セキュリティ**: XACML ポリシー登録時に WS ⊂ GET 不変条件違反を WARN ログで検出 (issue #1085) (#1109)
-  - `PolicyService.validateWsGetSymmetry()` を追加。`createPolicy` / `updatePolicy` / `updatePolicySystem` / `updatePolicyForUser` の各経路で、`rule.target.actions` に `attributeId === 'method'` かつ `matchValue === 'WS'` (`string-equal`) のエントリがあり、同じ rule に `'GET'` が含まれていない場合に WARN ログを出力
-  - `authorizeWs()` (`src/core/auth/policy/policy.pip.ts`) は WS と GET を両方評価し両方 Permit でないと許可しない設計のため、WS-only ルールは管理者意図と実挙動が乖離しやすい (例: 「WS だけ Deny」を意図しても GET 経由でデータが取得可能)。reject ではなく WARN に留めることで既存ポリシーとの後方互換を維持
-  - `docs/AUTH.md` に「WebSocket Authorization (WS ⊂ GET)」セクションを追加し、不変条件・推奨記法・WARN ログの読み方を明示
-  - テスト: `tests/unit/core/auth/policy/policy.service.test.ts` に 7 ケース (WS-only / WS+GET / GET-only / glob matchFunction / 非 method attributeId / actions なし / updatePolicy・updatePolicySystem 経由) を追加
 
-- **セキュリティ**: 公開エンドポイントレート制限の部分失敗時のロールバック実装 (issue #1075 follow-up) (#1102)
-  - 旧挙動: `consumeBucket()` で 3 つの時間窓 (minute/hour/day) を `Promise.all` で並列更新していたため、一部の窓で例外 (DDB / Mongo の一時障害等) が発生した場合、成功した窓だけトークンが消費されたまま残り、後続リクエストがその窓を不当に削られる「過大カウント」が発生していた。また制限超過拒否時にも、拒否された窓以外で消費が成立しているケースがあり同様の不整合が起きていた
-  - 対応:
-    - `Promise.allSettled` で 3 窓を並列更新し、(a) 一部 throw 時は **値が非負で fulfilled** な窓だけを負 weight で `updateBucket` し直してトークンを返却 (ロールバック) した上で元の例外を再 throw、(b) 制限超過拒否時にも拒否された窓以外で消費が成立した窓を同様にロールバック
-    - **negative-value guard**: `updateBucket` は条件失敗時に負値を fulfilled として返すが、その場合 DDB の SET / Mongo の $inc は実行されず消費は成立していない。これを誤ってロールバックすると過大トークンが加算されるため、ロールバック対象は `r.value >= 0` の fulfilled 結果のみに限定 (CodeRabbit 指摘 #1102 の追加修正)
-    - DDB の `ConditionExpression: remainingTokens - :consumed >= 0` は負 `:consumed` を常に満たすため `SET remainingTokens = remainingTokens - (-weight)` で加算復元される。Mongo の `$inc: { remainingTokens: -tokensToConsume }` も負 `tokensToConsume` で `+weight` の `$inc` として正しく動作することを確認済み
-    - ロールバック自体が失敗した場合は黙って許容 (過大カウント方向の安全な失敗モード)。Promise.all reject 時は呼び出し側 (`enforcePublicRateLimit`) で fail-open 扱いとなり公開エンドポイントを落とさない
-  - テスト: 既存 11 ケースに加え、ロールバック挙動を検証する 6 ケースを追加 (一部 throw 時の正しいロールバック対象選択、negative-value 混在時のロールバック対象除外回帰テスト、全窓 throw 時のロールバック発火なし、ロールバック失敗時の握り潰し、制限超過拒否時の整合性確保、全成功時のロールバック非発火)
-  - PR #1101 への CodeRabbit レビュー指摘 (`src/core/quotas/rate-limit/public-rate-limit.service.ts` lines 97-101) への follow-up
 
-- **セキュリティ**: 公開 (未認証) エンドポイントに IP ベースのレート制限を導入 (issue #1075) (#1101)
-  - 旧挙動: `/.well-known/ai-plugin.json` `/.well-known/agent-card.json` `/.well-known/ngsi-ld` `/openapi.json` `/api.json` `/tools.json` `/llms.txt` および `/oauth/token` `/auth/refresh` `/auth/nonce` には一切のレート制限が掛かっておらず、テナント単位の `checkRateLimit()` も認証後にしか発火しないため事実上無制限だった。OAuth `client_id+secret` のオフラインなしブルートフォース、重い JSON 生成 (`/openapi.json` 等) の連打による Lambda 同時実行枠枯渇 (DoS) が成立していた (#1101)
-  - 対応 (#1101):
-    - `src/core/quotas/rate-limit/public-rate-limit.service.ts` を新設し、既存の `providers.rateLimit` (DynamoDB / MongoDB トークンバケット) を再利用しつつ IP / OAuth `client_id` 別バケットでレート制限を行う `checkPublicRateLimit()` / `checkOAuthClientRateLimit()` を追加
-    - `src/handlers/api/index.ts` に `enforcePublicRateLimit()` ヘルパーと `isPublicMetadataPath()` / `extractOAuthClientId()` を追加し、メタデータ系・OAuth・auth refresh / nonce のディスパッチ前に呼び出す。`/auth/login` は既存の `LoginProtectionService` で保護されているため除外、`/health` `/version` は監視ポーリング用途のため除外
-    - **早期発火**: 公開パスのレート制限チェックを `Promise.all([resolveJwtSecret(), getMongoClient()])` および `resolveHostnameContext()` よりも前に実行し、レート制限超過時に JWT 秘密の解決・Mongo 接続・ホスト名 DDB 参照を全てスキップ。これによりレート超過リクエストの Lambda CPU 消費とコールドスタート待機を最小化
-    - `src/config/defaults.ts` に `PUBLIC_RATE_LIMIT` を新設しカテゴリ別 (metadata / oauth / auth) のデフォルト値を集約。OAuth は IP 別バケットに加えて `client_id` 別バケットも併用してパスワードスプレー対策。`DISCOVERY` 定数に `OPENAPI_JSON_PATH` / `API_JSON_PATH` / `NGSI_LD_WELL_KNOWN_PATH` を追加してパス文字列を集約
-    - バケットストア障害時は安全側に倒さず通過させる (公開エンドポイントを落とさない)。`TooManyRequestsError` 経由で 429 + `Retry-After` ヘッダを返す
-  - テスト: `tests/unit/core/quotas/rate-limit/public-rate-limit.service.test.ts` に 11 ケース、`tests/unit/handlers/api/index.test.ts` に「公開エンドポイントのレート制限 (#1075)」13 ケースを追加 (Basic Auth / form-urlencoded / JSON ボディからの `client_id` 抽出、429 + Retry-After、`/auth/refresh` と `/auth/nonce` 両方の確認、`/health` `/auth/login` の除外、ストア障害フォールバック) (#1101)
+* **セキュリティ**: Lambda IAM の `kms:CreateKey` に Condition を追加し用途・タグを強制 (issue #1071) (#1108)
+  
+  * `infrastructure/template.yaml` の `ApiHandlerFunction.Policies` 内 `kms:CreateKey` Statement に `Condition` を追加: `kms:KeyUsage = ENCRYPT_DECRYPT` / `kms:KeySpec = SYMMETRIC_DEFAULT` / `aws:RequestTag/geonicdb:purpose = envelope-encryption` を強制し、未知タグキーは `ForAllValues:StringEquals` の `aws:TagKeys` で `geonicdb:tenantId` / `geonicdb:purpose` のみに制限。`Null: aws:RequestTag/geonicdb:tenantId = false` で tenant 所有情報のないキー作成を禁止
+    
+  * `Resource` は AWS 仕様上 `kms:CreateKey` (new-resource action) では `'*'` 必須のため変更しない。代わりに `kms:TagResource` を別 Statement として `arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*` で許可し、`CreateKeyCommand` の `Tags` パラメータ適用に必要な権限を Region/Account 制限付きで付与
+    
+  * 実コード (`src/infrastructure/kms/key-manager.ts createTenantKey()`) は既に上記タグ・KeyUsage・KeySpec で発行しているため非破壊。compromised Lambda が署名鍵・非対称鍵・無タグキー・tenantId 不明のキーを量産する経路を抑止
+    
+* **セキュリティ**: API Gateway `GatewayResponses` の `Access-Control-Allow-Origin` を Parameter 化 (issue #1088) (#1108)
+  
+  * 新 Parameter `GatewayResponseAllowOrigin` を追加 (デフォルト `*` で互換維持)。`infrastructure/template.yaml` の `DEFAULT_4XX` / `DEFAULT_5XX` で `!Sub "'${GatewayResponseAllowOrigin}'"` を参照
+    
+  * 本番デプロイ時は `--parameter-overrides GatewayResponseAllowOrigin='https://app.example.com'` で許可 origin に限定可能。Lambda 経由の通常応答は `src/api/shared/middleware/cors.middleware.ts` の origin echo back + `tenant.allowedOrigins` で制御 (#1069 で導入済)
+    
+  * これにより Lambda が呼ばれない API Gateway 直返しエラー応答経由でのエラーボディ漏洩経路 (任意 origin からの fetch) を本番で塞げるようにする
+    
+* **セキュリティ**: XACML ポリシー登録時に WS ⊂ GET 不変条件違反を WARN ログで検出 (issue #1085) (#1109)
+  
+  * `PolicyService.validateWsGetSymmetry()` を追加。`createPolicy` / `updatePolicy` / `updatePolicySystem` / `updatePolicyForUser` の各経路で、`rule.target.actions` に `attributeId === 'method'` かつ `matchValue === 'WS'` (`string-equal`) のエントリがあり、同じ rule に `'GET'` が含まれていない場合に WARN ログを出力
+    
+  * `authorizeWs()` (`src/core/auth/policy/policy.pip.ts`) は WS と GET を両方評価し両方 Permit でないと許可しない設計のため、WS-only ルールは管理者意図と実挙動が乖離しやすい (例: 「WS だけ Deny」を意図しても GET 経由でデータが取得可能)。reject ではなく WARN に留めることで既存ポリシーとの後方互換を維持
+    
+  * `docs/AUTH.md` に「WebSocket Authorization (WS ⊂ GET)」セクションを追加し、不変条件・推奨記法・WARN ログの読み方を明示
+    
+  * テスト: `tests/unit/core/auth/policy/policy.service.test.ts` に 7 ケース (WS-only / WS+GET / GET-only / glob matchFunction / 非 method attributeId / actions なし / updatePolicy・updatePolicySystem 経由) を追加
 
-- **セキュリティ**: PBKDF2 反復回数を `NODE_ENV` 依存から固定定数に変更 (issue #1073) (#1100)
-  - 旧挙動: `process.env.NODE_ENV === 'test'` の三項演算で iter=1000 / 100000 を切り替えていたため、CI/CD や Lambda 環境変数の誤設定で `NODE_ENV=test` が混入すると本番ハッシュ計算が 100 倍弱体化する経路があった
-  - 修正: `src/config/defaults.ts` に `PASSWORD_HASH` ブロックを新設し、`PBKDF2_ITERATIONS: 100000` (本番固定値) / `KEY_LENGTH` / `SALT_LENGTH` / `DIGEST` を集約。`password.service.ts` は `NODE_ENV` を一切参照しない
-  - テスト用オーバーライドは独立した環境変数 `PASSWORD_HASH_ITERATIONS_TEST` を明示設定した時のみ有効化 (正の整数チェック)。Jest / Cucumber 両セットアップでこの変数を `'1000'` に設定
-  - 起動時 (初回 hash 呼び出し時) に反復回数を INFO ログに出力し、誤設定の回帰を CloudWatch から検知可能化
-  - テスト: `password.service.test.ts` に新規 6 ケース (override 適用 / 不正値拒否 / NODE_ENV 非依存性) を追加
 
-- **[Breaking] WebSocket 認証**: URL クエリパラメータ `?token=` 経路を完全廃止 (issue #1072) (#1099)
-  - 旧挙動: `extractWebSocketToken()` (`src/handlers/websocket/connect.ts`) と `extractLocalWebSocketToken()` (`src/core/streaming/local-ws-server.ts`) が `Authorization` ヘッダ / `Sec-WebSocket-Protocol` に加え、フォールバックとして `?token=<jwt>` URL クエリも受領していた (deprecation warning ログのみで実利用許可) (#1099)
-  - 攻撃面: URL に乗ったトークンはリバースプロキシ / WAF / LB のアクセスログに記録され、ブラウザ履歴やキャッシュにも残存。`Referer` ヘッダ経由で外部に漏洩する経路もあり (Referrer-Policy 未設定と相乗) (#1099)
-  - 対応: query token 抽出ロジックを auth flow の最先頭に移動して **fail-closed** 化。クエリに `token` が含まれていれば、たとえ有効な `Authorization` ヘッダや `Sec-WebSocket-Protocol` が併送されていても warn ログを残した上で `null` を返し、1008 / 401 で接続を拒否する。URL は既に上流プロキシのログに記録された後
+* **セキュリティ**: 公開エンドポイントレート制限の部分失敗時のロールバック実装 (issue #1075 follow-up) (#1102)
+  
+  * 旧挙動: `consumeBucket()` で 3 つの時間窓(minute/hour/day)を `Promise.all` で並列更新していたため、一部の窓で例外(DDB / Mongo の一時障害等)が発生した場合、成功した窓だけトークンが消費されたまま残り、後続リクエストがその窓を不当に削られる「過大カウント」が発生していた。また制限超過拒否時にも、拒否された窓以外で消費が成立しているケースがあり同様の不整合が起きていた
+    
+  * 対応:
+    
+    * `Promise.allSettled` で 3 窓を並列更新し、(a) 一部 throw 時は **値が非負で fulfilled** な窓だけを負 weight で `updateBucket` し直してトークンを返却(ロールバック)した上で元の例外を再 throw、(b) 制限超過拒否時にも拒否された窓以外で消費が成立した窓を同様にロールバック
+      
+    * **negative-value guard**: `updateBucket` は条件失敗時に負値を fulfilled として返すが、その場合 DDB の SET / Mongo の $inc は実行されず消費は成立していない。これを誤ってロールバックすると過大トークンが加算されるため、ロールバック対象は `r.value >= 0` の fulfilled 結果のみに限定(CodeRabbit 指摘 #1102 の追加修正)
+      
+    * DDB の `ConditionExpression: remainingTokens - :consumed >= 0` は負 `:consumed` を常に満たすため `SET remainingTokens = remainingTokens - (-weight)` で加算復元される。Mongo の `$inc: { remainingTokens: -tokensToConsume }` も負 `tokensToConsume` で `+weight` の `$inc` として正しく動作することを確認済み
+      
+    * ロールバック自体が失敗した場合は黙って許容(過大カウント方向の安全な失敗モード)。Promise.all reject 時は呼び出し側 (`enforcePublicRateLimit`) で fail-open 扱いとなり公開エンドポイントを落とさない
+      
+  * テスト: 既存 11 ケースに加え、ロールバック挙動を検証する 6 ケースを追加(一部 throw 時の正しいロールバック対象選択、negative-value 混在時のロールバック対象除外回帰テスト、全窓 throw 時のロールバック発火なし、ロールバック失敗時の握り潰し、制限超過拒否時の整合性確保、全成功時のロールバック非発火)
+    
+  * PR #1101 への CodeRabbit レビュー指摘 (`src/core/quotas/rate-limit/public-rate-limit.service.ts` lines 97-101) への follow-up
+
+
+* **セキュリティ**: 公開(未認証)エンドポイントに IP ベースのレート制限を導入 (issue #1075) (#1101)
+  
+  * 旧挙動: `/.well-known/ai-plugin.json` `/.well-known/agent-card.json` `/.well-known/ngsi-ld` `/openapi.json` `/api.json` `/tools.json` `/llms.txt` および `/oauth/token` `/auth/refresh` `/auth/nonce` には一切のレート制限が掛かっておらず、テナント単位の `checkRateLimit()` も認証後にしか発火しないため事実上無制限だった。OAuth `client_id+secret` のオフラインなしブルートフォース、重い JSON 生成 (`/openapi.json` 等) の連打による Lambda 同時実行枠枯渇 (DoS) が成立していた (#1101)
+    
+  * 対応 (#1101):
+    
+    * `src/core/quotas/rate-limit/public-rate-limit.service.ts` を新設し、既存の `providers.rateLimit` (DynamoDB / MongoDB トークンバケット) を再利用しつつ IP / OAuth `client_id` 別バケットでレート制限を行う `checkPublicRateLimit()` / `checkOAuthClientRateLimit()` を追加
+      
+    * `src/handlers/api/index.ts` に `enforcePublicRateLimit()` ヘルパーと `isPublicMetadataPath()` / `extractOAuthClientId()` を追加し、メタデータ系・OAuth・auth refresh / nonce のディスパッチ前に呼び出す。`/auth/login` は既存の `LoginProtectionService` で保護されているため除外、`/health` `/version` は監視ポーリング用途のため除外
+      
+    * **早期発火**: 公開パスのレート制限チェックを `Promise.all([resolveJwtSecret(), getMongoClient()])` および `resolveHostnameContext()` よりも前に実行し、レート制限超過時に JWT 秘密の解決・Mongo 接続・ホスト名 DDB 参照を全てスキップ。これによりレート超過リクエストの Lambda CPU 消費とコールドスタート待機を最小化
+      
+    * `src/config/defaults.ts` に `PUBLIC_RATE_LIMIT` を新設しカテゴリ別 (metadata / oauth / auth) のデフォルト値を集約。OAuth は IP 別バケットに加えて `client_id` 別バケットも併用してパスワードスプレー対策。`DISCOVERY` 定数に `OPENAPI_JSON_PATH` / `API_JSON_PATH` / `NGSI_LD_WELL_KNOWN_PATH` を追加してパス文字列を集約
+      
+    * バケットストア障害時は安全側に倒さず通過させる (公開エンドポイントを落とさない)。`TooManyRequestsError` 経由で 429 + `Retry-After` ヘッダを返す
+      
+  * テスト: `tests/unit/core/quotas/rate-limit/public-rate-limit.service.test.ts` に 11 ケース、`tests/unit/handlers/api/index.test.ts` に「公開エンドポイントのレート制限 (#1075)」13 ケースを追加 (Basic Auth / form-urlencoded / JSON ボディからの `client_id` 抽出、429 + Retry-After、`/auth/refresh` と `/auth/nonce` 両方の確認、`/health` `/auth/login` の除外、ストア障害フォールバック) (#1101)
+
+
+* **セキュリティ**: PBKDF2 反復回数を `NODE_ENV` 依存から固定定数に変更 (issue #1073) (#1100)
+  
+  * 旧挙動: `process.env.NODE_ENV === 'test'` の三項演算で iter=1000 / 100000 を切り替えていたため、CI/CD や Lambda 環境変数の誤設定で `NODE_ENV=test` が混入すると本番ハッシュ計算が 100 倍弱体化する経路があった
+    
+  * 修正: `src/config/defaults.ts` に `PASSWORD_HASH` ブロックを新設し、`PBKDF2_ITERATIONS: 100000` (本番固定値) / `KEY_LENGTH` / `SALT_LENGTH` / `DIGEST` を集約。`password.service.ts` は `NODE_ENV` を一切参照しない
+    
+  * テスト用オーバーライドは独立した環境変数 `PASSWORD_HASH_ITERATIONS_TEST` を明示設定した時のみ有効化 (正の整数チェック)。Jest / Cucumber 両セットアップでこの変数を `'1000'` に設定
+    
+  * 起動時 (初回 hash 呼び出し時) に反復回数を INFO ログに出力し、誤設定の回帰を CloudWatch から検知可能化
+    
+  * テスト: `password.service.test.ts` に新規 6 ケース (override 適用 / 不正値拒否 / NODE\_ENV 非依存性) を追加
+
+
+* **\[Breaking] WebSocket 認証**: URL クエリパラメータ `?token=` 経路を完全廃止 (issue #1072) (#1099)
+  
+  * 旧挙動: `extractWebSocketToken()` (`src/handlers/websocket/connect.ts`) と `extractLocalWebSocketToken()` (`src/core/streaming/local-ws-server.ts`) が `Authorization` ヘッダ / `Sec-WebSocket-Protocol` に加え、フォールバックとして `?token=<jwt>` URL クエリも受領していた (deprecation warning ログのみで実利用許可) (#1099)
+    
+  * 攻撃面: URL に乗ったトークンはリバースプロキシ / WAF / LB のアクセスログに記録され、ブラウザ履歴やキャッシュにも残存。`Referer` ヘッダ経由で外部に漏洩する経路もあり (Referrer-Policy 未設定と相乗) (#1099)
+    
+  * 対応: query token 抽出ロジックを auth flow の最先頭に移動して **fail-closed** 化。クエリに `token` が含まれていれば、たとえ有効な `Authorization` ヘッダや `Sec-WebSocket-Protocol` が併送されていても warn ログを残した上で `null` を返し、1008 / 401 で接続を拒否する。URL は既に上流プロキシのログに記録された後なので、トークンは漏洩済みとして扱う (#1099)
+    
+  * クライアント影響: 既存クライアントはトークンを以下のいずれかに移行する必要がある (#1099)
+    
+    * **Node.js / 自前 WebSocket クライアント**: `Authorization: Bearer <token>` ヘッダ
+      
+    * **ブラウザ**: 標準の `WebSocket` API は任意ヘッダ設定不可のため、`new WebSocket(url, ['access_token', token])` 形式の `Sec-WebSocket-Protocol` サブプロトコル
+      
+  * 関連プロジェクト確認: `@geolonia/geonicdb-sdk` (`src/sdk/websocket.ts`) は既に `Sec-WebSocket-Protocol` 採用済 → SDK ユーザ (geonicdb-pulse / geonicdb-voice) はノーオペで移行可能。geonicdb-cli / geonicdb-app-template は WebSocket 未使用、geonicdb-demo-app の `use-geonicdb-stream.ts` も query token 未使用 (#1099)
+    
+  * ドキュメント更新: `docs/EVENT_STREAMING.md`、`docs/INSTRUCTION.md` (7.2 接続方法 / 7.6 実装例)、`src/api/shared/controllers/meta.controller.ts` (`/llms.txt` の Event Streaming セクション・`/api.json` の `eventStreaming.auth`) から `&token=...` の記述を除去し、ヘッダ 2 経路に書き換え。`?token=` 経由の接続は拒否される旨を明示 (#1099)
+    
+  * テスト: `tests/unit/handlers/websocket/connect.test.ts` / `tests/unit/core/streaming/local-ws-server.test.ts` に「クエリ `?token=` だけの接続は 401 / 1008 で拒否される」「ヘッダと query token を併送しても query があれば fail-closed」回帰テストを追加。warn ログ送出も spy で固定。既存テストは Bearer ヘッダ送信に書き換え。E2E `tests/e2e/step-definitions/common/websocket.steps.ts` の `connectWebSocket` ヘルパーも `Authorization` ヘッダ送信に変更し、url/options 構築は `buildLocalWsConnection` ヘルパーに共通化 (#1099)
 
 ### 2026-04-29
-- **CORS / セキュリティ**: Origin echo back + テナント単位 `allowedOrigins` でトークン漏洩・CSRF 経路を遮断 (issue #1069) (#1097)
-  - 旧挙動: `Access-Control-Allow-Origin: '*'` を返しつつ `Authorization` / `X-Api-Key` / `DPoP` を `Access-Control-Allow-Headers` に含めていたため、攻撃者制御のサイトからブラウザに乗ったユーザの Bearer トークン / API Key 付きリクエストを送らせる経路が成立していた (CSRF + トークン漏洩懸念) (#1097)
-  - 環境変数による単一ホワイトリストは GeonicDB がマルチテナント・データ連携基盤 (Context Broker) であるため不適切。許可 origin はテナント運用者がランタイムに DB 越しで設定できる設計に変更 (#1097)
-  - **データモデル拡張**: `TenantSettings.allowedOrigins?: string[]` を追加 (`src/core/auth/tenant/tenant.types.ts`)。`undefined` = 後方互換で全許可、`[]` = 全 deny、`['*']` = 全許可、`[origin1, ...]` = 完全一致。最大 50 個 (`TENANT.MAX_ALLOWED_ORIGINS`) (#1097)
-  - **CORS middleware の echo back 化** (`src/api/shared/middleware/cors.middleware.ts`): `Access-Control-Allow-Origin` をリクエストの `Origin` ヘッダ echo back に変更し、`Vary: Origin` を必ず付与。CDN / ブラウザキャッシュで origin 別レスポンスが混ざらないようにする (#1097)
-  - **認証層での fail-close** (`src/core/auth/origin/origin-check.ts` 新設、`src/api/shared/middleware/auth.middleware.ts` に統合): preflight (OPTIONS) は origin 検証なしで通過させ、実 request の認証フェーズで `validateOriginForTenant()` が違反を 403 で fail-close する。data API は `optionalAuth(event, tenantService)` で、admin API / `/auth/logout` は `requireAuth(event)` で `user.tenantId` から tenant を引いて検証 (#1097)
-  - **エラー時も CORS ヘッダ echo back**: 403 を返すケースでも `Access-Control-Allow-Origin` / `Vary: Origin` を付ける。echo back しないとブラウザはレスポンスを完全ブロックして「Network error」になり、運用者にも原因が見えないため (#1097)
-  - **共通 OriginSchema 切り出し**: API Key の `OriginSchema` を `src/api/admin/schemas/origin.schemas.ts` に共通化し、API Key と Tenant の両方で再利用 (#1097)
-  - **Admin API**: `PATCH /admin/tenants/{tenantId}` の `settings.allowedOrigins` で CRUD 可能 (zod `OriginSchema.array().max(50)` バリデーション) (#1097)
-  - **super_admin はテナントに紐付かない (tenantId=null) ため origin 検証 skip**。認証無効モード (`AUTH_ENABLED=false`) も従来通り origin 検証 skip — IP 制限と同じ扱い (#1097)
-  - テスト: `validateOriginForTenant` unit test (13 ケース)、`cors.middleware.test` を echo back / Vary / extractRequestOrigin で更新 (28 ケース)、`auth.middleware.test` に origin 検証 13 ケース追加。`cors-comprehensive.feature` に `@issue-1069` シナリオ 10 件追加 (origin echo back / preflight 通過 / tenant allow/deny / wildcard / 空配列 / Origin 不在 / 後方互換) (#1097)
-  - 関連プロジェクト影響: geonicdb-cli は `Origin` ヘッダを送らないため API Key / Bearer 認証で動作するが、絞り込み済みテナントには CLI 利用者が `Origin` ヘッダ付与か `*` 許可が必要。geonicdb-pulse / voice / demo-app は SDK 経由で `Origin` 自動付与のため、本番テナントの `allowedOrigins` に `https://*.geolonia.com` 等の登録運用が必要 (#1097)
 
-- **セキュリティ監査バッチ**: 総合監査 (#1068) の互換性影響なし issue 5 件を一括対応 (#1098)
-  - `TestPasswordHasher` を `tests/` 配下に移動。本番モジュールから SHA-256 / salt なしのテスト用ハッシャー export を削除し、誤注入経路を排除 (#1077)
-  - ログイン失敗経路 (user not found / env super admin password mismatch) にダミー PBKDF2 検証を追加。timing-based user enumeration を防ぐため、応答時間を均等化 (#1095)
-  - `loadBoundPolicy()` のテナント不一致 / global→tenant 違反バインドを `error` レベル + `errorCode` / `securityEvent` 構造化フィールドに昇格。CloudWatch メトリクスフィルタで検知可能化 (#1081)
-  - `validateAllowedPath()` にパストラバーサル拒否 (`..`, `//`, `/./`) を追加。string-prefix チェックでの誤評価を防御層として完全排除。テスト 6 ケース追加 (#1083)
-  - `docs/AUTH.md` に「Path-Level vs Entity-Level Authorization」節を追加。`requireAuthz` (fail-closed) と `requireEntityAuthz` (fail-open) の設計判断と運用上の含意 (owner-only ポリシーは明示的 Deny ルールが必要) を明文化 (#1076)
 
-### 2026-04-28
-- **CORS 修正**: `Access-Control-Allow-Headers` に `If-None-Match` / `If-Modified-Since` を追加 (#1065)
-  - 旧設定では cross-origin リクエストにこれら 2 ヘッダーが allow されていなかったため、ブラウザの HTTP cache 自動再検証と SDK の `_cachedRequest` が CORS preflight (OPTIONS) で reject され、INM 付き GET を送ることができなかった (#1065)
-  - 結果として PR #1060 (SDK invalidation 削除) / #1062 (CORS expose ETag) / #1063 (Cache-Control: no-cache strip) という 3 段の修正が揃っていても、INM そのものがブラウザから出ないため 304 経路全体が機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが効かない現象の最終真因) (#1065)
-  - 修正: `src/config/defaults.ts` に `CORS_ALLOW_HEADERS` 定数を新設し `If-None-Match` / `If-Modified-Since` を含めた完全な allow-list を集約。`cors.middleware.ts` と `infrastructure/template.yaml` (Cors.AllowHeaders / GatewayResponses) は同定数に同期 (#1065)
-  - 検証方法: `curl -X OPTIONS -H 'Access-Control-Request-Headers: if-none-match' <endpoint>/ngsi-ld/v1/entities` で `If-None-Match` が allow-headers に含まれることを確認 (#1065)
-  - テスト: cors.middleware.test に `If-None-Match` / `If-Modified-Since` の allow ケースを追加。cors-comprehensive.feature に `@issue-1065` シナリオ 2 件追加 (#1065)
+* **CORS / セキュリティ**: Origin エコーバック + テナント単位 `allowedOrigins` でトークン漏洩・CSRF 経路を遮断 (issue #1069) (#1097)
+  
+  * 旧挙動: `Access-Control-Allow-Origin: '*'` を返しつつ `Authorization` / `X-Api-Key` / `DPoP` を `Access-Control-Allow-Headers` に含めていたため、攻撃者制御のサイトからブラウザに乗ったユーザの Bearer トークン / API Key 付きリクエストを送らせる経路が成立していた (CSRF + トークン漏洩懸念) (#1097)
+    
+  * 環境変数による単一ホワイトリストは GeonicDB がマルチテナント・データ連携基盤 (Context Broker) であるため不適切。許可 origin はテナント運用者がランタイムに DB 越しで設定できる設計に変更 (#1097)
+    
+  * **データモデル拡張**: `TenantSettings.allowedOrigins?: string[]` を追加 (`src/core/auth/tenant/tenant.types.ts`)。`undefined` = 後方互換で全許可、`[]` = 全 deny、`['*']` = 全許可、`[origin1, ...]` = 完全一致。最大 50 個 (`TENANT.MAX_ALLOWED_ORIGINS`) (#1097)
+    
+  * **CORS middleware のエコーバック化** (`src/api/shared/middleware/cors.middleware.ts`): `Access-Control-Allow-Origin` をリクエストの `Origin` ヘッダエコーバックに変更し、`Vary: Origin` を必ず付与。CDN / ブラウザキャッシュで origin 別レスポンスが混ざらないようにする (#1097)
+    
+  * **認証層での fail-close** (`src/core/auth/origin/origin-check.ts` 新設、`src/api/shared/middleware/auth.middleware.ts` に統合): preflight (OPTIONS) は origin 検証なしで通過させ、実 request の認証フェーズで `validateOriginForTenant()` が違反を 403 で fail-close する。data API は `optionalAuth(event, tenantService)` で、admin API / `/auth/logout` は `requireAuth(event)` で `user.tenantId` から tenant を引いて検証 (#1097)
+    
+  * **エラー時も CORS ヘッダエコーバック**: 403 を返すケースでも `Access-Control-Allow-Origin` / `Vary: Origin` を付ける。エコーバックしないとブラウザはレスポンスを完全ブロックして「Network error」になり、運用者にも原因が見えないため (#1097)
+    
+  * **共通 OriginSchema 切り出し**: API Key の `OriginSchema` を `src/api/admin/schemas/origin.schemas.ts` に共通化し、API Key と Tenant の両方で再利用 (#1097)
+    
+  * **Admin API**: `PATCH /admin/tenants/{tenantId}` の `settings.allowedOrigins` で CRUD 可能 (zod `OriginSchema.array().max(50)` バリデーション) (#1097)
+    
+  * **super\_admin はテナントに紐付かない (tenantId=null) ため origin 検証 skip**。認証無効モード (`AUTH_ENABLED=false`) も従来通り origin 検証 skip — IP 制限と同じ扱い (#1097)
+    
+  * テスト: `validateOriginForTenant` unit test (13 ケース)、`cors.middleware.test` を echo back / Vary / extractRequestOrigin で更新 (28 ケース)、`auth.middleware.test` に origin 検証 13 ケース追加。`cors-comprehensive.feature` に `@issue-1069` シナリオ 10 件追加 (origin echo back / preflight 通過 / tenant allow/deny / wildcard / 空配列 / Origin 不在 / 後方互換) (#1097)
+    
+  * 関連プロジェクト影響: geonicdb-cli は `Origin` ヘッダを送らないため API Key / Bearer 認証で動作するが、絞り込み済みテナントには CLI 利用者が `Origin` ヘッダ付与か `*` 許可が必要。geonicdb-pulse / voice / demo-app は SDK 経由で `Origin` 自動付与のため、本番テナントの `allowedOrigins` に `https://*.geolonia.com` 等の登録運用が必要 (#1097)
 
-- **デプロイ可視化**: `/version` エンドポイントの `git_hash` フィールドにコミット SHA を埋め込み (#1064)
-  - `infrastructure/template.yaml` に `GitHash` パラメータを追加し、Lambda 環境変数 `GIT_HASH` として注入 (#1064)
-  - `deploy-env.yml` で `GitHash=${{ github.sha }}` を SAM パラメータに渡す (staging / prod 両経路対応) (#1064)
-  - 用途: staging / prod でデプロイ済みのコミットを `curl /version` で即時確認できるようにする。デプロイ問題の切り分けが従来 CloudFormation イベントログまで遡らないと判明しなかったが、これで一発で分かる (#1064)
 
-- **条件付きリクエスト修正**: `Cache-Control: no-cache` リクエストヘッダーを INM 評価から除外 (#1063)
-  - 旧挙動: `fresh` パッケージが RFC 2616 §14.9.4 に従いリクエストの `Cache-Control: no-cache` を "force reload" として扱い、`If-None-Match` 一致でも 304 を返さず常に 200 + body を返却していた (#1063)
-  - ブラウザは特定のコンテキスト (ハードリロード後の継続フェッチ等) で `Cache-Control: no-cache` を fetch に自動付与するため、SDK が明示的に `If-None-Match` を送っていてもサーバが 304 を返さなくなり、SDK の帯域節約が常に機能しない問題が発生 (incident 2026-04-28: pulse で SDK キャッシュが効いているように見えて毎回 200 が返る現象の真因) (#1063)
-  - 修正: `evaluateConditionalRequest` の `normalizeRequestHeaders` でリクエストヘッダーから `cache-control` を除外。SDK の明示的な `If-None-Match` 送信 = 「同じなら 304 で OK」という意思表示なので、ブラウザ自動付与の `Cache-Control: no-cache` で 304 を抑制しないのが正しい (#1063)
-  - `Cache-Control: no-store` (CDN バイパス意図) は引き続き `honorClientNoStore` で適切に扱う (本修正は INM 評価のみ影響) (#1063)
-  - テスト: `evaluateConditionalRequest` ユニットテストに Cache-Control: no-cache + INM / + IMS の 2 ケース追加。`http-cache-control.feature` に NGSIv2 単一エンティティ / NGSI-LD リストの 2 シナリオ追加 (#1063)
-
-- **CORS 修正**: `Access-Control-Expose-Headers` に複数のレスポンスヘッダーを追加 (#1062)
-  - **ETag / Vary**: 旧設定では `ETag` が CORS で隠され、ブラウザ JavaScript から `res.headers.get('etag')` が `null` を返していたため、SDK がキャッシュエントリを作れず `If-None-Match` も送れず、304 帯域節約パスが完全に機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが一切効かなかった真因) (#1062)
-  - **Content-Crs**: NGSI-LD / NGSIv2 の geo レスポンスで CRS を通知するヘッダー。ブラウザクライアントが座標系を判別するために必要 (#1062)
-  - **Fiware-Next-Token**: NGSIv2 ページネーション継続トークン。クライアントが次ページをリクエストするために必要 (#1062)
-  - **NGSILD-Warning**: NGSI-LD federation 警告。クライアントに警告を通知するために必要 (#1062)
-  - **Retry-After**: 429 rate limit / 503 retry-after 案内。クライアントがリトライ戦略を決めるために必要 (#1062)
-  - `Cache-Control` / `Last-Modified` / `Content-Type` 等は CORS-safelisted なので expose 不要 (#1062)
-  - 漏れ検出: 全エンドポイントのレスポンスヘッダーを grep して CORS expose リストと突合し、不足している 4 件 (Content-Crs / Fiware-Next-Token / NGSILD-Warning / Retry-After) を発見・追加 (#1062)
-  - 設定値は `src/config/defaults.ts` の `CORS_EXPOSE_HEADERS` (`as const` 配列) に集約 (#1062)
-
-- **セキュリティ**: Dependabot アラート 13 件を一括解消 (#1061)
-  - 直接依存 (overrides 経由): `hono` ^4.12.14, `@hono/node-server` ^1.19.13 — JSX SSR HTML インジェクション / cookie 名検証 / IPv4-mapped IPv6 / serveStatic / toSSG パストラバーサルを解消 (#1061)
-  - 間接依存 (overrides 追加): `protobufjs@<8` ^7.5.5 (任意コード実行), `basic-ftp` ^5.3.1 (CRLF インジェクション / DoS), `follow-redirects` ^1.16.0 (Authorization ヘッダーリーク), `uuid` ^14.0.0 (バッファ境界) (#1061)
-  - `npm audit` で 0 vulnerabilities を確認 (#1061)
-
-- **SDK パフォーマンス修正**: WebSocket エンティティイベントでの自動キャッシュ無効化を削除 (#1060)
-  - 旧実装: `entityCreated` / `entityUpdated` / `entityDeleted` 受信時に SDK が `_invalidateCacheForEntityEvent()` で全エンティティキャッシュエントリを `deleteWhere` で削除していた (#1060)
-  - 削除すると ETag も失われ、次回読み取りで `If-None-Match` が送られず、サーバは毎回 full `200` body を返却 → 304 帯域節約パスが完全に機能していなかった (#1060)
-  - data エンドポイントは `Cache-Control: private, no-cache` で毎回再検証されるため、キャッシュを残しても安全 (サーバ側 ETag マッチで 304 / 200 が自動的に振り分けられる) (#1060)
-  - 結果: pulse 等のリアルタイム監視アプリで WebSocket 受信中にキャッシュが効くようになり、未変更データの再取得が 304 で済むようになる (#1060)
-  - 明示的に全クリアしたい場合は `clearCache()` を呼ぶ (公開 API なので未変更)。`clearCache()` で `cacheInvalidated` イベントが発火するように修正 — WebSocket 経路を削除した結果、このイベントが発火しなくなる退行を回避 (#1060)
-
-- **セキュリティ強化**: Security Audit Group 3 — 公開 vs 認証境界の網羅検証 (#1057)
-  - **#1053: 公開メタエンドポイントに STATIC ポリシーを適用** — `/llms.txt`, `/api.json`, `/openapi.json`, `/tools.json`, `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json` の 6 エンドポイントが `Cache-Control` を返していなかった (CDN がキャッシュ判断できず、コスト・レイテンシが悪化)。`applyCachePolicy('static')` を適用して `Cache-Control: public, max-age=3600` を返すよう修正。ただし `/openapi.json` は tenant 依存の `CustomDataModel_*` を埋め込むケースがあるため、注入された場合のみ `meta` ポリシーへフォールバック (#1057)
-  - **#1053: STATIC ポリシーの Vary を最小化** — STATIC は cross-tenant で共有可能なため、`Vary` を `Accept` のみに制限。`Fiware-Service` / `Authorization` / `X-Api-Key` を含めると CDN がテナント / ユーザ毎にキャッシュ分離してしまい、STATIC の意義 (CDN 広域共有) が損なわれる (#1057)
-  - **#1053: lint テスト追加** — `meta.controller.test.ts` に「Cache-Control policy assignment lint」を新設。各公開エンドポイントが `public, max-age=3600` を返し、`private` / `no-cache` を含まないこと、`Vary` がテナント / 認証次元を含まないこと、`/openapi.json` の tenant スキーマありケースで `meta` フォールバックが効くことを 12 ケースで検証 (#1057)
-  - **#1048: Vary 網羅性 audit + 文書化** — 現状の `Vary` (`Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`) が網羅的であることを確認。`DPoP` (リクエスト毎)、`Accept-Language` (NGSI で使われない)、`Origin`、`X-Forwarded-For` (認証段階で評価) を意図的に除外することを `docs/SECURITY.md` に明記 (#1057)
-  - **#1052: DPoP / DPoP-Nonce × cache 検証 + 文書化** — `DPoP-Nonce` が 304 パススルーホワイトリストに既に含まれていることをユニットテストで固定。DPoP 認証失敗が `evaluateConditionalRequest` より前に評価される invariant を `docs/AUTH.md` / `docs/SECURITY.md` に明記 (#1057)
-  - **ドキュメント**: `docs/SECURITY.md` に「Vary Header Coverage Audit」「DPoP / DPoP-Nonce & Cache Integrity」「Public vs Authenticated Endpoint Cache Policy Matrix」3 セクション追加。`docs/AUTH.md` に「DPoP & HTTP Cache Interaction」サブセクション追加 (#1057)
+* **セキュリティ監査バッチ**: 総合監査 (#1068) の互換性影響なし issue 5 件を一括対応 (#1098)
+  
+  * `TestPasswordHasher` を `tests/` 配下に移動。本番モジュールから SHA-256 / salt なしのテスト用ハッシャー export を削除し、誤注入経路を排除 (#1077)
+    
+  * ログイン失敗経路 (user not found / env super admin password mismatch) にダミー PBKDF2 検証を追加。timing-based user enumeration を防ぐため、応答時間を均等化 (#1095)
+    
+  * `loadBoundPolicy()` のテナント不一致 / global→tenant 違反バインドを `error` レベル + `errorCode` / `securityEvent` 構造化フィールドに昇格。CloudWatch メトリクスフィルタで検知可能化 (#1081)
+    
+  * `validateAllowedPath()` にパストラバーサル拒否 (`..`, `//`, `/./`) を追加。string-prefix チェックでの誤評価を防御層として完全排除。テスト 6 ケース追加 (#1083)
+    
+  * `docs/AUTH.md` に「Path-Level vs Entity-Level Authorization」節を追加。`requireAuthz` (fail-closed) と `requireEntityAuthz` (fail-open) の設計判断と運用上の含意 (owner-only ポリシーは明示的 Deny ルールが必要) を明文化 (#1076)
 
 ### 2026-04-28
-- **セキュリティ強化**: Security Audit Group 2 — 認可整合性 (#1056)
-  - **#1049: HMAC ベース ETag** — ETag 生成を `createHash` から `createHmac(algo, secret)` に変更。鍵は `ETAG_HMAC_SECRET` 環境変数から取得し、本番 (`ENVIRONMENT='prod'`) では未設定なら fail-fast で起動失敗。dev/test では documented なフォールバックを使う。これまで決定的だった ETag が攻撃者に再現不能化され、`If-None-Match` 試行による `modifiedAt` / 件数ブラインド情報リークを根本的に排除。同テナント内の正規ユーザは同じ鍵で計算されるため 304 帯域節約は維持 (#1056)
-  - **#1050: XACML ポリシー Revoke 後のキャッシュ整合性** — handler の評価順 (`requireAuthz` → controller → `evaluateConditionalRequest`) を unit test で固定 (jest `invocationCallOrder` で controller 含めた順序を検証)。`requireAuthz` が throw した場合、catch 経路が 4xx を返し controller / `evaluateConditionalRequest` を経由しないため、認可剥奪後に旧 ETag の `If-None-Match` が 304 で旧 view を resurface することはない。E2E では実 ETag を取得後に認証 / テナントを変更して投げ直し、4xx が返ることを検証 (#1056)
-  - **テスト**: cache-control middleware unit test に HMAC 関連 6 ケース追加 (異なる secret / 同 secret stable / 環境変数 fallback / prod fail-fast / prod with secret OK)。handler unit test に `#1050` regression test 2 ケース追加 (controller 未呼び出し検証 + invocationCallOrder で順序固定)。`policy-enforcement.feature` に `@issue-1050` シナリオ 2 件追加 (実 ETag を取得 → 認証クリア / 別テナントへの切替後 INM が 304 にならず 4xx) (#1056)
-  - **ドキュメント**: `docs/AUTH.md` に「Policy Propagation Delay & HTTP Cache Integrity」セクション新設 (PolicyService cache TTL: 60s 仕様化)。`docs/SECURITY.md` に「HMAC-Based ETag」「Policy Revocation & Cache Integrity」サブセクション追加。`docs/ENV.md` / `infrastructure/template.yaml` に `ETAG_HMAC_SECRET` 追加 (#1056)
+
+
+* **CORS 修正**: `Access-Control-Allow-Headers` に `If-None-Match` / `If-Modified-Since` を追加 (#1065)
+  
+  * 旧設定では cross-origin リクエストにこれら 2 ヘッダーが allow されていなかったため、ブラウザの HTTP cache auto-revalidation と SDK の `_cachedRequest` が CORS preflight (OPTIONS) で reject され、INM 付き GET を送ることができなかった (#1065)
+    
+  * 結果として PR #1060 (SDK invalidation 削除) / #1062 (CORS expose ETag) / #1063 (Cache-Control: no-cache strip) という 3 段の修正が揃っていても、INM そのものがブラウザから出ないため 304 経路全体が機能していなかった (incident 2026-04-28: pulse で SDK cache が効かない現象の最終真因) (#1065)
+    
+  * 修正: `src/config/defaults.ts` に `CORS_ALLOW_HEADERS` 定数を新設し `If-None-Match` / `If-Modified-Since` を含めた完全な allow-list を集約。`cors.middleware.ts` と `infrastructure/template.yaml` (Cors.AllowHeaders / GatewayResponses) は同定数に同期 (#1065)
+    
+  * 検証方法: `curl -X OPTIONS -H 'Access-Control-Request-Headers: if-none-match' <endpoint>/ngsi-ld/v1/entities` で `If-None-Match` が allow-headers に含まれることを確認 (#1065)
+    
+  * テスト: cors.middleware.test に `If-None-Match` / `If-Modified-Since` の allow ケースを追加。cors-comprehensive.feature に `@issue-1065` シナリオ 2 件追加 (#1065)
+
+
+* **デプロイ可視化**: `/version` エンドポイントの `git_hash` フィールドにコミット SHA を埋め込み (#1064)
+  
+  * `infrastructure/template.yaml` に `GitHash` パラメータを追加し、Lambda 環境変数 `GIT_HASH` として注入 (#1064)
+    
+  * `deploy-env.yml` で `GitHash=${{ github.sha }}` を SAM パラメータに渡す (staging / prod 両経路対応) (#1064)
+    
+  * 用途: staging / prod でデプロイ済みのコミットを `curl /version` で即時確認できるようにする。デプロイ問題の切り分けが従来 CloudFormation event log まで遡らないと判明しなかったが、これで一発で分かる (#1064)
+
+
+* **条件付きリクエスト修正**: `Cache-Control: no-cache` リクエストヘッダーを INM 評価から除外 (#1063)
+  
+  * 旧挙動: `fresh` パッケージが RFC 2616 §14.9.4 に従いリクエストの `Cache-Control: no-cache` を "force reload" として扱い、`If-None-Match` 一致でも 304 を返さず常に 200 + body を返却していた (#1063)
+    
+  * ブラウザは特定の context (ハードリロード後の継続フェッチ等) で `Cache-Control: no-cache` を fetch に自動付与するため、SDK が明示的に `If-None-Match` を送っていてもサーバが 304 を返さなくなり、SDK の帯域節約が常に死ぬ問題が発生 (incident 2026-04-28: pulse で SDK キャッシュが効いているように見えて毎回 200 が返る現象の真因) (#1063)
+    
+  * 修正: `evaluateConditionalRequest` の `normalizeRequestHeaders` でリクエストヘッダーから `cache-control` を除外。SDK の明示的な `If-None-Match` 送信 = 「同じなら 304 で OK」という意思表示なので、ブラウザ自動付与の `Cache-Control: no-cache` で 304 を抑制しないのが正しい (#1063)
+    
+  * `Cache-Control: no-store` (CDN bypass 意図) は引き続き `honorClientNoStore` で適切に扱う (本修正は INM 評価のみ影響) (#1063)
+    
+  * テスト: `evaluateConditionalRequest` unit test に Cache-Control: no-cache + INM / + IMS の 2 ケース追加。`http-cache-control.feature` に NGSIv2 単一 entity / NGSI-LD list の 2 シナリオ追加 (#1063)
+
+
+* **CORS 修正**: `Access-Control-Expose-Headers` に複数のレスポンスヘッダーを追加 (#1062)
+  
+  * **ETag / Vary**: 旧設定では `ETag` が CORS で隠され、ブラウザ JS から `res.headers.get('etag')` が `null` を返していたため、SDK がキャッシュエントリを作れず `If-None-Match` も送れず、304 帯域節約パスが完全に機能していなかった (incident 2026-04-28: pulse で SDK キャッシュが一切効かなかった真因) (#1062)
+    
+  * **Content-Crs**: NGSI-LD / NGSIv2 の geo response で CRS を通知するヘッダー。ブラウザクライアントが座標系を判別するために必要 (#1062)
+    
+  * **Fiware-Next-Token**: NGSIv2 ページネーション継続トークン。クライアントが次ページをリクエストするために必要 (#1062)
+    
+  * **NGSILD-Warning**: NGSI-LD federation warning。クライアントに警告を通知するために必要 (#1062)
+    
+  * **Retry-After**: 429 rate limit / 503 retry-after 案内。クライアントが retry 戦略を決めるために必要 (#1062)
+    
+  * `Cache-Control` / `Last-Modified` / `Content-Type` 等は CORS-safelisted なので expose 不要 (#1062)
+    
+  * 漏れ検出: 全エンドポイント response header を grep して CORS expose リストと突合し、missing 4 件 (Content-Crs / Fiware-Next-Token / NGSILD-Warning / Retry-After) を発見・追加 (#1062)
+    
+  * 設定値は `src/config/defaults.ts` の `CORS_EXPOSE_HEADERS` (`as const` 配列) に集約 (#1062)
+
+
+* **セキュリティ**: Dependabot アラート 13 件を一括解消 (#1061)
+  
+  * 直接依存 (overrides 経由): `hono` ^4.12.14, `@hono/node-server` ^1.19.13 — JSX SSR HTML injection / cookie name 検証 / IPv4-mapped IPv6 / serveStatic / toSSG path traversal を解消 (#1061)
+    
+  * 間接依存 (overrides 追加): `protobufjs@<8` ^7.5.5 (任意コード実行), `basic-ftp` ^5.3.1 (CRLF injection / DoS), `follow-redirects` ^1.16.0 (Authorization ヘッダーリーク), `uuid` ^14.0.0 (バッファ境界) (#1061)
+    
+  * `npm audit` で 0 vulnerabilities を確認 (#1061)
+
+
+* **SDK パフォーマンス修正**: WebSocket entity events での自動キャッシュ無効化を削除 (#1060)
+  
+  * 旧実装: `entityCreated` / `entityUpdated` / `entityDeleted` 受信時に SDK が `_invalidateCacheForEntityEvent()` で全 entities cache エントリを `deleteWhere` で削除していた (#1060)
+    
+  * 削除すると ETag も失われ、次回読み取りで `If-None-Match` が送られず、サーバは毎回 full `200` body を返却 → 304 帯域節約パスが完全に死んでいた (#1060)
+    
+  * data エンドポイントは `Cache-Control: private, no-cache` で毎回 revalidation されるため、cache を残しても安全 (server 側 ETag マッチで 304 / 200 が自動的に振り分けられる) (#1060)
+    
+  * 結果: pulse 等のリアルタイム監視アプリで WebSocket 受信中にキャッシュが効くようになり、unchanged data の再取得が 304 で済むようになる (#1060)
+    
+  * 明示的に全クリアしたい場合は `clearCache()` を呼ぶ (公開 API なので未変更)。`clearCache()` で `cacheInvalidated` イベントが発火するように修正 — WebSocket 経路を削除した結果、このイベントが発火しなくなる退行を回避 (#1060)
+
+
+* **セキュリティ強化**: Security Audit Group 3 — 公開 vs 認証境界の網羅検証 (#1057)
+  
+  * **#1053: 公開メタエンドポイントに STATIC ポリシーを適用** — `/llms.txt`, `/api.json`, `/openapi.json`, `/tools.json`, `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json` の 6 エンドポイントが `Cache-Control` を返していなかった (CDN がキャッシュ判断できず、コスト・レイテンシが悪化)。`applyCachePolicy('static')` を適用して `Cache-Control: public, max-age=3600` を返すよう修正。ただし `/openapi.json` は tenant 依存の `CustomDataModel_*` を埋め込むケースがあるため、注入された場合のみ `meta` ポリシーへフォールバック (#1057)
+    
+  * **#1053: STATIC ポリシーの Vary を最小化** — STATIC は cross-tenant で共有可能なため、`Vary` を `Accept` のみに制限。`Fiware-Service` / `Authorization` / `X-Api-Key` を含めると CDN がテナント / ユーザ毎にキャッシュ分離してしまい、STATIC の意義 (CDN 広域共有) が損なわれる (#1057)
+    
+  * **#1053: lint test 追加** — `meta.controller.test.ts` に「Cache-Control policy assignment lint」を新設。各公開エンドポイントが `public, max-age=3600` を返し、`private` / `no-cache` を含まないこと、`Vary` がテナント / 認証次元を含まないこと、`/openapi.json` の tenant スキーマありケースで `meta` フォールバックが効くことを 12 ケースで検証 (#1057)
+    
+  * **#1048: Vary 網羅性 audit + 文書化** — 現状の `Vary` (`Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`) が網羅的であることを確認。`DPoP` (per-request)、`Accept-Language` (NGSI で使われない)、`Origin`、`X-Forwarded-For` (auth 段階で評価) を意図的に除外することを `docs/SECURITY.md` に明記 (#1057)
+    
+  * **#1052: DPoP / DPoP-Nonce × cache 検証 + 文書化** — `DPoP-Nonce` が 304 passthrough whitelist に既に含まれていることを unit test で固定。DPoP 認証失敗が `evaluateConditionalRequest` より前に評価される invariant を `docs/AUTH.md` / `docs/SECURITY.md` に明記 (#1057)
+    
+  * **ドキュメント**: `docs/SECURITY.md` に「Vary Header Coverage Audit」「DPoP / DPoP-Nonce & Cache Integrity」「Public vs Authenticated Endpoint Cache Policy Matrix」3 セクション追加。`docs/AUTH.md` に「DPoP & HTTP Cache Interaction」サブセクション追加 (#1057)
 
 ### 2026-04-28
-- **セキュリティ強化**: Security Audit Group 1 — Cache-Control / ETag の即値強化 (#1055)
-  - **#1047: 共有キャッシュ汚染防止** — data エンドポイントの `Cache-Control` を `no-cache` から `private, no-cache` に変更。RFC 7234 §5.2.2.6 の `private` で CloudFront / 中間プロキシ / ISP プロキシでの保存を禁止し、ブラウザ等の private cache のみを許容。`Authorization` 付きレスポンスがブラウザ disk cache に乗らない問題 (Chrome/Safari の挙動) も同時に解消 (#1055)
-  - **#1051: テナント間 ETag 衝突防止** — `deriveEtagScope(event)` の seed に `Fiware-Service` + `Fiware-ServicePath` を追加。Vary が壊れた中間キャッシュ越しでも ETag 値そのものがテナント / サブテナント間で必ず異なることを保証。`Authorization` / `X-Api-Key` は seed に含めない (同テナント内の別ユーザは 304 で帯域節約できるべきで、テナント seed が認可境界として十分) (#1055)
-  - **テスト** (#1055): cache-control middleware unit test に scope 検証 4 ケース追加 (cross-tenant / cross-servicePath / case-insensitive header lookup)。`http-cache-control.feature` に `@issue-1047` シナリオ 3 件、`@issue-1051` シナリオ 3 件追加
-  - **ドキュメント** (#1055): `docs/API.md`, `docs/API_NGSIV2.md`, `docs/API_NGSILD.md`, `docs/INSTRUCTION.md`, `docs/SECURITY.md` に `private, no-cache` ポリシーと tenant-scoped ETag を反映
+
+
+* **セキュリティ強化**: Security Audit Group 2 — 認可整合性 (#1056)
+  
+  * **#1049: HMAC ベース ETag** — ETag 生成を `createHash` から `createHmac(algo, secret)` に変更。鍵は `ETAG_HMAC_SECRET` 環境変数から取得し、本番 (`ENVIRONMENT='prod'`) では未設定なら fail-fast で起動失敗。dev/test では documented なフォールバックを使う。これまで決定的だった ETag が攻撃者に再現不能化され、`If-None-Match` 試行による `modifiedAt` / 件数ブラインド情報リークを根本的に排除。同テナント内の正規ユーザは同じ鍵で計算されるため 304 帯域節約は維持 (#1056)
+    
+  * **#1050: XACML ポリシー Revoke 後のキャッシュ整合性** — handler の評価順 (`requireAuthz` → controller → `evaluateConditionalRequest`) を unit test で固定 (jest `invocationCallOrder` で controller 含めた順序を検証)。`requireAuthz` が throw した場合、catch 経路が 4xx を返し controller / `evaluateConditionalRequest` を経由しないため、認可剥奪後に旧 ETag の `If-None-Match` が 304 で旧 view を resurface することはない。E2E では実 ETag を取得後に認証/テナントを変更して投げ直し、4xx が返ることを検証 (#1056)
+    
+  * **テスト**: cache-control middleware unit test に HMAC 関連 6 ケース追加 (異なる secret / 同 secret stable / 環境変数 fallback / prod fail-fast / prod with secret OK)。handler unit test に `#1050` regression test 2 ケース追加 (controller 未呼び出し検証 + invocationCallOrder で順序固定)。`policy-enforcement.feature` に `@issue-1050` シナリオ 2 件追加 (実 ETag を取得 → 認証クリア / 別テナントへの切替後 INM が 304 にならず 4xx) (#1056)
+    
+  * **ドキュメント**: `docs/AUTH.md` に「Policy Propagation Delay & HTTP Cache Integrity」セクション新設 (PolicyService cache TTL: 60s 仕様化)。`docs/SECURITY.md` に「HMAC-Based ETag」「Policy Revocation & Cache Integrity」サブセクション追加。`docs/ENV.md` / `infrastructure/template.yaml` に `ETAG_HMAC_SECRET` 追加 (#1056)
+
+### 2026-04-28
+
+
+* **セキュリティ強化**: Security Audit Group 1 — Cache-Control / ETag の即値強化 (#1055)
+  
+  * **#1047: 共有キャッシュ汚染防止** — data エンドポイントの `Cache-Control` を `no-cache` から `private, no-cache` に変更。RFC 7234 §5.2.2.6 の `private` で CloudFront / 中間プロキシ / ISP プロキシでの保存を禁止し、ブラウザ等の private cache のみを許容。`Authorization` 付きレスポンスがブラウザ disk cache に乗らない問題 (Chrome/Safari の挙動) も同時に解消 (#1055)
+    
+  * **#1051: テナント間 ETag 衝突防止** — `deriveEtagScope(event)` の seed に `Fiware-Service` + `Fiware-ServicePath` を追加。Vary が壊れた中間キャッシュ越しでも ETag 値そのものがテナント / サブテナント間で必ず異なることを保証。`Authorization` / `X-Api-Key` は seed に含めない (同テナント内の別ユーザは 304 で帯域節約できるべきで、テナント seed が認可境界として十分) (#1055)
+    
+  * **テスト** (#1055): cache-control middleware unit test に scope 検証 4 ケース追加 (cross-tenant / cross-servicePath / case-insensitive header lookup)。`http-cache-control.feature` に `@issue-1047` シナリオ 3 件、`@issue-1051` シナリオ 3 件追加
+    
+  * **ドキュメント** (#1055): `docs/API.md`, `docs/API_NGSIV2.md`, `docs/API_NGSILD.md`, `docs/INSTRUCTION.md`, `docs/SECURITY.md` に `private, no-cache` ポリシーと tenant-scoped ETag を反映
 
 ### 2026-04-27
-- **セキュリティ / バグ修正**: HTTP キャッシュコントロール監査で検出した 4 件のバグを修正 (#1054)
-  - **B-1: Accept ヘッダー違いで body が異なるのに ETag 同一** — `Accept: application/json` (257B) と `application/ld+json` (476B、`@context` 含む) で body は明確に異なるが ETag が完全一致する weak validator 違反 (RFC 7232 §2.3.3)。shared cache が cross-Accept で 304 を返し、クライアントが間違った形式の body を replay する誤動作を確認 (#1054)
-  - **B-2: 別エンドポイント間で空リスト ETag が衝突** — `/v2/subscriptions` と `/ngsi-ld/v1/csourceRegistrations` 等が共に空 (count=0) のとき同一 ETag。subscription の ETag を csourceRegistrations の `If-None-Match` に投げると 304 が返り、URL を cache key に使わない中間層で誤配信されうる (#1054)
-  - **B-3: HEAD メソッドが 405** — RFC 7231 §4.3.2 違反。HEAD は GET 対応リソースで MUST サポートだが、ルーティング層で全 GET エンドポイントが 405 を返していた (#1054)
-  - **B-4: temporal endpoint が cache control middleware の管轄外** — `/ngsi-ld/v1/temporal/entities` 系が `Cache-Control` も `Vary` も付けずに返していた (#1054)
-  - **対策実装** (#1054):
-    - `cache-control.middleware.ts` — `deriveEtagScope(event)` を新設し、ETag 計算 seed に `path + Accept` を混ぜることで B-1 / B-2 を一括解消。`createListEtagBuilder(scope)` / `generateEntityEtag(scope, modifiedAt)` シグネチャ変更
-    - 全 controller (NGSIv2/NGSI-LD の entities / subscriptions / registrations / csource-subscriptions) が `deriveEtagScope(event)` を渡すよう更新
-    - `handlers/api/index.ts` — HEAD リクエストを内部で GET にフォールバックし、`addCorsHeaders` ラッパーで最終 body を抑止 (成功・エラー両経路)
-    - `temporal.controller.ts` の GET 4 経路に `applyCachePolicy('data')` を適用
-    - `local-server.ts` — Express の自動 ETag 生成を `app.set('etag', false)` で無効化。ローカル開発でも本番 (API Gateway + Lambda) と同じ挙動を再現
-    - **追加カバレッジ**: NGSIv2 / NGSI-LD の attribute-level GET エンドポイント (`/v2/entities/{id}/attrs`, `/v2/entities/{id}/attrs/{name}`, `/v2/entities/{id}/attrs/{name}/value`, `/ngsi-ld/v1/entities/{id}/attrs/{name}`) も `applyCacheHeaders` 経由で ETag/Last-Modified/Cache-Control/Vary を返すよう追加。Express auto-ETag 無効化に伴うキャッシュ無し状態を回避
-  - **テスト** (#1054): cache-control middleware unit test に scope 検証 11 ケース追加。`http-cache-control.feature` に B-1 / B-2 / B-3 / B-4 シナリオ 7 件追加。`head-requests.feature` を 200 期待形に書き換え (HEAD が GET 等価で動作することを検証)
-  - **ドキュメント** (#1054): `docs/API.md` に Temporal クラス追加、ETag scope (path + Accept) の説明追加、HEAD サポート明記、attribute-level エンドポイント追加
 
-## [0.4.0] — 2026-04-27
+
+* **セキュリティ / バグ修正**: HTTP キャッシュコントロール監査で検出した 4 件のバグを修正 (#1054)
+  
+  * **B-1: Accept ヘッダー違いで body が異なるのに ETag 同一** — `Accept: application/json` (257B) と `application/ld+json` (476B、`@context` 含む) で body は明確に異なるが ETag が完全一致する weak validator 違反 (RFC 7232 §2.3.3)。shared cache が cross-Accept で 304 を返し、クライアントが間違った形式の body を replay する誤動作を確認 (#1054)
+    
+  * **B-2: 別エンドポイント間で空リスト ETag が衝突** — `/v2/subscriptions` と `/ngsi-ld/v1/csourceRegistrations` 等が共に空 (count=0) のとき同一 ETag。subscription の ETag を csourceRegistrations の `If-None-Match` に投げると 304 が返り、URL を cache key に使わない中間層で誤配信されうる (#1054)
+    
+  * **B-3: HEAD メソッドが 405** — RFC 7231 §4.3.2 違反。HEAD は GET 対応リソースで MUST サポートだが、ルーティング層で全 GET エンドポイントが 405 を返していた (#1054)
+    
+  * **B-4: temporal endpoint が cache control middleware の管轄外** — `/ngsi-ld/v1/temporal/entities` 系が `Cache-Control` も `Vary` も付けずに返していた (#1054)
+    
+  * **対策実装** (#1054):
+    
+    * `cache-control.middleware.ts` — `deriveEtagScope(event)` を新設し、ETag 計算 seed に `path + Accept` を混ぜることで B-1 / B-2 を一括解消。`createListEtagBuilder(scope)` / `generateEntityEtag(scope, modifiedAt)` シグネチャ変更
+      
+    * 全 controller (NGSIv2/NGSI-LD の entities / subscriptions / registrations / csource-subscriptions) が `deriveEtagScope(event)` を渡すよう更新
+      
+    * `handlers/api/index.ts` — HEAD リクエストを内部で GET にフォールバックし、`addCorsHeaders` ラッパーで最終 body を抑止 (成功・エラー両経路)
+      
+    * `temporal.controller.ts` の GET 4 経路に `applyCachePolicy('data')` を適用
+      
+    * `local-server.ts` — Express の自動 ETag 生成を `app.set('etag', false)` で無効化。ローカル開発でも本番 (API Gateway + Lambda) と同じ挙動を再現
+      
+    * **追加カバレッジ**: NGSIv2 / NGSI-LD の attribute-level GET エンドポイント (`/v2/entities/{id}/attrs`, `/v2/entities/{id}/attrs/{name}`, `/v2/entities/{id}/attrs/{name}/value`, `/ngsi-ld/v1/entities/{id}/attrs/{name}`) も `applyCacheHeaders` 経由で ETag/Last-Modified/Cache-Control/Vary を返すよう追加。Express auto-ETag 無効化に伴うキャッシュ無し状態を回避
+      
+  * **テスト** (#1054): cache-control middleware unit test に scope 検証 11 ケース追加。`http-cache-control.feature` に B-1 / B-2 / B-3 / B-4 シナリオ 7 件追加。`head-requests.feature` を 200 期待形に書き換え (HEAD が GET 等価で動作することを検証)
+    
+  * **ドキュメント** (#1054): `docs/API.md` に Temporal クラス追加、ETag scope (path + Accept) の説明追加、HEAD サポート明記、attribute-level エンドポイント追加
+
+## \[0.4.0] — 2026-04-27
 
 ### 2026-04-27
-- **Feature**: SDK クライアントキャッシュ Phase A — `@geolonia/geonicdb-sdk` に in-memory cache + ETag/304 自動ハンドリング + リクエスト重複排除 + ETag ベースの `poll()` API を追加 (#1043)
-  - `src/sdk/cache.ts` — `SdkCache` (LRU、`maxEntries` 制限、URL+method キーで `etag` / `lastModified` / `data` / `headers` を保持) (#1043)
-  - `src/sdk/auth.ts` `request()` — GET / HEAD では cache 経由で `If-None-Match` / `If-Modified-Since` を自動付与し、304 受信時は cached body を 200 として透過的に返却。304 で更新された validator を cache に再反映 (#1043)
-  - 同一 path への in-flight 重複リクエストを 1 つにまとめる dedup を追加 (#1043)
-  - `src/sdk/index.ts` — `db.poll(params, { interval, onData, onNoChange, onError })` を新設。ETag を比較して未変更時は転送ゼロ。`handle.stop()` で停止。`interval` の入力検証あり (#1043)
-  - WebSocket の `entityCreated` / `entityUpdated` / `entityDeleted` 受信時にキャッシュを自動無効化 (#1043)
-  - 認証コンテキスト (`login()` / `setCredentials()` / `logout()`) の切替時に cache + in-flight dedup を自動破棄 — クロスユーザー漏洩対策 (#1043)
-  - `GeonicDBOptions` に `cache` / `cacheMaxEntries`、`GeonicDBEventMap` に `cacheHit` / `cacheMiss` / `cacheInvalidated` を追加 (#1043)
-  - SDK 設定値 (`SDK_CACHE_MAX_ENTRIES_DEFAULT` / `SDK_POLL_INTERVAL_MS_DEFAULT`) を `src/config/defaults.ts` に集約 (#1043)
-  - `docs/SDK.md` / `src/sdk/README.md` 更新 (#1043)
-  - Phase B (Service Worker + オフラインファースト) は #1044 で対応予定 (#1043)
-- **Chore**: 依存関係の一括アップデート — 12 個の Dependabot PR をまとめて適用
-  - npm: `@cucumber/cucumber` 12.8.1→12.8.2, `eslint` 10.2.0→10.2.1, `mongodb` 7.1.1→7.2.0, `@opentelemetry/auto-instrumentations-node` 0.72.0→0.73.0, `@opentelemetry/exporter-trace-otlp-http` 0.214.0→0.215.0, `typescript-eslint` 8.58.2→8.59.0, `@aws-sdk/*` 3.1032.0→3.1037.0 (9 パッケージ)
-  - GitHub Actions: `docker/setup-qemu-action` v3→v4, `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/metadata-action` v5→v6, `docker/build-push-action` v6→v7
-  - `typescript-eslint` 8.59.0 で新しく検出された `no-unnecessary-type-assertion` を `eslint --fix` で一括修正、`no-base-to-string` 違反を `isSimpleValue` の型ガード化で解消、未使用 import 3 件を削除
-- **Fix**: `GET /v2/entities/{entityId}` および `GET /ngsi-ld/v1/entities/{entityId}` に entity-level XACML 認可チェック (`checkEntityOwnership`) が抜けていた既存問題を修正 (#1028)
-  - XACML 統合 (#748) リファクタリング後の漏れ。他の操作 (PATCH/PUT/DELETE/属性取得) では呼ばれていたが、GET 単一取得だけ不在だった (#1028)
-  - 影響: entity-level policy (`resource.entityId` / `resource.entityOwner` ベース) が GET で無視され、Phase 2 の cache control と組み合わさると認可剥奪後も 304 で古いキャッシュが返るリスクがあった (#1028)
-  - 修正: NGSIv2 / NGSI-LD の `getEntity` で `await this.checkEntityOwnership(...)` を呼ぶよう追加。E2E に「entity-level Deny → 403」「Permit → ETag → policy 更新で Deny → If-None-Match で 403 (304 ではない)」の 2 シナリオ追加 (#1028)
-  - 同時に entity-ownership.feature と instruction.feature の `deny-non-owner-write` ポリシーで `target.actions` が指定されておらず GET にも誤って Deny が効いてしまっていた既存の policy 設計の不備を修正。`PATCH/PUT/DELETE` のみに限定 (#1028)
-- **Feature**: HTTP キャッシュコントロール Phase 2 — レスポンスに `Cache-Control` / `Vary` ヘッダーを付与し、エンドポイント別ポリシーとクライアント主導 `no-store` 上書きをサポート (#989)
-  - data API (entities / subscriptions / registrations / csourceSubscriptions): `Cache-Control: no-cache` (#989)
-  - meta API (types / attributes): `Cache-Control: max-age=60, stale-while-revalidate=120` (#989)
-  - 全レスポンスに `Vary: Fiware-Service, Fiware-ServicePath, Authorization, Accept` を付与し、CloudFront 等のエッジキャッシュでテナント分離を保証 (#989)
-  - クライアントが `Cache-Control: no-store` リクエストヘッダーを送信した場合、レスポンスの `Cache-Control` を `no-store` で上書き (#989)
-  - `applyCachePolicy()` ヘルパー追加。ETag を持たない API (types / attributes) にも Cache-Control + Vary を一貫して適用 (#989)
-- **Feature**: HTTP キャッシュコントロール Phase 1 — GET エンドポイントに `ETag` / `Last-Modified` を導入し、`If-None-Match` / `If-Modified-Since` による条件付きリクエスト (304 Not Modified) をサポート (#1026)
-  - 対象: `/v2/entities`, `/v2/subscriptions`, `/v2/registrations`, `/ngsi-ld/v1/entities`, `/ngsi-ld/v1/subscriptions`, `/ngsi-ld/v1/csourceRegistrations`, `/ngsi-ld/v1/csourceSubscriptions` の一覧 / 単一取得 (#1026)
-  - リスト用 ETag は各要素の `id + modifiedAt` のストリーミングハッシュ + 総件数のダイジェスト (RFC 7232 §2.3.2 weak validator として正確)、単一用 ETag は `modifiedAt` のハッシュ (#1026)
-  - `fresh` モジュールで RFC 7232 準拠の評価 (弱い ETag、ワイルドカード、HTTP-date) (#1026)
-  - 304 レスポンスは ETag / Last-Modified / Cache-Control / Vary / CORS / 相関 ID / トレースを保持 (#1026)
-- **Feature**: A2A (Agent-to-Agent) プロトコル Phase 1 対応 (#1025)
-  - `GET /.well-known/agent-card.json` — Agent Card 配信 (5 スキル: entities, batch, temporal, config, admin) (#1025)
-  - `POST /a2a` — JSON-RPC 2.0 エンドポイント。`message/send`, `tasks/get`, `tasks/list`, `tasks/cancel` メソッドに対応 (#1025)
-  - MongoDB `a2aTasks` コレクションによる Task 状態管理 (ライフサイクル: submitted → working → completed/failed/canceled、TTL 30 日) (#1025)
-  - 既存 MCP ツール 5 つを A2A スキルにマッピング。サービス層を直接呼び出し (#1025)
-  - `@a2a-js/sdk` v0.3.13 を活用 (`JsonRpcTransportHandler` + `DefaultRequestHandler`) (#1025)
 
-## [0.3.0] — 2026-04-24
+
+* **Feature**: SDK クライアントキャッシュ Phase A — `@geolonia/geonicdb-sdk` に in-memory cache + ETag/304 自動ハンドリング + リクエスト重複排除 + ETag ベースの `poll()` API を追加 (#1043)
+  
+  * `src/sdk/cache.ts` — `SdkCache` (LRU、`maxEntries` 制限、URL+method キーで `etag` / `lastModified` / `data` / `headers` を保持) (#1043)
+    
+  * `src/sdk/auth.ts` `request()` — GET / HEAD では cache 経由で `If-None-Match` / `If-Modified-Since` を自動付与し、304 受信時は cached body を 200 として透過的に返却。304 で更新された validator を cache に再反映 (#1043)
+    
+  * 同一 path への in-flight 重複リクエストを 1 つにまとめる dedup を追加 (#1043)
+    
+  * `src/sdk/index.ts` — `db.poll(params, { interval, onData, onNoChange, onError })` を新設。ETag を比較して未変更時は転送ゼロ。`handle.stop()` で停止。`interval` の入力検証あり (#1043)
+    
+  * WebSocket の `entityCreated` / `entityUpdated` / `entityDeleted` 受信時にキャッシュを自動無効化 (#1043)
+    
+  * 認証コンテキスト (`login()` / `setCredentials()` / `logout()`) の切替時に cache + in-flight dedup を自動破棄 — クロスユーザー漏洩対策 (#1043)
+    
+  * `GeonicDBOptions` に `cache` / `cacheMaxEntries`、`GeonicDBEventMap` に `cacheHit` / `cacheMiss` / `cacheInvalidated` を追加 (#1043)
+    
+  * SDK 設定値 (`SDK_CACHE_MAX_ENTRIES_DEFAULT` / `SDK_POLL_INTERVAL_MS_DEFAULT`) を `src/config/defaults.ts` に集約 (#1043)
+    
+  * `docs/SDK.md` / `src/sdk/README.md` 更新 (#1043)
+    
+  * Phase B (Service Worker + オフラインファースト) は #1044 で対応予定 (#1043)
+    
+* **Chore**: 依存関係の一括アップデート — 12 個の Dependabot PR をまとめて適用
+  
+  * npm: `@cucumber/cucumber` 12.8.1→12.8.2, `eslint` 10.2.0→10.2.1, `mongodb` 7.1.1→7.2.0, `@opentelemetry/auto-instrumentations-node` 0.72.0→0.73.0, `@opentelemetry/exporter-trace-otlp-http` 0.214.0→0.215.0, `typescript-eslint` 8.58.2→8.59.0, `@aws-sdk/*` 3.1032.0→3.1037.0 (9 パッケージ)
+    
+  * GitHub Actions: `docker/setup-qemu-action` v3→v4, `docker/setup-buildx-action` v3→v4, `docker/login-action` v3→v4, `docker/metadata-action` v5→v6, `docker/build-push-action` v6→v7
+    
+  * `typescript-eslint` 8.59.0 で新しく検出された `no-unnecessary-type-assertion` を `eslint --fix` で一括修正、`no-base-to-string` 違反を `isSimpleValue` の型ガード化で解消、未使用 import 3 件を削除
+    
+* **Fix**: `GET /v2/entities/{entityId}` および `GET /ngsi-ld/v1/entities/{entityId}` に entity-level XACML 認可チェック (`checkEntityOwnership`) が抜けていた既存問題を修正 (#1028)
+  
+  * XACML 統合 (#748) リファクタリング後の漏れ。他の操作 (PATCH/PUT/DELETE/属性取得) では呼ばれていたが、GET 単一取得だけ不在だった (#1028)
+    
+  * 影響: entity-level policy (`resource.entityId` / `resource.entityOwner` ベース) が GET で無視され、Phase 2 の cache control と組み合わさると認可剥奪後も 304 で古いキャッシュが返るリスクがあった (#1028)
+    
+  * 修正: NGSIv2 / NGSI-LD の `getEntity` で `await this.checkEntityOwnership(...)` を呼ぶよう追加。E2E に「entity-level Deny → 403」「Permit → ETag → policy 更新で Deny → If-None-Match で 403 (304 ではない)」の 2 シナリオ追加 (#1028)
+    
+  * 同時に entity-ownership.feature と instruction.feature の `deny-non-owner-write` ポリシーで `target.actions` が指定されておらず GET にも誤って Deny が効いてしまっていた既存の policy 設計の不備を修正。`PATCH/PUT/DELETE` のみに限定 (#1028)
+    
+* **Feature**: HTTP キャッシュコントロール Phase 2 — レスポンスに `Cache-Control` / `Vary` ヘッダーを付与し、エンドポイント別ポリシーとクライアント主導 `no-store` 上書きをサポート (#989)
+  
+  * data API (entities / subscriptions / registrations / csourceSubscriptions): `Cache-Control: no-cache` (#989)
+    
+  * meta API (types / attributes): `Cache-Control: max-age=60, stale-while-revalidate=120` (#989)
+    
+  * 全レスポンスに `Vary: Fiware-Service, Fiware-ServicePath, Authorization, Accept` を付与し、CloudFront 等のエッジキャッシュでテナント分離を保証 (#989)
+    
+  * クライアントが `Cache-Control: no-store` リクエストヘッダーを送信した場合、レスポンスの `Cache-Control` を `no-store` で上書き (#989)
+    
+  * `applyCachePolicy()` ヘルパー追加。ETag を持たない API (types / attributes) にも Cache-Control + Vary を一貫して適用 (#989)
+    
+* **Feature**: HTTP キャッシュコントロール Phase 1 — GET エンドポイントに `ETag` / `Last-Modified` を導入し、`If-None-Match` / `If-Modified-Since` による条件付きリクエスト (304 Not Modified) をサポート (#1026)
+  
+  * 対象: `/v2/entities`, `/v2/subscriptions`, `/v2/registrations`, `/ngsi-ld/v1/entities`, `/ngsi-ld/v1/subscriptions`, `/ngsi-ld/v1/csourceRegistrations`, `/ngsi-ld/v1/csourceSubscriptions` の一覧 / 単一取得 (#1026)
+    
+  * リスト用 ETag は各要素の `id + modifiedAt` のストリーミングハッシュ + 総件数のダイジェスト (RFC 7232 §2.3.2 weak validator として正確)、単一用 ETag は `modifiedAt` のハッシュ (#1026)
+    
+  * `fresh` モジュールで RFC 7232 準拠の評価(弱い ETag、ワイルドカード、HTTP-date)(#1026)
+    
+  * 304 レスポンスは ETag / Last-Modified / Cache-Control / Vary / CORS / 相関 ID / トレースを保持 (#1026)
+    
+* **Feature**: A2A (Agent-to-Agent) プロトコル Phase 1 対応 (#1025)
+  
+  * `GET /.well-known/agent-card.json` — Agent Card 配信(5 スキル: entities, batch, temporal, config, admin)(#1025)
+    
+  * `POST /a2a` — JSON-RPC 2.0 エンドポイント。`message/send`, `tasks/get`, `tasks/list`, `tasks/cancel` メソッドに対応 (#1025)
+    
+  * MongoDB `a2aTasks` コレクションによる Task 状態管理(ライフサイクル: submitted → working → completed/failed/canceled、TTL 30 日)(#1025)
+    
+  * 既存 MCP ツール 5 つを A2A スキルにマッピング。サービス層を直接呼び出し (#1025)
+    
+  * `@a2a-js/sdk` v0.3.13 を活用(`JsonRpcTransportHandler` + `DefaultRequestHandler`)(#1025)
+
+## \[0.3.0] — 2026-04-24
 
 ### 2026-04-24
-- **Feature**: カスタムデータモデルに `additionalProperties` フィールドを追加。`false` 指定でモデル未定義の属性を拒否する厳格モードを有効化。デフォルトは `true` (NGSI-LD の自然な挙動を維持) (#1007)
-- **Feature**: SDK に型付きエラークラスを導入。`GeonicDBError` 基底クラスと `AuthenticationError`, `AuthorizationError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `NetworkError` を追加。`instanceof` でエラー種別を判定可能に (#1008)
-- **Feature**: SDK WebSocket イベント (`entityCreated`/`entityUpdated`/`entityDeleted`) に `entity` フィールドを追加。`id` + `type` + `data` から構築した完全な NGSI-LD エンティティオブジェクトを直接取得可能に (#1009)
-- **Feature**: SDK に `debug` オプションを追加。有効時に HTTP リクエスト/レスポンス、WebSocket 接続・イベント、トークンリフレッシュをコンソールにログ出力 (#1010)
+
+
+* **Feature**: カスタムデータモデルに `additionalProperties` フィールドを追加。`false` 指定でモデル未定義の属性を拒否する厳格モードを有効化。デフォルトは `true`(NGSI-LD の自然な挙動を維持)(#1007)
+  
+* **Feature**: SDK に型付きエラークラスを導入。`GeonicDBError` 基底クラスと `AuthenticationError`, `AuthorizationError`, `NotFoundError`, `ConflictError`, `ValidationError`, `RateLimitError`, `NetworkError` を追加。`instanceof` でエラー種別を判定可能に (#1008)
+  
+* **Feature**: SDK WebSocket イベント(`entityCreated`/`entityUpdated`/`entityDeleted`)に `entity` フィールドを追加。`id` + `type` + `data` から構築した完全な NGSI-LD エンティティオブジェクトを直接取得可能に (#1009)
+  
+* **Feature**: SDK に `debug` オプションを追加。有効時に HTTP リクエスト/レスポンス、WebSocket 接続・イベント、トークンリフレッシュをコンソールにログ出力 (#1010)
 
 ### 2026-04-23
-- **Feature**: ReactiveCore Rules のクロスプロトコル エンティティ生成 (#1004)
-  - `createEntity` / `updateAttribute` / `deleteAttribute` アクションに `protocol` フィールドを追加（NGSIv2 ↔ NGSI-LD の壁を越えた操作が可能に）
-  - `createEntity` に `servicePath` / `scope` フィールドを追加（ターゲットの階層パスを制御）
-  - servicePath ↔ scope の自動マッピング（NGSIv2 `/sensors` → NGSI-LD `["/sensors"]`）
-  - `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` テンプレート変数を追加
-  - Change Stream ハンドラが EntityDocument の `protocol` / `scope` をルールエンジンに伝播するよう修正
-- **Improve**: WAF カスタムルール（RateLimitPerIP、SizeRestrictionBody10MB）にカスタムレスポンスを追加。アプリケーション互換の JSON エラーボディと適切な HTTP ステータスコード（429/413）を返すように改善 (#986)
-- **Feature**: WAF ロギング設定を追加。BLOCK/COUNT アクションのみ記録し、マネージドルールのブロック原因をトレース可能に (#986)
+
+
+* **Feature**: ReactiveCore Rules のクロスプロトコル エンティティ生成 (#1004)
+  
+  * `createEntity` / `updateAttribute` / `deleteAttribute` アクションに `protocol` フィールドを追加(NGSIv2 ↔ NGSI-LD の壁を越えた操作が可能に)
+    
+  * `createEntity` に `servicePath` / `scope` フィールドを追加(ターゲットの階層パスを制御)
+    
+  * servicePath ↔ scope の自動マッピング(NGSIv2 `/sensors` → NGSI-LD `["/sensors"]`)
+    
+  * `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` テンプレート変数を追加
+    
+  * Change Stream ハンドラが EntityDocument の `protocol` / `scope` をルールエンジンに伝播するよう修正
+    
+* **Improve**: WAF カスタムルール(RateLimitPerIP、SizeRestrictionBody10MB)にカスタムレスポンスを追加。アプリケーション互換の JSON エラーボディと適切な HTTP ステータスコード(429/413)を返すように改善 (#986)
+  
+* **Feature**: WAF ロギング設定を追加。BLOCK/COUNT アクションのみ記録し、マネージドルールのブロック原因をトレース可能に (#986)
 
 ### 2026-04-21
-- **Fix**: WAF `SizeRestrictionBody10MB` ルールの `OversizeHandling: MATCH` により 8 KB 超のリクエストが全て 403 Forbidden になる問題を修正 (#983)
+
+
+* **Fix**: WAF `SizeRestrictionBody10MB` ルールの `OversizeHandling: MATCH` により 8KB 超のリクエストが全て 403 Forbidden になる問題を修正 (#983)
 
 ### 2026-04-18
-- **Breaking**: NGSIv2 と NGSI-LD のエンティティ分離・仕様準拠 (#966)
-  - **プロトコルベースのエンティティ分離**: NGSIv2 で作成したエンティティは NGSIv2 からのみ、NGSI-LD で作成したエンティティは NGSI-LD からのみアクセス可能に
-  - NGSI-LD API で `Fiware-ServicePath` ヘッダーを無視するよう修正（ETSI GS CIM 009 仕様準拠）
-  - servicePath と scope を独立した概念として維持
-  - NGSIv2 `servicePath` built-in attribute を追加（`?attrs=servicePath` で取得可能）
-  - 既存エンティティ（`protocol` フィールドなし）は NGSI-LD 扱い
+
+
+* **Breaking**: NGSIv2 と NGSI-LD のエンティティ分離・仕様準拠 (#966)
+  
+  * **プロトコルベースのエンティティ分離**: NGSIv2 で作成したエンティティは NGSIv2 からのみ、NGSI-LD で作成したエンティティは NGSI-LD からのみアクセス可能に
+    
+  * NGSI-LD API で `Fiware-ServicePath` ヘッダーを無視するよう修正(ETSI GS CIM 009 仕様準拠)
+    
+  * servicePath と scope を独立した概念として維持
+    
+  * NGSIv2 `servicePath` built-in attribute を追加(`?attrs=servicePath` で取得可能)
+    
+  * 既存エンティティ(`protocol` フィールドなし)は NGSI-LD 扱い
 
 ### 2026-04-14
-- **Release**: SDK v0.2.0 — `count()` と `requestRaw()` メソッドを追加 (#928)
-- **Change**: SDK ライセンスを AGPL-3.0 から MIT に変更（本体は AGPL-3.0 のまま） (#942)
-- **Remove**: 内蔵 SDK 配信エンドポイント（`/sdk/v1/geonicdb.js`、`/sdk/v1/geonicdb.d.ts`）を削除。npm / unpkg CDN から取得する方式に統一 (#942)
+
+
+* **Release**: SDK v0.2.0 — `count()` と `requestRaw()` メソッドを追加 (#928)
+  
+* **Change**: SDK ライセンスを AGPL-3.0 から MIT に変更(本体は AGPL-3.0 のまま)(#942)
+  
+* **Remove**: 内蔵 SDK 配信エンドポイント(`/sdk/v1/geonicdb.js`、`/sdk/v1/geonicdb.d.ts`)を削除。npm / unpkg CDN から取得する方式に統一 (#942)
 
 ### 2026-04-10
-- **Fix**: ユニークインデックスをテナントスコープ化 — policies、policySets、apiKeys、oauthClients、rules の ID がテナント内で一意に変更。異なるテナント間で同一 ID を使用可能に (#896)
-- **Feature**: MCP ツールの NGSI-LD クエリパラメータを大幅拡張 (#898)
-  - `entities` ツール: `idList`、`idPattern`、`orderBy`、`orderDirection`、`sysAttrs`、`pick`、`omit`、`scopeQ`、`lang`、`geoproperty`、`spatialId`、`spatialIdDepth` を追加
-  - `batch` ツールの `query` アクション: `orderBy`、`orderDirection`、`sysAttrs` を追加
-  - `entityToKeyValues` に `sysAttrs`（`createdAt`/`modifiedAt` 出力）と `distance` 出力を追加
-  - `orderBy` の `!` プレフィックスによる降順指定をサポート
-  - CSV パラメータの空要素フィルタリングを追加
-  - MCP ツールを NGSI-LD に統一（NGSIv2 固有パラメータ `mq`、`typePattern` を削除）
-  - `/tools.json` AI ディスカバリーエンドポイントを同期
+
+
+* **Fix**: ユニークインデックスをテナントスコープ化 — policies、policySets、apiKeys、oauthClients、rules の ID がテナント内で一意に変更。異なるテナント間で同一 ID を使用可能に (#896)
+  
+* **Feature**: MCP ツールの NGSI-LD クエリパラメータを大幅拡張 (#898)
+  
+  * `entities` ツール: `idList`、`idPattern`、`orderBy`、`orderDirection`、`sysAttrs`、`pick`、`omit`、`scopeQ`、`lang`、`geoproperty`、`spatialId`、`spatialIdDepth` を追加
+    
+  * `batch` ツールの `query` アクション: `orderBy`、`orderDirection`、`sysAttrs` を追加
+    
+  * `entityToKeyValues` に `sysAttrs`(`createdAt`/`modifiedAt` 出力)と `distance` 出力を追加
+    
+  * `orderBy` の `!` プレフィックスによる降順指定をサポート
+    
+  * CSV パラメータの空要素フィルタリングを追加
+    
+  * MCP ツールを NGSI-LD に統一(NGSIv2 固有パラメータ `mq`、`typePattern` を削除)
+    
+  * `/tools.json` AI ディスカバリーエンドポイントを同期
 
 ### 2026-04-09
-- SDK を TypeScript で書き直し、npm パッケージ `@geolonia/geonicdb-sdk` として公開可能に
-- Types/Attributes Discovery、Temporal API、Batch Operations の convenience methods を追加 (#832)
-- `setCredentials()` の `expiresIn: 0` が無視されるバグを修正 (#876)
+
+
+* SDK を TypeScript で書き直し、npm パッケージ `@geolonia/geonicdb-sdk` として公開可能に
+  
+* Types/Attributes Discovery、Temporal API、Batch Operations の convenience methods を追加 (#832)
+  
+* `setCredentials()` の `expiresIn: 0` が無視されるバグを修正 (#876)
 
 ### 2026-04-08
-- **Feature**: カスタムデータモデルの JSON-LD `@context` URI 改善 (#858)
-  - `propertyDetails` に `@context` フィールドを追加（既存語彙 URL の指定が可能に）
-  - 自動生成 URI を URN → URL に移行（`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`）
-  - 属性 URI をエンティティタイプから独立させ、テナント内で再利用可能に
-  - MCP ツール / llms.txt / openapi.json に schema.org 語彙サジェスト指示を追加
+
+
+* **Feature**: カスタムデータモデルの JSON-LD `@context` URI 改善 (#858)
+  
+  * `propertyDetails` に `@context` フィールドを追加(既存語彙 URL の指定が可能に)
+    
+  * 自動生成 URI を URN → URL に移行(`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
+    
+  * 属性 URI をエンティティタイプから独立させ、テナント内で再利用可能に
+    
+  * MCP ツール / llms.txt / openapi.json に schema.org 語彙サジェスト指示を追加
 
 ### 2026-04-07
-- **Fix**: 不正な GeoJSON データが存在する場合のインデックス初期化失敗を自動回復 — 問題のあるエンティティを隔離して `2dsphere` インデックスを再構築 (#857)
-- **Fix**: WAF `EC2MetaDataSSRF_BODY` ルールが `allowedOrigins` 内の `localhost` URL を SSRF として誤検知しブロックする問題を修正 (#848)
-- **Fix**: WAF `CrossSiteScripting_BODY` ルールが `allowedOrigins` 内の URL を XSS と誤検知し API キー作成が 403 になる問題を修正 (#846)
+
+
+* **Fix**: 不正な GeoJSON データが存在する場合のインデックス初期化失敗を自動回復 — 問題のあるエンティティを隔離して `2dsphere` インデックスを再構築 (#857)
+  
+* **Fix**: WAF `EC2MetaDataSSRF_BODY` ルールが `allowedOrigins` 内の `localhost` URL を SSRF として誤検知しブロックする問題を修正 (#848)
+  
+* **Fix**: WAF `CrossSiteScripting_BODY` ルールが `allowedOrigins` 内の URL を XSS と誤検知し API キー作成が 403 になる問題を修正 (#846)
 
 ### 2026-04-05
-- **Breaking**: `onTokenRefresh(callback)` を廃止し `on('tokenRefresh', cb)` イベントに統一 (#831)
-- **Change**: `request()` がエラーチェック + JSON パース済みの値を返すように変更（生 Response → `Promise<Object|string|null>`） (#831)
-- **Feature**: `GET /sdk/v1/geonicdb.d.ts` エンドポイントを追加 — TypeScript 型定義を配信 (#831)
-- **Docs**: `setCredentials()` で Bearer + refreshToken を指定すると DPoP/PoW を完全にバイパスする旨を明記 (#831)
+
+
+* **Breaking**: `onTokenRefresh(callback)` を廃止し `on('tokenRefresh', cb)` イベントに統一 (#831)
+  
+* **Change**: `request()` がエラーチェック + JSON パース済みの値を返すように変更(生 Response → `Promise<Object|string|null>`) (#831)
+  
+* **Feature**: `GET /sdk/v1/geonicdb.d.ts` エンドポイントを追加 — TypeScript 型定義を配信 (#831)
+  
+* **Docs**: `setCredentials()` で Bearer + refreshToken を指定すると DPoP/PoW を完全にバイパスする旨を明記 (#831)
 
 ### 2026-04-04
-- **Feature**: JavaScript SDK に公開 API メソッドを追加 — 内部メソッドへの依存を排除 (#830)
-  - `setCredentials()`: 外部認証トークンの注入（Bearer JWT セッション等） (#830)
-  - `onTokenRefresh(callback)`: トークンリフレッシュ時のコールバック登録 (#830)
-  - `request(method, path, body)`: 認証付き汎用 API リクエスト (#830)
-  - `reconnect()`: WebSocket 強制再接続 (#830)
-  - `isConnected()`: WebSocket 接続状態の確認 (#830)
-  - WebSocket ライフサイクルイベント追加: `connected`, `disconnected`, `reconnecting` (#830)
-  - SDK ファイル冒頭に JSDoc 型定義を埋め込み — AI コーディングアシスタントが自動的に全 API を把握可能 (#830)
+
+
+* **Feature**: JavaScript SDK に公開 API メソッドを追加 — 内部メソッドへの依存を排除 (#830)
+  
+  * `setCredentials()`: 外部認証トークンの注入(Bearer JWT セッション等) (#830)
+    
+  * `onTokenRefresh(callback)`: トークンリフレッシュ時のコールバック登録 (#830)
+    
+  * `request(method, path, body)`: 認証付き汎用 API リクエスト (#830)
+    
+  * `reconnect()`: WebSocket 強制再接続 (#830)
+    
+  * `isConnected()`: WebSocket 接続状態の確認 (#830)
+    
+  * WebSocket ライフサイクルイベント追加: `connected`, `disconnected`, `reconnecting` (#830)
+    
+  * SDK ファイル冒頭に JSDoc 型定義を埋め込み — AI コーディングアシスタントが自動的に全 API を把握可能 (#830)
 
 ### 2026-04-01
-- **Fix**: WAF `SizeRestrictions_BODY` ルールがリクエストボディ 8KB 以上で 403 Forbidden を返す問題を修正 (#813)
-  - `AWSManagedRulesCommonRuleSet` から `SizeRestrictions_BODY` を除外
-  - 代替としてカスタム 10MB ボディサイズ制限ルールを追加（API Gateway REST API 上限と一致）
+
+
+* **Fix**: WAF `SizeRestrictions_BODY` ルールがリクエストボディ 8KB 以上で 403 Forbidden を返す問題を修正 (#813)
+  
+  * `AWSManagedRulesCommonRuleSet` から `SizeRestrictions_BODY` を除外
+    
+  * 代替としてカスタム 10MB ボディサイズ制限ルールを追加(API Gateway REST API 上限と一致)
 
 ### 2026-03-25
-- **Feature**: `POST /me/api-keys/{keyId}/refresh` & `POST /admin/api-keys/{keyId}/refresh` で API キーのローテーション機能を追加 (#798)
-- **Breaking**: `keyPrefix` フィールドを `ApiKeyPublic` レスポンスから削除 (#798)
-- **Breaking**: 新規 API キーの `keyId` を `gdb_` + UUID 形式から素の UUID 形式に変更（既存キーは後方互換で維持） (#798)
-- **Change**: API キー一覧・詳細レスポンスに `key: "******"` マスク表示を追加 (#798)
-- **Perf**: コールドスタート時の初期化を並列化 — 最大 1000ms 短縮 (#775)
-  - `handlers/api/index.ts` で `resolveJwtSecret()` と `getMongoClient()` を `Promise.all` で並列実行
-  - Secrets Manager 解決（〜100-500ms）と MongoDB 接続確立（〜500-1000ms）を直列から並列に変更
-- **Security**: `updatePolicy` の TOCTOU 競合状態を Optimistic Locking で修正 (#784) (#793)
-  - `Policy`/`PolicyDocument`/`PolicyPublic` に `version: number` フィールドを追加
-  - `PolicyRepository.updatePolicy()` にバージョンフィルタ（`findOneAndUpdate` で `version` 一致確認）を追加
-  - バージョン不一致時に `ConflictError` (409) を返す
-  - 既存ドキュメント（`version` フィールドなし）は `version: 0` として移行互換対応
-- **Security**: `permit-overrides` 結合アルゴリズムを `super_admin` 以外に禁止（defense in depth） (#785) (#793)
-  - `validateCombiningAlgorithm()` に `actorRole` パラメータを追加
-  - `tenant_admin`/`user` が `permit-overrides` を指定した場合 `ForbiddenError` (403) を返す
-  - 更新時に `ruleCombiningAlgorithm` を指定しない場合も既存値（有効アルゴリズム）を検証
+
+
+* **Feature**: `POST /me/api-keys/{keyId}/refresh` & `POST /admin/api-keys/{keyId}/refresh` で API キーのローテーション機能を追加 (#798)
+  
+* **Breaking**: `keyPrefix` フィールドを `ApiKeyPublic` レスポンスから削除 (#798)
+  
+* **Breaking**: 新規 API キーの `keyId` を `gdb_` + UUID 形式から素の UUID 形式に変更(既存キーは後方互換で維持) (#798)
+  
+* **Change**: API キー一覧・詳細レスポンスに `key: "******"` マスク表示を追加 (#798)
+  
+* **Perf**: コールドスタート時の初期化を並列化 — 最大 1000ms 短縮 (#775)
+  
+  * `handlers/api/index.ts` で `resolveJwtSecret()` と `getMongoClient()` を `Promise.all` で並列実行
+    
+  * Secrets Manager 解決(\~100-500ms)と MongoDB 接続確立(\~500-1000ms)を直列から並列に変更
+    
+* **Security**: `updatePolicy` の TOCTOU 競合状態を Optimistic Locking で修正 (#784) (#793)
+  
+  * `Policy`/`PolicyDocument`/`PolicyPublic` に `version: number` フィールドを追加
+    
+  * `PolicyRepository.updatePolicy()` にバージョンフィルタ(`findOneAndUpdate` で `version` 一致確認)を追加
+    
+  * バージョン不一致時に `ConflictError` (409) を返す
+    
+  * 既存ドキュメント(`version` フィールドなし)は `version: 0` として移行互換対応
+    
+* **Security**: `permit-overrides` 結合アルゴリズムを `super_admin` 以外に禁止(defense in depth) (#785) (#793)
+  
+  * `validateCombiningAlgorithm()` に `actorRole` パラメータを追加
+    
+  * `tenant_admin`/`user` が `permit-overrides` を指定した場合 `ForbiddenError` (403) を返す
+    
+  * 更新時に `ruleCombiningAlgorithm` を指定しない場合も既存値(有効アルゴリズム)を検証
 
 ### 2026-03-24
-- **Perf**: テナントデータ二重取得の排除 (#776)
-  - `handlers/api/index.ts` のリクエストボディサイズチェックで `tenantData` を直接更新するよう修正
-  - レート制限無効かつリクエストボディあり時に、ボディチェックとレスポンスサイズチェックで計 2 回発生していた `TenantRepository.getByName()` を 1 回に削減
-- **Perf**: policyId バインドポリシーのキャッシュ追加 (#777)
-  - `PolicyCache` に `getPolicy/setPolicy` メソッドを追加（TTL: 60 秒）
-  - `PolicyService.loadBoundPolicy()` でキャッシュを参照し、カスタムポリシーを持つテナントの認証フローで MongoDB ラウンドトリップを削減
-- **Perf**: API Gateway gzip 圧縮を有効化（MinimumCompressionSize: 1024）(#791)
-  - 1KB 以上のレスポンスを自動 gzip 圧縮 — Entity リスト等で 60〜75% の転送量削減
-- **Perf**: Lambda アーキテクチャを ARM64 (Graviton2) へ移行 (#791)
-  - 全 Lambda 関数を arm64 に統一 — 約 20% の CPU 処理速度向上
-- **Perf**: Lambda メモリサイズを 256MB → 512MB に引き上げ (#791)
-  - CPU 割り当て倍増により JSON シリアライズ・MongoDB クエリ・XACML 評価を高速化
-- **Perf**: esbuild Minify を有効化してバンドルサイズを削減 (#791)
-  - 全 Lambda ハンドラのコードバンドルを minify — 推定 30〜50% サイズ削減、コールドスタート短縮
-- **Security Fix**: path 属性に対する `string-regexp` matchFunction を禁止 (#788)
-  - `validateNonEscalatingPolicy` 内でポリシーレベル・ルールレベル両方の path 属性に `matchFunction: 'string-regexp'` が指定された場合に `ForbiddenError` を返すよう修正
-  - 正規表現によるパスプレフィックス制約バイパスを防止（代替: `glob` を使用）
-- **Security Fix**: API Key 更新時の `policyId` バリデーションに `minPriority` チェックを追加 (#788)
-  - `ApiKeyService.updateKey()` で `validatePolicyId()` に `ROLE_MIN_PRIORITY[actor.role]` を渡すよう修正
-  - `tenant_admin` が priority < 10 のポリシーを API Key にバインドできる権限昇格を防止
-- **Fix**: `DELETE /me/policies/{policyId}` で tenant_admin が自分のポリシーを削除できない問題を修正 (#790)
-  - tenant_admin の場合、`createdBy` 一致 または テナントスコープ一致（`tenantId` 一致）でアクセス許可
-  - 旧データ（`createdBy: null`）も tenant_admin は削除・更新・取得可能に
-  - GET・PATCH も同一ロジックで統一（`checkOwnershipOrTenantScope` 導入）
-- **Fix**: DPoP Nonce リトライ時の 400 エラーをブラウザコンソールから排除 (#758)
-  - `POST /auth/nonce` レスポンスに `dpop_nonce` フィールドを追加（RFC 9449 §8 準拠）
-  - SDK が事前取得した `dpop_nonce` を使って最初から nonce 付き DPoP proof を送信
-  - ページロード後初回のトークン取得で発生していた `400 use_dpop_nonce` ハンドシェイクを回避
+
+
+* **Perf**: テナントデータ二重取得の排除 (#776)
+  
+  * `handlers/api/index.ts` のリクエストボディサイズチェックで `tenantData` を直接更新するよう修正
+    
+  * レート制限無効かつリクエストボディあり時に、ボディチェックとレスポンスサイズチェックで計 2 回発生していた `TenantRepository.getByName()` を 1 回に削減
+    
+* **Perf**: policyId バインドポリシーのキャッシュ追加 (#777)
+  
+  * `PolicyCache` に `getPolicy/setPolicy` メソッドを追加(TTL: 60 秒)
+    
+  * `PolicyService.loadBoundPolicy()` でキャッシュを参照し、カスタムポリシーを持つテナントの認証フローで MongoDB ラウンドトリップを削減
+    
+* **Perf**: API Gateway gzip 圧縮を有効化(MinimumCompressionSize: 1024)(#791)
+  
+  * 1KB 以上のレスポンスを自動 gzip 圧縮 — Entity リスト等で 60〜75% の転送量削減
+    
+* **Perf**: Lambda アーキテクチャを ARM64 (Graviton2) へ移行 (#791)
+  
+  * 全 Lambda 関数を arm64 に統一 — 約 20% の CPU 処理速度向上
+    
+* **Perf**: Lambda メモリサイズを 256MB → 512MB に引き上げ (#791)
+  
+  * CPU 割り当て倍増により JSON シリアライズ・MongoDB クエリ・XACML 評価を高速化
+    
+* **Perf**: esbuild Minify を有効化してバンドルサイズを削減 (#791)
+  
+  * 全 Lambda ハンドラのコードバンドルを minify — 推定 30〜50% サイズ削減、コールドスタート短縮
+    
+* **Security Fix**: path 属性に対する `string-regexp` matchFunction を禁止 (#788)
+  
+  * `validateNonEscalatingPolicy` 内でポリシーレベル・ルールレベル両方の path 属性に `matchFunction: 'string-regexp'` が指定された場合に `ForbiddenError` を返すよう修正
+    
+  * 正規表現によるパスプレフィックス制約バイパスを防止(代替: `glob` を使用)
+    
+* **Security Fix**: API Key 更新時の `policyId` バリデーションに `minPriority` チェックを追加 (#788)
+  
+  * `ApiKeyService.updateKey()` で `validatePolicyId()` に `ROLE_MIN_PRIORITY[actor.role]` を渡すよう修正
+    
+  * `tenant_admin` が priority < 10 のポリシーを API Key にバインドできる権限昇格を防止
+    
+* **Fix**: `DELETE /me/policies/{policyId}` で tenant\_admin が自分のポリシーを削除できない問題を修正 (#790)
+  
+  * tenant\_admin の場合、`createdBy` 一致 または テナントスコープ一致(`tenantId` 一致)でアクセス許可
+    
+  * 旧データ(`createdBy: null`)も tenant\_admin は削除・更新・取得可能に
+    
+  * GET・PATCH も同一ロジックで統一(`checkOwnershipOrTenantScope` 導入)
+    
+* **Fix**: DPoP Nonce リトライ時の 400 エラーをブラウザコンソールから排除 (#758)
+  
+  * `POST /auth/nonce` レスポンスに `dpop_nonce` フィールドを追加(RFC 9449 §8 準拠)
+    
+  * SDK が事前取得した `dpop_nonce` を使って最初から nonce 付き DPoP proof を送信
+    
+  * ページロード後初回のトークン取得で発生していた `400 use_dpop_nonce` ハンドシェイクを回避
 
 ### 2026-03-23
-- **Feature**: PATCH /me/api-keys/{keyId} と PATCH /me/oauth-clients/{clientId} を実装 (#791)
-  - 自分が作成した API キー・OAuth クライアントの属性を部分更新可能に
-  - 更新可能フィールド（API キー）: `name`, `allowedOrigins`, `policyId`, `rateLimit`, `dpopRequired`, `isActive`  - 更新可能フィールド（OAuth クライアント）: `name`, `description`, `policyId`, `isActive`  - `policyId` バインドは `createdBy === actor.id` チェック済み — 自分が作成したポリシーのみ許可
-  - API キー作成時（POST /me/api-keys）にも `policyId` 指定が可能に
+
+
+* **Feature**: PATCH /me/api-keys/{keyId} と PATCH /me/oauth-clients/{clientId} を実装 (#791)
+  
+  * 自分が作成した API キー・OAuth クライアントの属性を部分更新可能に
+    
+  * 更新可能フィールド(API キー): `name`, `allowedOrigins`, `policyId`, `rateLimit`, `dpopRequired`, `isActive`
+    
+  * 更新可能フィールド(OAuth クライアント): `name`, `description`, `policyId`, `isActive`
+    
+  * `policyId` バインドは `createdBy === actor.id` チェック済み — 自分が作成したポリシーのみ許可
+    
+  * API キー作成時(POST /me/api-keys)にも `policyId` 指定が可能に
 
 ### 2026-03-21
-- **Breaking**: API キー・OAuth クライアントのフィールド変更 (#759)
-  - API キー: `allowedScopes`, `allowedEntityTypes`, `permissions` フィールドを削除、`policyId`（オプション）を追加
-  - OAuth クライアント: `clientName` を `name` にリネーム、`allowedScopes` を削除、`policyId`（オプション）を追加
-  - 自動生成ポリシー（`__apikey_*` プレフィックス、`buildAutoPolicy`、`syncAutoPolicy`）を廃止
-  - `policyId` で既存の XACML ポリシーをクレデンシャルに紐付け可能（紐付けポリシーの Target はバイパス）
-  - `policyId` 未指定時はテナントポリシー + ロールデフォルトにフォールバック
-- **Fix**: XACML Target の同一 `attributeId` 複数値が OR 評価されるように修正 (#756)
-  - 同一 `attributeId` 内の複数 `matchValue` を OR（いずれかマッチ）で評価
-  - 異なる `attributeId` 間は AND（全てマッチ必須）を維持
-  - これにより `actions` に `POST` と `PATCH` を並記して複数メソッドを許可可能に
+
+
+* **Breaking**: API キー・OAuth クライアントのフィールド変更 (#759)
+  
+  * API キー: `allowedScopes`, `allowedEntityTypes`, `permissions` フィールドを削除、`policyId`(オプション)を追加
+    
+  * OAuth クライアント: `clientName` を `name` にリネーム、`allowedScopes` を削除、`policyId`(オプション)を追加
+    
+  * 自動生成ポリシー(`__apikey_*` プレフィックス、`buildAutoPolicy`、`syncAutoPolicy`)を廃止
+    
+  * `policyId` で既存の XACML ポリシーをクレデンシャルに紐付け可能(紐付けポリシーの Target はバイパス)
+    
+  * `policyId` 未指定時はテナントポリシー + ロールデフォルトにフォールバック
+    
+* **Fix**: XACML Target の同一 `attributeId` 複数値が OR 評価されるように修正 (#756)
+  
+  * 同一 `attributeId` 内の複数 `matchValue` を OR(いずれかマッチ)で評価
+    
+  * 異なる `attributeId` 間は AND(全てマッチ必須)を維持
+    
+  * これにより `actions` に `POST` と `PATCH` を並記して複数メソッドを許可可能に
 
 ### 2026-03-20
-- **Feature**: API キー作成時に XACML ポリシーを自動生成する (#749)
-  - `permissions` フィールド（`read`/`write`/`create`/`update`/`delete`）を指定するだけで XACML ポリシーが自動生成
-  - `write` は `create` + `update` + `delete` のエイリアス
-  - `allowedEntityTypes` との連動でエンティティタイプ制限付きポリシーも自動生成
-  - API キー削除時にポリシーも連動削除
-  - `permissions` 未指定時は既存動作と同一（デフォルト Deny）
-- **Feature**: XACML resource 属性に `servicePath` を追加 (#750)
-  - `Fiware-ServicePath` ヘッダーの値をポリシー評価に使用可能に
-  - glob パターン（例: `/opendata/**`）でServicePath階層のアクセス制御が可能
-  - 正規表現マッチ（`string-regexp`）にも対応
-- **Feature**: XACML 認可一元化 — 5 層の認可ロジックを統合 (#748)
-  - ロールごとのデフォルトフォールバックポリシーを追加: user (readonly)、api_key (全 Deny)、anonymous (全 Deny)
-  - entity-type ミドルウェアを廃止（`allowedEntityTypes` フィールドは ApiKey モデルに残存）
-  - テナントフィーチャーフラグを全廃（`apiKeysEnabled`、`oauthClientsEnabled`、`anonymousAccessEnabled`）
-  - scope/resource-scope ミドルウェアを廃止（XACML ポリシーに統合）
-  - **破壊的変更**: user ロール（ポリシーなし）は GET のみ Permit、api_key ロール（ポリシーなし）は全 Deny
-  - **破壊的変更**: 未認証リクエストは 401 ではなく 403 を返す（anonymous として XACML 評価）
+
+
+* **Feature**: API キー作成時に XACML ポリシーを自動生成する (#749)
+  
+  * `permissions` フィールド(`read`/`write`/`create`/`update`/`delete`)を指定するだけで XACML ポリシーが自動生成
+    
+  * `write` は `create` + `update` + `delete` のエイリアス
+    
+  * `allowedEntityTypes` との連動でエンティティタイプ制限付きポリシーも自動生成
+    
+  * API キー削除時にポリシーも連動削除
+    
+  * `permissions` 未指定時は既存動作と同一(デフォルト Deny)
+    
+* **Feature**: XACML resource 属性に `servicePath` を追加 (#750)
+  
+  * `Fiware-ServicePath` ヘッダーの値をポリシー評価に使用可能に
+    
+  * glob パターン(例: `/opendata/**`)でServicePath階層のアクセス制御が可能
+    
+  * 正規表現マッチ(`string-regexp`)にも対応
+    
+* **Feature**: XACML 認可一元化 — 5 層の認可ロジックを統合 (#748)
+  
+  * ロールごとのデフォルトフォールバックポリシーを追加: user (readonly)、api\_key (全 Deny)、anonymous (全 Deny)
+    
+  * entity-type ミドルウェアを廃止(`allowedEntityTypes` フィールドは ApiKey モデルに残存)
+    
+  * テナントフィーチャーフラグを全廃(`apiKeysEnabled`、`oauthClientsEnabled`、`anonymousAccessEnabled`)
+    
+  * scope/resource-scope ミドルウェアを廃止(XACML ポリシーに統合)
+    
+  * **破壊的変更**: user ロール(ポリシーなし)は GET のみ Permit、api\_key ロール(ポリシーなし)は全 Deny
+    
+  * **破壊的変更**: 未認証リクエストは 401 ではなく 403 を返す(anonymous として XACML 評価)
 
 ### 2026-03-19
-- **Fix**: `api_key` ロールでポリシー未マッチ時に 403 エラーが返される問題を修正 (#744)
-  - テナントに anonymous 用ポリシーのみ存在する場合、`api_key` ロールのリクエストが `NotApplicable` → `Deny` に変換されていた
-  - `api_key` ロールはスコープベースのアクセス制御（`allowedScopes` / `allowedEntityTypes`）で制限済みのため、XACML ポリシー未マッチ時は `Permit` にフォールバックするように変更
-  - 明示的な `Deny` ポリシーは引き続き有効
+
+
+* **Fix**: `api_key` ロールでポリシー未マッチ時に 403 エラーが返される問題を修正 (#744)
+  
+  * テナントに anonymous 用ポリシーのみ存在する場合、`api_key` ロールのリクエストが `NotApplicable` → `Deny` に変換されていた
+    
+  * `api_key` ロールはスコープベースのアクセス制御(`allowedScopes` / `allowedEntityTypes`)で制限済みのため、XACML ポリシー未マッチ時は `Permit` にフォールバックするように変更
+    
+  * 明示的な `Deny` ポリシーは引き続き有効
 
 ### 2026-03-18
-- **Feature**: テナント単位の匿名アクセスポリシーをサポート (#730)
-  - `anonymous` ロールを追加し、未認証リクエストにポリシー評価を適用
-  - テナントフィーチャーフラグ `anonymousAccessEnabled`（デフォルト: false）でオプトイン制御
-  - `optionalAuth()` ミドルウェア追加: 認証トークンがあれば検証、なければ匿名アクターとして通過
-  - 匿名アクセスはポリシーで明示的に Permit されない限り Deny（fail-closed）
-  - テナント管理者が XACML ポリシーで `role=anonymous` 向けのアクセス制御を定義可能
-- **Fix**: SDK のエンティティ API パスを NGSIv2 (`/v2/entities`) から NGSI-LD (`/ngsi-ld/v1/entities`) に修正 (#728)
-  - 全 CRUD メソッド (createEntity、getEntities、getEntity、updateEntity、deleteEntity) のパスを修正
-  - Content-Type / Accept ヘッダーを `application/ld+json` に変更
-  - エラーレスポンスの `detail` フィールド（NGSI-LD 形式）に対応
-- **Fix**: API Gateway レベルの CORS 設定に DPoP ヘッダーを追加 (#726)
-  - `template.yaml` の `Cors.AllowHeaders` / `GatewayResponses` (4XX/5XX) に `DPoP` を追加
-  - Lambda に到達しないプリフライト/エラーレスポンスでもブラウザから DPoP 送信可能に
-- **Fix**: CORS ヘッダーに DPoP 関連ヘッダーを追加 (RFC 9449) (#725)
-  - `Access-Control-Allow-Headers` に `DPoP` を追加（ブラウザからの DPoP proof 送信を許可）
-  - `Access-Control-Expose-Headers` に `DPoP-Nonce` を追加（クライアント JS での nonce 読み取りを許可）
+
+
+* **Feature**: テナント単位の匿名アクセスポリシーをサポート (#730)
+  
+  * `anonymous` ロールを追加し、未認証リクエストにポリシー評価を適用
+    
+  * テナントフィーチャーフラグ `anonymousAccessEnabled`(デフォルト: false)でオプトイン制御
+    
+  * `optionalAuth()` ミドルウェア追加: 認証トークンがあれば検証、なければ匿名アクターとして通過
+    
+  * 匿名アクセスはポリシーで明示的に Permit されない限り Deny(fail-closed)
+    
+  * テナント管理者が XACML ポリシーで `role=anonymous` 向けのアクセス制御を定義可能
+    
+* **Fix**: SDK のエンティティ API パスを NGSIv2 (`/v2/entities`) から NGSI-LD (`/ngsi-ld/v1/entities`) に修正 (#728)
+  
+  * 全 CRUD メソッド (createEntity、getEntities、getEntity、updateEntity、deleteEntity) のパスを修正
+    
+  * Content-Type / Accept ヘッダーを `application/ld+json` に変更
+    
+  * エラーレスポンスの `detail` フィールド(NGSI-LD 形式)に対応
+    
+* **Fix**: API Gateway レベルの CORS 設定に DPoP ヘッダーを追加 (#726)
+  
+  * `template.yaml` の `Cors.AllowHeaders` / `GatewayResponses` (4XX/5XX) に `DPoP` を追加
+    
+  * Lambda に到達しないプリフライト/エラーレスポンスでもブラウザから DPoP 送信可能に
+    
+* **Fix**: CORS ヘッダーに DPoP 関連ヘッダーを追加 (RFC 9449) (#725)
+  
+  * `Access-Control-Allow-Headers` に `DPoP` を追加(ブラウザからの DPoP proof 送信を許可)
+    
+  * `Access-Control-Expose-Headers` に `DPoP-Nonce` を追加(クライアント JS での nonce 読み取りを許可)
 
 ### 2026-03-17
-- **Breaking**: `write:X` スコープが `read:X` を暗黙的に含まなくなった (#723)
-  - 問い合わせフォームなどの write-only ユースケースで、読み取りアクセスを防止
-  - `admin:X` → `read:X` / `write:X` の包含は維持
-  - 読み書き両方必要な場合は `read:X write:X` を明示的に付与すること
-- **Fix**: ユーザー作成・更新時に指定された `tenantId` のテナント存在確認を追加 (#722)
-  - 存在しないテナント ID でユーザーを作成すると 400 エラーを返す
-  - ユーザー更新時のテナント移動先も同様に検証（`null` への変更は許可）
-  - `UserService` に `TenantService` を注入しバリデーション層で整合性を担保
+
+
+* **Breaking**: `write:X` スコープが `read:X` を暗黙的に含まなくなった (#723)
+  
+  * 問い合わせフォームなどの write-only ユースケースで、読み取りアクセスを防止
+    
+  * `admin:X` → `read:X` / `write:X` の包含は維持
+    
+  * 読み書き両方必要な場合は `read:X write:X` を明示的に付与すること
+    
+* **Fix**: ユーザー作成・更新時に指定された `tenantId` のテナント存在確認を追加 (#722)
+  
+  * 存在しないテナント ID でユーザーを作成すると 400 エラーを返す
+    
+  * ユーザー更新時のテナント移動先も同様に検証(`null` への変更は許可)
+    
+  * `UserService` に `TenantService` を注入しバリデーション層で整合性を担保
 
 ### 2026-03-12
-- **Fix**: ログイン時のテナントヘッダー（`NGSILD-Tenant` / `Fiware-Service`）フォーマット検証を追加 (issue #708) (#711)
-  - 不正な形式のヘッダー値で 400 エラーを返す
-- **Fix**: テナント名フォーマットバリデーションを Zod スキーマに追加 (issue #709) (#711)
-  - `POST /admin/tenants` および `PATCH /admin/tenants/{tenantId}` で `^[a-z0-9_]+$` を強制
-  - 大文字・ハイフン・スペース等を含む名前は 400 エラー
-- **Feat**: ログイン時の `NGSILD-Tenant` / `Fiware-Service` ヘッダーによるテナント指定をサポート (issue #710) (#711)
-  - 優先順位: `body.tenantId` > `NGSILD-Tenant` ヘッダー > プライマリテナント
-  - ヘッダー値からテナント名でテナントを解決（存在しない場合は 400 エラー）
+
+
+* **Fix**: ログイン時のテナントヘッダー（`NGSILD-Tenant` / `Fiware-Service`）フォーマット検証を追加 (issue #708) (#711)
+  
+  * 不正な形式のヘッダー値で 400 エラーを返す
+    
+* **Fix**: テナント名フォーマットバリデーションを Zod スキーマに追加 (issue #709) (#711)
+  
+  * `POST /admin/tenants` および `PATCH /admin/tenants/{tenantId}` で `^[a-z0-9_]+$` を強制
+    
+  * 大文字・ハイフン・スペース等を含む名前は 400 エラー
+    
+* **Feat**: ログイン時の `NGSILD-Tenant` / `Fiware-Service` ヘッダーによるテナント指定をサポート (issue #710) (#711)
+  
+  * 優先順位: `body.tenantId` > `NGSILD-Tenant` ヘッダー > プライマリテナント
+    
+  * ヘッダー値からテナント名でテナントを解決（存在しない場合は 400 エラー）
 
 ### 2026-03-10
-- **Feat**: DPoP (Demonstration of Proof-of-Possession) トークンバインド (#707)
-  - RFC 9449 準拠: ECDSA P-256 鍵ペアによるトークン所有証明
-  - `/oauth/token` で DPoP proof 付きトークン交換 → `token_type: "DPoP"` + JWT `cnf.jkt` バインド
-  - API リクエストごとに DPoP proof を検証（`htm`/`htu`/`ath` チェック）
-  - `dpopRequired` API キーフラグ: DPoP proof なしのトークン交換を拒否
-  - SDK: `crypto.subtle` で非抽出鍵ペア生成、自動 proof 付与
-  - WebSocket: Post-Connect DPoP binding (`dpop_bind` メッセージ)
-  - DPoP-Nonce (RFC 9449 §8): サーバー発行 nonce によるプリコンピュート防止。ステートレス HMAC 方式（TTL: 300 秒）
-  - `use_dpop_nonce` エラーコード + `DPoP-Nonce` レスポンスヘッダーによる自動リトライフロー
-  - Bearer フォールバック: DPoP 非対応クライアントは従来通り Bearer トークンで動作
+
+
+* **Feat**: DPoP (Demonstration of Proof-of-Possession) トークンバインド (#707)
+  
+  * RFC 9449 準拠: ECDSA P-256 鍵ペアによるトークン所有証明
+    
+  * `/oauth/token` で DPoP proof 付きトークン交換 → `token_type: "DPoP"` + JWT `cnf.jkt` バインド
+    
+  * API リクエストごとに DPoP proof を検証（`htm`/`htu`/`ath` チェック）
+    
+  * `dpopRequired` API キーフラグ: DPoP proof なしのトークン交換を拒否
+    
+  * SDK: `crypto.subtle` で非抽出鍵ペア生成、自動 proof 付与
+    
+  * WebSocket: Post-Connect DPoP binding (`dpop_bind` メッセージ)
+    
+  * DPoP-Nonce (RFC 9449 §8): サーバー発行 nonce によるプリコンピュート防止。ステートレス HMAC 方式（TTL: 300秒）
+    
+  * `use_dpop_nonce` エラーコード + `DPoP-Nonce` レスポンスヘッダーによる自動リトライフロー
+    
+  * Bearer フォールバック: DPoP 非対応クライアントは従来通り Bearer トークンで動作
 
 ### 2026-03-09
-- **Fix**: `POST /admin/api-keys` で `tenantId` を必須バリデーションに変更 (#704)
-  - super_admin が `tenantId` なしでキーを作成すると 400 エラーを返す
-  - スキーマレベルで `null` / 空文字を拒否（`tenant_admin` は省略可、セッションから自動設定）
-  - サービス層で super_admin の `tenantId` 必須チェックを追加
+
+
+* **Fix**: `POST /admin/api-keys` で `tenantId` を必須バリデーションに変更 (#704)
+  
+  * super\_admin が `tenantId` なしでキーを作成すると 400 エラーを返す
+    
+  * スキーマレベルで `null` / 空文字を拒否（`tenant_admin` は省略可、セッションから自動設定）
+    
+  * サービス層で super\_admin の `tenantId` 必須チェックを追加
 
 ### 2026-03-08
-- **Feat**: JS SDK + API キートークン交換エンドポイント (#689)
-  - `POST /auth/nonce`: Nonce + Proof of Work チャレンジ発行（API キー + Origin バインド）
-  - `POST /oauth/token` (`grant_type=api_key`): API キー → セッション JWT 交換
-  - `GET /sdk/v1/geonicdb.js`: ブラウザ用 JavaScript SDK 配信
-  - セキュリティ多層構造: Origin 検証 → HMAC Nonce → PoW → 短命 JWT（1h）
-- **Fix**: `allowedOrigins: []`（空配列）で作成された API キーが一切使用不能になるバグを修正 (issue #678) (#687)
-  - Create/Update 両スキーマに `.min(1)` バリデーションを追加
-  - 全オリジン許可には `["*"]` を使用
-- **Feat**: API キーの `allowedEntityTypes` ランタイムエンフォースメント (#688)
-  - エンティティ作成・取得・更新・削除時に API キーの許可タイプを検証
-  - 一覧取得時に `type` フィルタを自動注入
-  - バッチ操作で全エンティティタイプを一括検証
-  - NGSIv2・NGSI-LD 両 API に対応
+
+
+* **Feat**: JS SDK + API キートークン交換エンドポイント (#689)
+  
+  * `POST /auth/nonce`: Nonce + Proof of Work チャレンジ発行（API キー + Origin バインド）
+    
+  * `POST /oauth/token` (`grant_type=api_key`): API キー → セッション JWT 交換
+    
+  * `GET /sdk/v1/geonicdb.js`: ブラウザ用 JavaScript SDK 配信
+    
+  * セキュリティ多層構造: Origin 検証 → HMAC Nonce → PoW → 短命 JWT（1h）
+    
+* **Fix**: `allowedOrigins: []`（空配列）で作成された API キーが一切使用不能になるバグを修正 (issue #678) (#687)
+  
+  * Create/Update 両スキーマに `.min(1)` バリデーションを追加
+    
+  * 全オリジン許可には `["*"]` を使用
+    
+* **Feat**: APIキーの `allowedEntityTypes` ランタイムエンフォースメント (#688)
+  
+  * エンティティ作成・取得・更新・削除時にAPIキーの許可タイプを検証
+    
+  * 一覧取得時に `type` フィルタを自動注入
+    
+  * バッチ操作で全エンティティタイプを一括検証
+    
+  * NGSIv2・NGSI-LD 両APIに対応
 
 ### 2026-03-07
-- **BREAKING**: `super_admin` ロールの権限をプラットフォーム管理操作（`/admin/*`, `/auth/*`）のみに制限 (#674)
-  - データ API（`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`）へのアクセスは 403 Forbidden
-  - MCP ツールのデータ操作も同様に拒否
-  - `AUTH_ENABLED=false` 時の匿名 super_admin は従来通りアクセス可能（後方互換）
-- **Feat**: API キー認証基盤の追加 (`/admin/api-keys`, `/me/api-keys`) (#676)
-- **Feat**: テナント単位フィーチャーフラグ (`features.apiKeysEnabled`, `features.oauthClientsEnabled`) の追加 (#676)
-- **Feat**: X-Api-Key ヘッダーによる認証のサポート (#676)
-- **BREAKING**: `OAUTH_ENABLED` 環境変数の廃止（OAuth は `AUTH_ENABLED=true` なら常に有効） (#676)
+
+
+* **BREAKING**: `super_admin` ロールの権限をプラットフォーム管理操作（`/admin/*`, `/auth/*`）のみに制限 (#674)
+  
+  * データ API（`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`）へのアクセスは 403 Forbidden
+    
+  * MCP ツールのデータ操作も同様に拒否
+    
+  * `AUTH_ENABLED=false` 時の匿名 super\_admin は従来通りアクセス可能（後方互換）
+    
+* **Feat**: APIキー認証基盤の追加 (`/admin/api-keys`, `/me/api-keys`) (#676)
+  
+* **Feat**: テナント単位フィーチャーフラグ (`features.apiKeysEnabled`, `features.oauthClientsEnabled`) の追加 (#676)
+  
+* **Feat**: X-Api-Key ヘッダーによる認証のサポート (#676)
+  
+* **BREAKING**: `OAUTH_ENABLED` 環境変数の廃止（OAuth は `AUTH_ENABLED=true` なら常に有効） (#676)
 
 ### 2026-03-06
-- **Fix**: 認証無効時に `/me` エンドポイントが匿名ユーザー情報を返すように修正 (#663)
-- **Feat**: `limit=0` と `count` の組み合わせによるカウントのみクエリをサポート (#664)
-- **Feat**: XACML AuthzRequest に entityType 自動抽出を追加 (#665)
-  - PIP 拡張: `?type=` クエリパラメータまたはリクエストボディの `type`/`@type` フィールドから entityType を自動抽出
-  - パスレベル認可 (`requireAuthz`) でもエンティティタイプに基づくアクセス制御が可能に
-  - E2E テスト追加: エンティティタイプによる書き込み拒否・読み取り拒否シナリオ
-- **Fix**: `PATCH /entities/{id}/attrs` で新規属性の追加が可能に & NGSI-LD orderBy テスト追加 (#666)
-- **Feat**: XACML エンティティ単位のオーナーシップ制御 (#650)
-  - `EntityDocument` に `createdBy` フィールドを追加 (エンティティ作成者の記録)
-  - PIP (Policy Information Point) 拡張: `buildAuthzRequest` にエンティティコンテキスト (`entityId`/`entityType`/`entityOwner`) を渡せるように
-  - PDP (Policy Decision Point) 拡張: リソース属性 `entityId`/`entityType`/`entityOwner` のマッチング対応
-  - `${subject.userId}` 等のテンプレート変数展開 (XACML AttributeDesignator 相当の簡略化実装)
-  - `requireEntityAuthz` ヘルパー関数追加 (エンティティレベル PEP)
-  - 後方互換性: 全フィールド optional、既存ポリシー・既存エンティティへの影響なし
+
+
+* **Fix**: 認証無効時に `/me` エンドポイントが匿名ユーザー情報を返すように修正 (#663)
+  
+* **Feat**: `limit=0` と `count` の組み合わせによるカウントのみクエリをサポート (#664)
+  
+* **Feat**: XACML AuthzRequest に entityType 自動抽出を追加 (#665)
+  
+  * PIP 拡張: `?type=` クエリパラメータまたはリクエストボディの `type`/`@type` フィールドから entityType を自動抽出
+    
+  * パスレベル認可(`requireAuthz`)でもエンティティタイプに基づくアクセス制御が可能に
+    
+  * E2E テスト追加:エンティティタイプによる書き込み拒否・読み取り拒否シナリオ
+    
+* **Fix**: `PATCH /entities/{id}/attrs` で新規属性の追加が可能に & NGSI-LD orderBy テスト追加 (#666)
+  
+* **Feat**: XACML エンティティ単位のオーナーシップ制御 (#650)
+  
+  * `EntityDocument` に `createdBy` フィールドを追加(エンティティ作成者の記録)
+    
+  * PIP(Policy Information Point)拡張: `buildAuthzRequest` にエンティティコンテキスト(`entityId`/`entityType`/`entityOwner`)を渡せるように
+    
+  * PDP(Policy Decision Point)拡張:リソース属性 `entityId`/`entityType`/`entityOwner` のマッチング対応
+    
+  * `${subject.userId}` 等のテンプレート変数展開(XACML AttributeDesignator 相当の簡略化実装)
+    
+  * `requireEntityAuthz` ヘルパー関数追加(エンティティレベル PEP)
+    
+  * 後方互換性:全フィールド optional、既存ポリシー・既存エンティティへの影響なし
 
 ### 2026-03-05
-- **Feat**: ユーザー自身による OAuth Client Credentials セルフサービス (#642)
-  - `POST /me/oauth-clients` — 自分用の OAuth クライアントを作成 (シークレットは作成時のみ返却)
-  - `GET /me/oauth-clients` — 自分が作成したクライアント一覧を取得
-  - `DELETE /me/oauth-clients/:id` — 自分が作成したクライアントを削除
-  - `POST /me/oauth-clients/:id/regenerate-secret` — クライアントシークレットの再生成
-  - ユーザーあたり最大 5 クライアント、ロールベースのスコープ制限 (user ロールは resource スコープのみ)
-  - `OAuthClient` に `createdBy` フィールドを追加 (所有者追跡)
+
+
+* **Feat**: ユーザー自身による OAuth Client Credentials セルフサービス (#642)
+  
+  * `POST /me/oauth-clients` — 自分用の OAuth クライアントを作成(シークレットは作成時のみ返却)
+    
+  * `GET /me/oauth-clients` — 自分が作成したクライアント一覧を取得
+    
+  * `DELETE /me/oauth-clients/:id` — 自分が作成したクライアントを削除
+    
+  * `POST /me/oauth-clients/:id/regenerate-secret` — クライアントシークレットの再生成
+    
+  * ユーザーあたり最大 5 クライアント、ロールベースのスコープ制限(user ロールは resource スコープのみ)
+    
+  * `OAuthClient` に `createdBy` フィールドを追加(所有者追跡)
 
 ### 2026-03-03
-- **Docs**: CLI リファレンス (`docs/CLI.md`) を追加 (#632)
-  - `@geolonia/geonicdb-cli` (`geonic` コマンド) の全コマンドリファレンス
-  - インストール、認証、設定・プロファイル管理、入出力フォーマット
-  - entities、batch、subscriptions、registrations、temporal、snapshots、rules、admin 等の全コマンド
+
+
+* **Docs**: CLI リファレンス(`docs/CLI.md`)を追加 (#632)
+  
+  * `@geolonia/geonicdb-cli` (`geonic` コマンド)の全コマンドリファレンス
+    
+  * インストール、認証、設定・プロファイル管理、入出力フォーマット
+    
+  * entities、batch、subscriptions、registrations、temporal、snapshots、rules、admin 等の全コマンド
 
 ### 2026-03-02
-- **Fix**: Custom Data Model バリデーションの複数の不具合を修正 (#597)
-  - `validateValueType()` の case mismatch を修正 (PascalCase `"String"` 等が lowercase `'string'` と不一致で型チェックが無効化されていた)
-  - `batchCreateEntities` / `batchUpsertEntities` にカスタムデータモデルバリデーションを追加 (type 別キャッシュ付き)
-  - `getActiveDataModel()` のフェイルオープン動作を修正 (DB 障害時にバリデーションをスキップせずエラーを伝播)
+
+
+* **Fix**: Custom Data Model バリデーションの複数の不具合を修正 (#597)
+  
+  * `validateValueType()` の case mismatch を修正(PascalCase `"String"` 等が lowercase `'string'` と不一致で型チェックが無効化されていた)
+    
+  * `batchCreateEntities` / `batchUpsertEntities` にカスタムデータモデルバリデーションを追加(type 別キャッシュ付き)
+    
+  * `getActiveDataModel()` のフェイルオープン動作を修正(DB 障害時にバリデーションをスキップせずエラーを伝播)
 
 ### 2026-02-28
-- **Feat**: Crypto-Shredding と削除完了レポート生成 (#554)
-  - `DELETE /admin/tenants/{tenantId}?shred=true` で暗号化テナントの Crypto-Shredding を実行
-  - KMS CMK の DisableKey → ScheduleKeyDeletion → 全テナントデータ物理削除 → テナント論理削除
-  - 削除完了レポート自動生成 (ISMAP/ISO 27001/NIST SP 800-88 準拠)
-  - `GET /admin/tenants/{tenantId}/deletion-report` でレポート取得
-  - CloudTrail 監査イベント取得 (best-effort)
-  - テナント論理削除 (`status: 'deleted'`) とクエリからの自動除外
-- **Infra**: 単一リージョン Staging デプロイ対応 (#571)
-  - `HasSecondaryRegion` 条件追加: `SecondaryRegion=""` 時に `AWS::DynamoDB::Table` を使用
-  - 3 テーブル (DeploymentsTable, TokenInvalidationTable, UsageStatisticsTable) の単一リージョン版を追加
-  - 環境変数・IAM ポリシー参照をネスト `!If` で切り替え
-- **Infra**: Staging パラメータファイル追加 (#572)
-  - `infrastructure/parameters/staging.json` を新規作成 (`Environment: staging`, `LogLevel: INFO`)
-- **CI**: `ci.yml` に `workflow_call` トリガー追加 (#573)
-  - CD ワークフロー (`deploy.yml`) から CI パイプラインを再利用可能に
-- **CI**: CD パイプライン `deploy.yml` 新規作成 (#574, #575)
-  - Staging: `main` マージで自動デプロイ (OIDC 認証、ヘルスチェック、デプロイ記録)
-  - Production: `v*.*.*` タグで手動承認付きマルチリージョンデプロイ (Primary → Secondary → Route53)
-  - `ci.yml` から `push: [main]` トリガーを削除 (`deploy.yml` 経由の `workflow_call` に統合)
+
+
+* **Feat**: Crypto-Shredding と削除完了レポート生成 (#554)
+  
+  * `DELETE /admin/tenants/{tenantId}?shred=true` で暗号化テナントの Crypto-Shredding を実行
+    
+  * KMS CMK の DisableKey → ScheduleKeyDeletion → 全テナントデータ物理削除 → テナント論理削除
+    
+  * 削除完了レポート自動生成(ISMAP/ISO 27001/NIST SP 800-88 準拠)
+    
+  * `GET /admin/tenants/{tenantId}/deletion-report` でレポート取得
+    
+  * CloudTrail 監査イベント取得(best-effort)
+    
+  * テナント論理削除(`status: 'deleted'`)とクエリからの自動除外
+    
+* **Infra**: 単一リージョン Staging デプロイ対応 (#571)
+  
+  * `HasSecondaryRegion` 条件追加: `SecondaryRegion=""` 時に `AWS::DynamoDB::Table` を使用
+    
+  * 3 テーブル (DeploymentsTable, TokenInvalidationTable, UsageStatisticsTable) の単一リージョン版を追加
+    
+  * 環境変数・IAM ポリシー参照をネスト `!If` で切り替え
+    
+* **Infra**: Staging パラメータファイル追加 (#572)
+  
+  * `infrastructure/parameters/staging.json` を新規作成 (`Environment: staging`, `LogLevel: INFO`)
+    
+* **CI**: `ci.yml` に `workflow_call` トリガー追加 (#573)
+  
+  * CD ワークフロー (`deploy.yml`) から CI パイプラインを再利用可能に
+    
+* **CI**: CD パイプライン `deploy.yml` 新規作成 (#574, #575)
+  
+  * Staging: `main` マージで自動デプロイ(OIDC 認証、ヘルスチェック、デプロイ記録)
+    
+  * Production: `v*.*.*` タグで手動承認付きマルチリージョンデプロイ(Primary → Secondary → Route53)
+    
+  * `ci.yml` から `push: [main]` トリガーを削除(`deploy.yml` 経由の `workflow_call` に統合)
 
 ### 2026-02-27
-- **Perf**: KMS Decrypt DEK キャッシュと並列数制限の導入 (#578)
-  - 復号済み DEK をキャッシュし、同一エンベロープの繰り返し KMS DecryptCommand 呼び出しを排除
-  - `ConcurrencyLimiter` により KMS API 並列呼び出しを制限 (デフォルト: 10)
-  - `entity.repository.ts`, `temporal.repository.ts`, `snapshot.repository.ts` のバッチ復号に適用
-- **Feat**: 暗号化テナントでの時系列集計リクエストにランタイムチェックを追加 (#579)
-  - `aggrMethod` パラメータ指定時に暗号化テナントを検出して 400 Bad Request を返却
-  - 代替手段: `temporalValues` エンドポイントで復号後データを取得し、アプリケーション層で集計
-- **BREAKING**: エンティティ ID の一意制約をテナントスコープ内で `entityId` 単独に変更 (#580)
-  - インデックスを `(tenant, servicePath, entityId, entityType)` → `(tenant, servicePath, entityId)` に変更
-  - 同一 ID で異なる type のエンティティ作成は `409 AlreadyExists` を返却
-  - バッチ Upsert は `entityId` のみでマッチ (type の上書きが可能)
-  - NGSIv2 の `?type=` パラメータによる type disambiguation を廃止
-  - NGSI-LD の ID 一意セマンティクスと統一 (GeonicDB 独自拡張)
-- **Feat**: テナント単位 KMS CMK 導入と Envelope Encryption の実装 (#553)
-  - テナント作成時に AWS KMS CMK を自動生成 (`encryptionEnabled: true` 設定時)
-  - エンティティ `attributes` フィールドを AES-256-GCM Envelope Encryption で暗号化
-  - データキーキャッシュ (TTL/カウント/バイト制限) による KMS API 呼び出し最適化
-  - テナント削除時の KMS 鍵無効化・削除スケジュール (Crypto-Shredding 対応)
-  - 暗号化/非暗号化テナントの後方互換共存
-  - Temporal/Snapshot リポジトリの暗号化統合
-  - SAM テンプレート: KMS IAM ポリシー、DynamoDB SSE 設定、`EncryptionEnabled` パラメータ追加
-  - 依存追加: `@aws-sdk/client-kms`
+
+
+* **Perf**: KMS Decrypt DEK キャッシュと並列数制限の導入 (#578)
+  
+  * 復号済み DEK をキャッシュし、同一エンベロープの繰り返し KMS DecryptCommand 呼び出しを排除
+    
+  * `ConcurrencyLimiter` により KMS API 並列呼び出しを制限(デフォルト: 10)
+    
+  * `entity.repository.ts`, `temporal.repository.ts`, `snapshot.repository.ts` のバッチ復号に適用
+    
+* **Feat**: 暗号化テナントでの時系列集計リクエストにランタイムチェックを追加 (#579)
+  
+  * `aggrMethod` パラメータ指定時に暗号化テナントを検出して 400 Bad Request を返却
+    
+  * 代替手段: `temporalValues` エンドポイントで復号後データを取得し、アプリケーション層で集計
+    
+* **BREAKING**: エンティティ ID の一意制約をテナントスコープ内で `entityId` 単独に変更 (#580)
+  
+  * インデックスを `(tenant, servicePath, entityId, entityType)` → `(tenant, servicePath, entityId)` に変更
+    
+  * 同一 ID で異なる type のエンティティ作成は `409 AlreadyExists` を返却
+    
+  * バッチ Upsert は `entityId` のみでマッチ(type の上書きが可能)
+    
+  * NGSIv2 の `?type=` パラメータによる type disambiguation を廃止
+    
+  * NGSI-LD の ID 一意セマンティクスと統一(GeonicDB 独自拡張)
+    
+* **Feat**: テナント単位 KMS CMK 導入と Envelope Encryption の実装 (#553)
+  
+  * テナント作成時に AWS KMS CMK を自動生成(`encryptionEnabled: true` 設定時)
+    
+  * エンティティ `attributes` フィールドを AES-256-GCM Envelope Encryption で暗号化
+    
+  * データキーキャッシュ(TTL/カウント/バイト制限)による KMS API 呼び出し最適化
+    
+  * テナント削除時の KMS 鍵無効化・削除スケジュール(Crypto-Shredding 対応)
+    
+  * 暗号化/非暗号化テナントの後方互換共存
+    
+  * Temporal/Snapshot リポジトリの暗号化統合
+    
+  * SAM テンプレート: KMS IAM ポリシー、DynamoDB SSE 設定、`EncryptionEnabled` パラメータ追加
+    
+  * 依存追加: `@aws-sdk/client-kms`
+
 ### 2026-02-25
-- **Feat**: マルチリージョン HA アーキテクチャ Phase 1+2 (#557)
-  - Active-Passive 構成 (Primary: ap-northeast-1, Secondary: ap-northeast-3)
-  - ヘルスチェック強化: `/health`、`/health/live`、`/health/ready` に `region`、`regionRole` を追加
-  - `/health/ready` を DynamoDB/EventBridge 深層チェック対応に拡張 (Route 53 フェイルオーバー用)
-  - MongoDB クライアントに `readPreference`、`writeConcern`、`readConcern`、`retryWrites` の HA オプション追加
-  - EventBridge イベントに `sourceRegion` メタデータを自動注入
-  - Change Stream プロセッサのセカンダリリージョン自動無効化
-  - Secrets Manager 統合 (JWT シークレット / MongoDB URI の安全な管理)
-  - SAM テンプレート: `RegionRole` パラメータ、DynamoDB GlobalTable (3 テーブル)、WAF、条件付きリソース
-  - Route 53 フェイルオーバースタック (`infrastructure/template-route53.yaml`)
-  - フェイルオーバー自動化 Lambda + SNS 通知
-  - 依存追加: `@aws-sdk/client-secrets-manager`、`@aws-sdk/client-sns`- **Feat**: テナント削除時の全関連データ連鎖削除を実装 (#556)
-  - `DELETE /admin/tenants/{tenantId}` で全 16 コレクションのテナントデータを連鎖削除
-  - Deactivate-first パターン: 削除前にテナントを自動的に `isActive: false` に設定
-  - ユーザー存在チェック撤廃: ユーザーが存在するテナントも一括削除可能に
-  - 削除順序: subscriptions → registrations → entities → snapshots → 設定 → 認証 → users → memberships
-  - 各コレクションの削除件数を監査ログに記録
-  - `TenantDataCleanupService` を独立サービスとして分離 (Phase 2-3 Crypto-Shredding 拡張対応)
+
+
+* **Feat**: マルチリージョン HA アーキテクチャ Phase 1+2 (#557)
+  
+  * Active-Passive 構成 (Primary: ap-northeast-1, Secondary: ap-northeast-3)
+    
+  * ヘルスチェック強化: `/health`, `/health/live`, `/health/ready` に `region`, `regionRole` を追加
+    
+  * `/health/ready` を DynamoDB/EventBridge 深層チェック対応に拡張 (Route 53 フェイルオーバー用)
+    
+  * MongoDB クライアントに `readPreference`, `writeConcern`, `readConcern`, `retryWrites` の HA オプション追加
+    
+  * EventBridge イベントに `sourceRegion` メタデータを自動注入
+    
+  * Change Stream プロセッサのセカンダリリージョン自動無効化
+    
+  * Secrets Manager 統合 (JWT シークレット / MongoDB URI の安全な管理)
+    
+  * SAM テンプレート: `RegionRole` パラメータ、DynamoDB GlobalTable (3 テーブル)、WAF、条件付きリソース
+    
+  * Route 53 フェイルオーバースタック (`infrastructure/template-route53.yaml`)
+    
+  * フェイルオーバー自動化 Lambda + SNS 通知
+    
+  * 依存追加: `@aws-sdk/client-secrets-manager`, `@aws-sdk/client-sns`
+    
+* **Feat**: テナント削除時の全関連データ連鎖削除を実装 (#556)
+  
+  * `DELETE /admin/tenants/{tenantId}` で全 16 コレクションのテナントデータを連鎖削除
+    
+  * Deactivate-first パターン: 削除前にテナントを自動的に `isActive: false` に設定
+    
+  * ユーザー存在チェック撤廃: ユーザーが存在するテナントも一括削除可能に
+    
+  * 削除順序: subscriptions → registrations → entities → snapshots → 設定 → 認証 → users → memberships
+    
+  * 各コレクションの削除件数を監査ログに記録
+    
+  * `TenantDataCleanupService` を独立サービスとして分離(Phase 2-3 Crypto-Shredding 拡張対応)
 
 ### 2026-02-24
-- **Feat**: ReactiveCore Rules に `appendToTemporal` アクションタイプを追加 (#549)
-  - エンティティ変更時にルールベースで Temporal API (Time Series Collection) へ自動追記
-  - `attributes` で記録対象の属性を明示的に指定可能 (省略時は `changedAttributes` を使用)
-  - `TemporalService.recordEntityChange()` を内部的に呼び出し
+
+
+* **Feat**: ReactiveCore Rules に `appendToTemporal` アクションタイプを追加 (#549)
+  
+  * エンティティ変更時にルールベースで Temporal API (Time Series Collection) へ自動追記
+    
+  * `attributes` で記録対象の属性を明示的に指定可能(省略時は `changedAttributes` を使用)
+    
+  * `TemporalService.recordEntityChange()` を内部的に呼び出し
 
 ### 2026-02-21
-- **Fix**: minimatch ReDoS 脆弱性を修正 (Dependabot #5) (#537)
-  - `minimatch` の npm override を追加し全インスタンスを `^10.2.1` に統一
-  - ajv@6.12.6 (eslint devDependency) は 6.x 系にパッチなし、tolerable_risk として dismiss
+
+
+* **Fix**: minimatch ReDoS 脆弱性を修正 (Dependabot #5) (#537)
+  
+  * `minimatch` の npm override を追加し全インスタンスを `^10.2.1` に統一
+    
+  * ajv\@6.12.6 (eslint devDependency) は 6.x 系にパッチなし、tolerable\_risk として dismiss
 
 ### 2026-02-20
-- **Feat**: リソーススコープ付きトークン Phase 1 (#536)
-  - JWT にリソーススコープを埋め込み、エンティティタイプ/ID パターン/属性/操作レベルの細粒度アクセス制御を実現
-  - `POST /auth/login` に `resourceScopes` パラメータ追加
-  - OAuth `POST /oauth/token` に `resource_scopes` パラメータ追加
-  - 書き込み操作の事前チェック（`checkResourceScopes`）: 許可外のエンティティ書き込みを 403 で拒否
-  - 読み取りレスポンスの事後フィルタ（`filterByResourceScopes`）: 許可外のエンティティ/属性を除外
-  - 後方互換: `resourceScopes` なし = 従来通りフルアクセス
-- **Feat**: XACML ポリシー管理の tenant_admin 開放 (#531)
-  - `/admin/policies` と `/admin/policy-sets` を `tenant_admin` に開放
-  - ルーティング層の認証を `requireSuperAdminAuth` → `requireAdminAuth` に変更
-  - サービス層の既存テナントスコープ制御により安全に制限（自テナントのみ）
-  - `tenant_admin` が自テナントの `user` ロール向け XACML ポリシーを管理可能に
-- **Feat**: マルチテナントメンバーシップ + テナントスコープトークン (#527)
-  - FIWARE Keyrock Organization モデル準拠: 1 ユーザーが複数テナントに所属可能
-  - `tenant_memberships` コレクション追加（`userId + tenantId` ユニーク制約）
-  - テナントメンバーシップ管理 API 4 エンドポイント追加（PUT/DELETE/GET members, GET user tenants）
-  - テナントスコープログイン: `POST /auth/login` に `tenantId` パラメータ追加
-  - ユーザー作成時に自動メンバーシップ作成、テナント/ユーザー削除時にカスケード削除
-  - JWT `tenantId` 単一値を維持し、既存認可ミドルウェアへの影響ゼロ
-- **Feat**: `tenant_admin` が自テナント内のユーザー管理（CRUD）を実行可能に (#527)
-  - FIWARE Keyrock の Organization Owner と同等の権限委譲モデルを採用
-  - `/admin/users` パスの認証を `requireSuperAdminAuth` → `requireAdminAuth` に変更
-  - サービス層の既存権限チェック（`checkCanCreateUser` 等）により安全に制限
-  - `tenant_admin` は `user` ロールのみ作成可能（`super_admin` / `tenant_admin` 作成は 403）
-  - 他テナントのユーザーへの操作は禁止（既存のテナント分離ロジック）
+
+
+* **Feat**: リソーススコープ付きトークン Phase 1 (#536)
+  
+  * JWT にリソーススコープを埋め込み、エンティティタイプ/ID パターン/属性/操作レベルの細粒度アクセス制御を実現
+    
+  * `POST /auth/login` に `resourceScopes` パラメータ追加
+    
+  * OAuth `POST /oauth/token` に `resource_scopes` パラメータ追加
+    
+  * 書き込み操作の事前チェック(`checkResourceScopes`): 許可外のエンティティ書き込みを 403 で拒否
+    
+  * 読み取りレスポンスの事後フィルタ(`filterByResourceScopes`): 許可外のエンティティ/属性を除外
+    
+  * 後方互換: `resourceScopes` なし = 従来通りフルアクセス
+    
+* **Feat**: XACML ポリシー管理の tenant\_admin 開放 (#531)
+  
+  * `/admin/policies` と `/admin/policy-sets` を `tenant_admin` に開放
+    
+  * ルーティング層の認証を `requireSuperAdminAuth` → `requireAdminAuth` に変更
+    
+  * サービス層の既存テナントスコープ制御により安全に制限(自テナントのみ)
+    
+  * `tenant_admin` が自テナントの `user` ロール向け XACML ポリシーを管理可能に
+    
+* **Feat**: マルチテナントメンバーシップ + テナントスコープトークン (#527)
+  
+  * FIWARE Keyrock Organization モデル準拠: 1 ユーザーが複数テナントに所属可能
+    
+  * `tenant_memberships` コレクション追加(`userId + tenantId` ユニーク制約)
+    
+  * テナントメンバーシップ管理 API 4 エンドポイント追加(PUT/DELETE/GET members, GET user tenants)
+    
+  * テナントスコープログイン: `POST /auth/login` に `tenantId` パラメータ追加
+    
+  * ユーザー作成時に自動メンバーシップ作成、テナント/ユーザー削除時にカスケード削除
+    
+  * JWT `tenantId` 単一値を維持し、既存認可ミドルウェアへの影響ゼロ
+    
+* **Feat**: `tenant_admin` が自テナント内のユーザー管理(CRUD)を実行可能に (#527)
+  
+  * FIWARE Keyrock の Organization Owner と同等の権限委譲モデルを採用
+    
+  * `/admin/users` パスの認証を `requireSuperAdminAuth` → `requireAdminAuth` に変更
+    
+  * サービス層の既存権限チェック(`checkCanCreateUser` 等)により安全に制限
+    
+  * `tenant_admin` は `user` ロールのみ作成可能(`super_admin` / `tenant_admin` 作成は 403)
+    
+  * 他テナントのユーザーへの操作は禁止(既存のテナント分離ロジック)
 
 ### 2026-02-19
-- **Fix**: 認証付きローカルサーバー動作検証で発見されたバグ 6 件を修正 (#524)
-  - ローカルサーバーに `express.urlencoded()` ミドルウェアを追加（OAuth フォームエンコードリクエスト対応）
-  - XACML PDP の `matchFunction` 未指定時に glob パターン（`*` を含む matchValue）を自動検出するよう修正
-  - XACML XML インポートで AttributeDesignator の属性順序に依存しないパーサーに改修
-  - `PATCH /admin/policies/{policyId}` ルートを追加（405 → 200）
-  - OAuth クライアントレスポンスのフィールド名を `client_secret` → `clientSecret` に統一（Admin API camelCase 規約）
-  - ブルートフォース保護の `recordFailedAttempt()` からプログレッシブ遅延を削除（`checkLoginAllowed()` でのみ遅延を適用）
-- **Fix**: XACML 仕様準拠レビューで発見された不適合を修正 (#524)
-  - XACML エクスポートで glob matchFunction を `string-regexp-match` に正規表現変換して出力（XACML 3.0 に glob 関数は存在しないため）
-  - glob 自動検出を GeonicDB 独自拡張として明示的にドキュメント化
-- **Fix**: XACML ポリシー PDP の glob `/**` パターンがベースパス自体にマッチしないバグを修正
-  - `/v2/entities/**` が `/v2/entities` にマッチしなかった問題 — 標準 glob 仕様では `/**` は「0 個以上のパスセグメント」を意味する
-  - `policy.pdp.ts` の glob 変換ロジックを `/.*` → `(/.*)?` に修正
-- **Test**: XACML セキュリティ E2E テスト 22 シナリオ追加（`xacml-security.feature`）
-  - バッチ操作・NGSI-LD 固有エンドポイント・PATCH/PUT/DELETE メソッド施行
-  - ポリシー無効化・動的変更・クロス API 漏洩防止
-  - ポリシー優先度競合・デフォルト決定エッジケース・email 属性制御
-  - `/rules` エンドポイント施行・テナント分離 + XACML 複合テスト
+
+
+* **Fix**: 認証付きローカルサーバー動作検証で発見されたバグ 6 件を修正 (#524)
+  
+  * ローカルサーバーに `express.urlencoded()` ミドルウェアを追加(OAuth フォームエンコードリクエスト対応)
+    
+  * XACML PDP の `matchFunction` 未指定時に glob パターン(`*` を含む matchValue)を自動検出するよう修正
+    
+  * XACML XML インポートで AttributeDesignator の属性順序に依存しないパーサーに改修
+    
+  * `PATCH /admin/policies/{policyId}` ルートを追加(405 → 200)
+    
+  * OAuth クライアントレスポンスのフィールド名を `client_secret` → `clientSecret` に統一(Admin API camelCase 規約)
+    
+  * ブルートフォース保護の `recordFailedAttempt()` からプログレッシブ遅延を削除(`checkLoginAllowed()` でのみ遅延を適用)
+    
+* **Fix**: XACML 仕様準拠レビューで発見された不適合を修正 (#524)
+  
+  * XACML エクスポートで glob matchFunction を `string-regexp-match` に正規表現変換して出力(XACML 3.0 に glob 関数は存在しないため)
+    
+  * glob 自動検出を GeonicDB 独自拡張として明示的にドキュメント化
+    
+* **Fix**: XACML ポリシー PDP の glob `/**` パターンがベースパス自体にマッチしないバグを修正
+  
+  * `/v2/entities/**` が `/v2/entities` にマッチしなかった問題 — 標準 glob 仕様では `/**` は「0 個以上のパスセグメント」を意味する
+    
+  * `policy.pdp.ts` の glob 変換ロジックを `/.*` → `(/.*)?` に修正
+    
+* **Test**: XACML セキュリティ E2E テスト 22 シナリオ追加(`xacml-security.feature`)
+  
+  * バッチ操作・NGSI-LD 固有エンドポイント・PATCH/PUT/DELETE メソッド施行
+    
+  * ポリシー無効化・動的変更・クロス API 漏洩防止
+    
+  * ポリシー優先度競合・デフォルト決定エッジケース・email 属性制御
+    
+  * `/rules` エンドポイント施行・テナント分離 + XACML 複合テスト
 
 ### 2026-02-18
-- **Fix**: E2E テストで見逃された仕様準拠バグ 10 件を修正 (#520)
-  - **[BREAKING]** NGSIv2 `Fiware-Total-Count` ヘッダーが `options=count` 指定時のみ返されるよう修正(仕様: NGSIv2 spec "Pagination" section)(#520)
-  - **[BREAKING]** NGSI-LD `NGSILD-Results-Count` ヘッダーが `count=true` 指定時のみ返されるよう修正(仕様: ETSI GS CIM 009)(#520)
-  - NGSIv2 `POST /v2/op/query` に `options=values`/`options=unique` サポートを追加(仕様: NGSIv2 spec "Representation Formats")(#520)
-  - NGSIv2 `POST /v2/op/query` に `orderBy` サポートを追加(仕様: NGSIv2 spec "Ordering Results")(#520)
-  - NGSIv2 `POST /v2/op/query` に `expression.mq` サポートを追加(仕様: NGSIv2 spec "Batch Operations")(#520)
-  - NGSIv2 `POST /v2/op/notify` を Zod スキーマバリデーションに移行(`Ngsiv2NotifySchema` 適用)(#520)
-  - NGSIv2 `GET /v2/types?options=values` がタイプ名文字列配列を返すよう修正(仕様: NGSIv2 spec "Entity Types")(#520)
-  - NGSI-LD temporal controller の `AlreadyExistsError` → `AlreadyExistsLdError` に修正(仕様: ETSI GS CIM 009 §5.5.1)(#520)
-  - NGSI-LD コントローラーのエラータイプを ETSI 仕様に準拠: JSON パースエラーは `InvalidRequest`、データバリデーションエラーは `BadRequestData`(仕様: ETSI GS CIM 009 §5.5.1, Orion-LD/Stellio 互換)(#520)
-  - NGSI-LD batch 207 レスポンスの Content-Type を `application/json` に修正(仕様: ETSI GS CIM 009 §5.6.7/5.6.8)(#520)
 
-- **Fix**: ReactiveCore Rules の条件評価でエンティティレベルフィールド(`id`, `type`)を `attributeName` に指定できるよう修正(Issue #513)(#516)
-  - `value` 条件と `pattern` 条件で `attributeName: "id"` / `"type"` をサポート (#516)
-  - PATCH 後にルールアクションが実行されない問題を解消 (#516)
-- **Security**: OWASP API Security 一括修正 — 8 件のセキュリティ指摘対応 (#515)
-  - クロステナント Subscription 通知データ漏洩を修正 — `findMatchingSubscriptions` にテナントフィルタ追加 (#515)
-  - MCP ツールの OAuth スコープ検証・XACML 認可バイパスを修正 — `requireMcpScope` 追加、エンドポイントをレート制限後に移動 (#515)
-  - OAuth token エンドポイントにブルートフォース保護を追加 — `LoginProtectionService` を `clientId` ベースで適用 (#515)
-  - CSource 通知・Rule Webhook・Registration に DNS Rebinding 対策(`validateResolvedDns`)追加 (#515)
-  - `/admin/cadde`, `/admin/metrics`, `/rules`, `/custom-data-models` に OAuth スコープ要求を追加 (#515)
-  - PasswordSchema を `PASSWORD_POLICY.MIN_LENGTH` に統一、`SUPER_ADMIN_PASSWORD` 最低長チェック追加、WebSocket メッセージにトークン再検証追加 (#515)
-  - クエリパラメータにリソース制限追加 — ID リスト 100 件、ポリゴン頂点 1000、クエリ条件 50 上限 (#515)
-  - Temporal/Federation の正規表現パターンに ReDoS 対策(`validateRegexPattern`)追加 (#515)
-- **Security**: OWASP API Security M-3〜M-7 — リソース枯渇・レート制限バイパス防止 (#495)
-  - Pagination offset 上限追加(MAX_OFFSET: 10000、API4 対策)(M-3)
-  - Temporal API `timerel=between` の時間範囲上限追加(366 日、API4 対策)(M-4)
-  - OAuth scope ミドルウェアのセキュリティ設計を明確化(JWT RBAC/OAuth scope 分離、API5 対策)(M-5)
-  - Subscription throttling 最小値チェック追加(MIN_THROTTLING_SECONDS: 1、API6 対策)(M-6)
-  - 通知の並行送信をチャンク化(MAX_CONCURRENT: 10、API4/API6 対策)(M-7)
-- **Security**: SSRF 脆弱性一括修正 — IPv4-mapped IPv6 バイパス、DNS Rebinding、通知/コンテキスト URL 検証 (#490, #493, #495)
-  - IPv4-mapped/compatible IPv6 アドレスによる SSRF バイパスを防止(`[::ffff:127.0.0.1]` 等)(#490)
-  - IPv6 ULA(fc00::/7)アドレスをブロック対象に追加 (#490)
-  - `validateResolvedDns()` による DNS Rebinding 攻撃対策を追加 (#493)
-  - フェデレーション(Context Provider)の fetch 前に DNS 解決結果を検証 (#493)
-  - 通知送信(notifier)に SSRF バリデーションを追加、プライベート IP への送信を阻止 (#495 M-1)
-  - NGSI-LD `@context` URL に defense-in-depth バリデーションを追加 (#495 M-2)
-- **Tests**: SSRF 防御のユニットテスト追加(IPv4-mapped IPv6、DNS Rebinding、通知 SSRF)(#490, #493, #495)
-- **Tests**: E2E シナリオ追加(IPv4-mapped IPv6 / ULA でのサブスクリプション・レジストレーション拒否)(#490)
+
+* **Fix**: E2E テストで見逃された仕様準拠バグ 10 件を修正 (#520)
+  
+  * **\[BREAKING]** NGSIv2 `Fiware-Total-Count` ヘッダーが `options=count` 指定時のみ返されるよう修正(仕様: NGSIv2 spec "Pagination" section)(#520)
+    
+  * **\[BREAKING]** NGSI-LD `NGSILD-Results-Count` ヘッダーが `count=true` 指定時のみ返されるよう修正(仕様: ETSI GS CIM 009)(#520)
+    
+  * NGSIv2 `POST /v2/op/query` に `options=values`/`options=unique` サポートを追加(仕様: NGSIv2 spec "Representation Formats")(#520)
+    
+  * NGSIv2 `POST /v2/op/query` に `orderBy` サポートを追加(仕様: NGSIv2 spec "Ordering Results")(#520)
+    
+  * NGSIv2 `POST /v2/op/query` に `expression.mq` サポートを追加(仕様: NGSIv2 spec "Batch Operations")(#520)
+    
+  * NGSIv2 `POST /v2/op/notify` を Zod スキーマバリデーションに移行(`Ngsiv2NotifySchema` 適用)(#520)
+    
+  * NGSIv2 `GET /v2/types?options=values` がタイプ名文字列配列を返すよう修正(仕様: NGSIv2 spec "Entity Types")(#520)
+    
+  * NGSI-LD temporal controller の `AlreadyExistsError` → `AlreadyExistsLdError` に修正(仕様: ETSI GS CIM 009 §5.5.1)(#520)
+    
+  * NGSI-LD コントローラーのエラータイプを ETSI 仕様に準拠: JSON パースエラーは `InvalidRequest`、データバリデーションエラーは `BadRequestData`(仕様: ETSI GS CIM 009 §5.5.1, Orion-LD/Stellio 互換)(#520)
+    
+  * NGSI-LD batch 207 レスポンスの Content-Type を `application/json` に修正(仕様: ETSI GS CIM 009 §5.6.7/5.6.8)(#520)
+
+
+* **Fix**: ReactiveCore Rules の条件評価でエンティティレベルフィールド(`id`, `type`)を `attributeName` に指定できるよう修正(Issue #513)(#516)
+  
+  * `value` 条件と `pattern` 条件で `attributeName: "id"` / `"type"` をサポート (#516)
+    
+  * PATCH 後にルールアクションが実行されない問題を解消 (#516)
+    
+* **Security**: OWASP API Security 一括修正 — 8 件のセキュリティ指摘対応 (#515)
+  
+  * クロステナント Subscription 通知データ漏洩を修正 — `findMatchingSubscriptions` にテナントフィルタ追加 (#515)
+    
+  * MCP ツールの OAuth スコープ検証・XACML 認可バイパスを修正 — `requireMcpScope` 追加、エンドポイントをレート制限後に移動 (#515)
+    
+  * OAuth token エンドポイントにブルートフォース保護を追加 — `LoginProtectionService` を `clientId` ベースで適用 (#515)
+    
+  * CSource 通知・Rule Webhook・Registration に DNS Rebinding 対策(`validateResolvedDns`)追加 (#515)
+    
+  * `/admin/cadde`, `/admin/metrics`, `/rules`, `/custom-data-models` に OAuth スコープ要求を追加 (#515)
+    
+  * PasswordSchema を `PASSWORD_POLICY.MIN_LENGTH` に統一、`SUPER_ADMIN_PASSWORD` 最低長チェック追加、WebSocket メッセージにトークン再検証追加 (#515)
+    
+  * クエリパラメータにリソース制限追加 — ID リスト 100 件、ポリゴン頂点 1000、クエリ条件 50 上限 (#515)
+    
+  * Temporal/Federation の正規表現パターンに ReDoS 対策(`validateRegexPattern`)追加 (#515)
+    
+* **Security**: OWASP API Security M-3〜M-7 — リソース枯渇・レート制限バイパス防止 (#495)
+  
+  * Pagination offset 上限追加(MAX\_OFFSET: 10000、API4 対策)(M-3)
+    
+  * Temporal API `timerel=between` の時間範囲上限追加(366 日、API4 対策)(M-4)
+    
+  * OAuth scope ミドルウェアのセキュリティ設計を明確化(JWT RBAC/OAuth scope 分離、API5 対策)(M-5)
+    
+  * Subscription throttling 最小値チェック追加(MIN\_THROTTLING\_SECONDS: 1、API6 対策)(M-6)
+    
+  * 通知の並行送信をチャンク化(MAX\_CONCURRENT: 10、API4/API6 対策)(M-7)
+    
+* **Security**: SSRF 脆弱性一括修正 — IPv4-mapped IPv6 バイパス、DNS Rebinding、通知/コンテキスト URL 検証 (#490, #493, #495)
+  
+  * IPv4-mapped/compatible IPv6 アドレスによる SSRF バイパスを防止(`[::ffff:127.0.0.1]`等)(#490)
+    
+  * IPv6 ULA(fc00::/7)アドレスをブロック対象に追加 (#490)
+    
+  * `validateResolvedDns()` による DNS Rebinding 攻撃対策を追加 (#493)
+    
+  * フェデレーション(Context Provider)の fetch 前に DNS 解決結果を検証 (#493)
+    
+  * 通知送信(notifier)に SSRF バリデーションを追加、プライベート IP への送信を阻止 (#495 M-1)
+    
+  * NGSI-LD `@context` URL に defense-in-depth バリデーションを追加 (#495 M-2)
+    
+* **Tests**: SSRF 防御のユニットテスト追加(IPv4-mapped IPv6、DNS Rebinding、通知 SSRF)(#490, #493, #495)
+  
+* **Tests**: E2E シナリオ追加(IPv4-mapped IPv6 / ULA でのサブスクリプション・レジストレーション拒否)(#490)
 
 ### 2026-02-17
-- **Security**: `validateExternalUrl` の SSRF バイパス脆弱性を修正 (#490)
-  - IPv4-mapped IPv6 アドレス（`[::ffff:127.0.0.1]` 等）による内部ネットワークアクセスをブロック
-  - 10進数/8進数/16進数 IPv4 表記のバイパスに対するテストを追加（Node.js URL パーサーの正規化で防御済み）
-  - IPv6 unique-local アドレス（`fc00::/7`）をブロック対象に追加
-- **Security**: template.yaml デフォルト値のセキュリティ強化 (#491)
-  - `AuthEnabled` のデフォルトを `false` → `true` に変更（認証デフォルト有効化）
-  - `AuthzDefaultDecision` のデフォルトを `Permit` → `Deny` に変更（fail-closed）
-  - `getAuthzDefaultDecision()` のフォールバックを `Deny` に変更（環境変数未設定時も fail-closed）
-  - `AUTH_ENABLED=false` 明示設定時に警告ログを出力
-- **Security**: 本番環境でのスタックトレース漏洩防止 (#494)
-  - `NODE_ENV=production` 時はエラーログからスタックトレースを除外
-  - クライアントレスポンスには内部情報を含めない（既存動作を維持）
-- **Security**: OWASP API Security Top 10:2023 監査指摘 MEDIUM 7 件を修正 (#475, #476, #477, #478, #479, #481, #482)
-  - Policy/PolicySet のテナントスコープチェック追加（BOLA 対策, #475）
-  - ストレージクォータを作成時に強制（エンティティ/サブスクリプション/レジストレーション, #476）
-  - リクエストボディサイズのプラン別制限を強制（#477）
-  - `/admin/oauth-clients` に `requireScope('admin:oauth-clients')` を適用（BFLA 対策, #478）
-  - Webhook URL テンプレート置換後の SSRF 検証を追加（#479）
-  - `/statistics`, `/cache/statistics`, `/metrics` エンドポイントを認証必須化（#481）
-  - `/oauth/token` を API Gateway Event に登録（#482）
-- **Security**: OWASP API Security Top 10:2023 監査指摘の MEDIUM 4 件を修正 (#474)
-  - JWT 署名検証に `timingSafeEqual` を使用（タイミング攻撃防止）
-  - スーパー管理者パスワード比較に `timingSafeEqual` を使用（タイミング攻撃防止）
-  - XACML ポリシーの `string-regexp` マッチに ReDoS 検証を追加
-  - 予期しないエラーの内部メッセージ漏洩を防止（汎用メッセージに統一）
-- **Security**: Subscription/Registration オーナーシップ検証機能を追加（OWASP API1:2023 対策）(#467)
-  - `createdBy` フィールドによるリソースオーナーシップ追跡
-  - write 操作（UPDATE/DELETE）時に作成者とリクエストユーザーを照合
-  - `super_admin`/`tenant_admin` はオーナーシップチェックをバイパス
-  - `createdBy` 未設定の既存データは後方互換で誰でも操作可能
-  - read 操作（GET/LIST）は制限なし（NGSI 仕様準拠のテナント隔離のみ）
-- **Tests**: オーナーシップ検証のユニットテスト追加（Subscription/Registration サービス）(#467)
-- **Tests**: オーナーシップ検証の E2E テスト追加（ownership.feature: 4 シナリオ）(#467)
+
+
+* **Security**: `validateExternalUrl` の SSRF バイパス脆弱性を修正 (#490)
+  
+  * IPv4-mapped IPv6 アドレス（`[::ffff:127.0.0.1]` 等）による内部ネットワークアクセスをブロック
+    
+  * 10 進数/8 進数/16 進数 IPv4 表記のバイパスに対するテストを追加（Node.js URL パーサーの正規化で防御済み）
+    
+  * IPv6 unique-local アドレス（`fc00::/7`）をブロック対象に追加
+    
+* **Security**: template.yaml デフォルト値のセキュリティ強化 (#491)
+  
+  * `AuthEnabled` のデフォルトを `false` → `true` に変更（認証デフォルト有効化）
+    
+  * `AuthzDefaultDecision` のデフォルトを `Permit` → `Deny` に変更（fail-closed）
+    
+  * `getAuthzDefaultDecision()` のフォールバックを `Deny` に変更（環境変数未設定時も fail-closed）
+    
+  * `AUTH_ENABLED=false` 明示設定時に警告ログを出力
+    
+* **Security**: 本番環境でのスタックトレース漏洩防止 (#494)
+  
+  * `NODE_ENV=production` 時はエラーログからスタックトレースを除外
+    
+  * クライアントレスポンスには内部情報を含めない（既存動作を維持）
+    
+* **Security**: OWASP API Security Top 10:2023 監査指摘 MEDIUM 7 件を修正 (#475, #476, #477, #478, #479, #481, #482)
+  
+  * Policy/PolicySet のテナントスコープチェック追加（BOLA 対策, #475）
+    
+  * ストレージクォータを作成時に強制（エンティティ/サブスクリプション/レジストレーション, #476）
+    
+  * リクエストボディサイズのプラン別制限を強制（#477）
+    
+  * `/admin/oauth-clients` に `requireScope('admin:oauth-clients')` を適用（BFLA 対策, #478）
+    
+  * Webhook URL テンプレート置換後の SSRF 検証を追加（#479）
+    
+  * `/statistics`, `/cache/statistics`, `/metrics` エンドポイントを認証必須化（#481）
+    
+  * `/oauth/token` を API Gateway Event に登録（#482）
+    
+* **Security**: OWASP API Security Top 10:2023 監査指摘の MEDIUM 4 件を修正 (#474)
+  
+  * JWT 署名検証に `timingSafeEqual` を使用（タイミング攻撃防止）
+    
+  * スーパー管理者パスワード比較に `timingSafeEqual` を使用（タイミング攻撃防止）
+    
+  * XACML ポリシーの `string-regexp` マッチに ReDoS 検証を追加
+    
+  * 予期しないエラーの内部メッセージ漏洩を防止（汎用メッセージに統一）
+    
+* **Security**: Subscription/Registration オーナーシップ検証機能を追加（OWASP API1:2023 対策）(#467)
+  
+  * `createdBy` フィールドによるリソースオーナーシップ追跡
+    
+  * write 操作（UPDATE/DELETE）時に作成者とリクエストユーザーを照合
+    
+  * `super_admin`/`tenant_admin` はオーナーシップチェックをバイパス
+    
+  * `createdBy` 未設定の既存データは後方互換で誰でも操作可能
+    
+  * read 操作（GET/LIST）は制限なし（NGSI 仕様準拠のテナント隔離のみ）
+    
+* **Tests**: オーナーシップ検証のユニットテスト追加（Subscription/Registration サービス）(#467)
+  
+* **Tests**: オーナーシップ検証の E2E テスト追加（ownership.feature: 4 シナリオ）(#467)
 
 ### 2026-02-16
-- **Security**: WebSocket 認証トークンを URL クエリパラメータから `Authorization` ヘッダー / `Sec-WebSocket-Protocol` ヘッダーへ移行（#464）(#472)
-  - `Authorization: Bearer <token>` ヘッダー（推奨）
-  - `Sec-WebSocket-Protocol: access_token, <token>` ヘッダー（ブラウザクライアント向け）
-  - クエリパラメータは後方互換として維持（deprecation warning 付き）
-- **Security**: レスポンスボディサイズ制限の適用（#466）(#472)
-  - テナントのクォータプラン別 `maxResponseBodyBytes` を API ハンドラで強制
-  - 制限超過時に `ResponseTooLargeError` (413) を返却
-- **Security**: フェデレーション（Context Provider）レスポンスのスキーマ検証強化（#468）(#472)
-  - `Content-Length` ヘッダーによるレスポンスサイズ検証（上限 5MB）
-  - JSON ネスト深度制限（最大 10 階層）
-  - レスポンス内エンティティ数制限（最大 1000 件、超過分は切り詰め）
-- **Security**: トークン無効化（ブラックリスト）機能を追加（OWASP API2:2023 対策）(#460)
-  - `POST /auth/logout` エンドポイント追加（全セッション無効化）
-  - パスワード変更時に既存トークンを自動無効化
-  - ユーザー単位の無効化タイムスタンプ方式（DynamoDB / インメモリフォールバック）
-  - リフレッシュトークンの無効化チェック追加
-- **Security**: OWASP API2:2023 (Broken Authentication) 対応のブルートフォース保護機能を追加 (#459)
-  - メールアドレスベースのログイン試行回数追跡
-  - プログレッシブ遅延（2 回目以降: 2 秒→4 秒→8 秒）
-  - 自動アカウントロック（5 回失敗後、60 秒間ロック）
-  - ロック中は正しいパスワードでもログイン不可
-  - ログイン成功時にカウンターを自動リセット
-  - Lambda 最適化: `429 Too Many Requests` + `Retry-After` ヘッダーで応答（sleep 不使用）
-- **API**: `POST /admin/users/{userId}/unlock` エンドポイント追加（管理者によるロック解除）(#459)
-- **Infrastructure**: `loginAttempts` コレクション追加（email ユニークインデックス + TTL 自動クリーンアップ）(#459)
-- **Tests**: ユニットテスト追加（service, repository, controller, auth.service 統合）、E2E テスト追加（brute-force.feature）(#459)
-- **Security**: JWT `verifyToken()` に `alg` ヘッダー明示チェックを追加（`alg:none` 攻撃対策）(#462, #469)
-- **Security**: デフォルトパスワード最小長を 8→12 文字に強化（NIST SP 800-63B 準拠）(#463, #469)
-- **Security**: HTTP セキュリティヘッダー追加: `X-Content-Type-Options: nosniff`、`X-Frame-Options: DENY`、`Strict-Transport-Security`(#465, #469)
-- **Security**: フェデレーションリクエストに `redirect: manual` を設定し、リダイレクト先を `validateExternalUrl()` で SSRF 再検証（最大 1 回）(#461, #469)
-- **Feature**: デプロイメント設定の読み取り専用解決機能を追加 (#458)
-  - DynamoDB `geonicdb-deployments` テーブルからホスト名ベースのデプロイメント設定を取得
-  - キャッシュ付き Service（5 分 TTL、ネガティブキャッシュ対応）
-  - DynamoDB 障害時は null フォールバックで既存動作を維持
-- **Feature**: `ConnectionManager` クラスを追加（マルチデータベース接続管理）(#458)
-- **Feature**: ホスト名抽出ミドルウェアをリクエストパイプラインに組み込み (#458)
-- **Infrastructure**: SAM テンプレートに `DeploymentsTable` DynamoDB リソースと IAM ポリシーを追加 (#458)
-- **Security**: Admin API エンドポイントに OAuth スコープベースのアクセス制御を追加 (#457)
-  - `admin:users` スコープでユーザー管理 API (`/admin/users`) にアクセス可能
-  - `admin:tenants` スコープでテナント管理 API (`/admin/tenants`) にアクセス可能
-  - `admin:policies` スコープでポリシー管理 API (`/admin/policies`) にアクセス可能
-  - OAuth トークンはスコープベース、通常 JWT はロールベースで後方互換性を維持
-- **Tests**: Admin routes スコープ強制ユニットテスト 23 件追加、E2E の `@wip` タグ 2 件を解除 (#457)
-- **Feature**: GeonicDB を npm パッケージとして利用可能に (#453)
-  - `createServer()` プログラマティック API でサーバーをプログラムから起動・停止
-  - `npx geonicdb` CLI コマンドでスタンドアロン起動
-  - `--proxy` オプションで非マッチ URL をアプリ側 dev server に透過転送（URL 重複時は GeonicDB 優先）
-  - `--silent` オプションでコンソール出力抑制
-- **Build**: `tsc-alias` 導入でビルド時にパスエイリアスを相対パスに解決 (#453)
-- **Package**: `bin`、`types`、`files`、`peerDependencies` 設定で npm パッケージに対応 (#453)
+
+
+* **Security**: WebSocket 認証トークンを URL クエリパラメータから`Authorization`ヘッダー / `Sec-WebSocket-Protocol`ヘッダーへ移行 (#464) (#472)
+  
+  * `Authorization: Bearer <token>` ヘッダー(推奨)
+    
+  * `Sec-WebSocket-Protocol: access_token, <token>` ヘッダー(ブラウザクライアント向け)
+    
+  * クエリパラメータは後方互換として維持 (deprecation warning 付き)
+    
+* **Security**: レスポンスボディサイズ制限の適用 (#466) (#472)
+  
+  * テナントのクォータプラン別 `maxResponseBodyBytes` を API ハンドラで強制
+    
+  * 制限超過時に `ResponseTooLargeError` (413) を返却
+    
+* **Security**: フェデレーション (Context Provider) レスポンスのスキーマ検証強化 (#468) (#472)
+  
+  * `Content-Length` ヘッダーによるレスポンスサイズ検証 (上限 5MB)
+    
+  * JSON ネスト深度制限 (最大 10 階層)
+    
+  * レスポンス内エンティティ数制限 (最大 1000 件、超過分は切り詰め)
+    
+* **Security**: トークン無効化 (ブラックリスト) 機能を追加 (OWASP API2:2023 対策) (#460)
+  
+  * `POST /auth/logout` エンドポイント追加 (全セッション無効化)
+    
+  * パスワード変更時に既存トークンを自動無効化
+    
+  * ユーザー単位の無効化タイムスタンプ方式 (DynamoDB / インメモリフォールバック)
+    
+  * リフレッシュトークンの無効化チェック追加
+    
+* **Security**: OWASP API2:2023 (Broken Authentication) 対応のブルートフォース保護機能を追加 (#459)
+  
+  * メールアドレスベースのログイン試行回数追跡
+    
+  * プログレッシブ遅延 (2 回目以降: 2 秒→4 秒→8 秒)
+    
+  * 自動アカウントロック (5 回失敗後、60 秒間ロック)
+    
+  * ロック中は正しいパスワードでもログイン不可
+    
+  * ログイン成功時にカウンターを自動リセット
+    
+  * Lambda 最適化: `429 Too Many Requests` + `Retry-After` ヘッダーで応答 (sleep 不使用)
+    
+* **API**: `POST /admin/users/{userId}/unlock` エンドポイント追加 (管理者によるロック解除) (#459)
+  
+* **Infrastructure**: `loginAttempts` コレクション追加 (email ユニークインデックス + TTL 自動クリーンアップ) (#459)
+  
+* **Tests**: ユニットテスト追加 (service, repository, controller, auth.service 統合)、E2E テスト追加 (brute-force.feature) (#459)
+  
+* **Security**: JWT `verifyToken()` に `alg` ヘッダー明示チェックを追加 (`alg:none` 攻撃対策) (#462, #469)
+  
+* **Security**: デフォルトパスワード最小長を 8→12 文字に強化 (NIST SP 800-63B 準拠) (#463, #469)
+  
+* **Security**: HTTP セキュリティヘッダー追加: `X-Content-Type-Options: nosniff`、`X-Frame-Options: DENY`、`Strict-Transport-Security` (#465, #469)
+  
+* **Security**: フェデレーションリクエストに `redirect: manual` を設定し、リダイレクト先を `validateExternalUrl()` で SSRF 再検証 (最大 1 回) (#461, #469)
+  
+* **Feature**: デプロイメント設定の読み取り専用解決機能を追加 (#458)
+  
+  * DynamoDB `geonicdb-deployments` テーブルからホスト名ベースのデプロイメント設定を取得
+    
+  * キャッシュ付き Service (5 分 TTL、ネガティブキャッシュ対応)
+    
+  * DynamoDB 障害時は null フォールバックで既存動作を維持
+    
+* **Feature**: `ConnectionManager` クラスを追加 (マルチデータベース接続管理) (#458)
+  
+* **Feature**: ホスト名抽出ミドルウェアをリクエストパイプラインに組み込み (#458)
+  
+* **Infrastructure**: SAM テンプレートに `DeploymentsTable` DynamoDB リソースと IAM ポリシーを追加 (#458)
+  
+* **Security**: Admin API エンドポイントに OAuth スコープベースのアクセス制御を追加 (#457)
+  
+  * `admin:users` スコープでユーザー管理 API (`/admin/users`) にアクセス可能
+    
+  * `admin:tenants` スコープでテナント管理 API (`/admin/tenants`) にアクセス可能
+    
+  * `admin:policies` スコープでポリシー管理 API (`/admin/policies`) にアクセス可能
+    
+  * OAuth トークンはスコープベース、通常 JWT はロールベースで後方互換性を維持
+    
+* **Tests**: Admin routes スコープ強制ユニットテスト 23 件追加、E2E の`@wip`タグ 2 件を解除 (#457)
+  
+* **Feature**: GeonicDB を npm パッケージとして利用可能に (#453)
+  
+  * `createServer()` プログラマティック API でサーバーをプログラムから起動・停止
+    
+  * `npx geonicdb` CLI コマンドでスタンドアロン起動
+    
+  * `--proxy` オプションで非マッチ URL をアプリ側 dev server に透過転送 (URL 重複時は GeonicDB 優先)
+    
+  * `--silent` オプションでコンソール出力抑制
+    
+* **Build**: `tsc-alias` 導入でビルド時にパスエイリアスを相対パスに解決 (#453)
+  
+
+* **パッケージ**: `bin`, `types`, `files`, `peerDependencies` 設定で npm パッケージ対応 (#453)
 
 ### 2026-02-15
-- **Documentation**: `docs/INSTRUCTION.md` のカスタムデータモデルセクション（14.9）を大幅に拡充 (#445)
-  - `isActive` フラグの詳細な説明を追加（バリデーション、OpenAPI、一覧取得への影響）
-  - Smart Data Models との違いを明記（用途、バリデーション、管理方法の比較表）
-  - バリデーションの詳細とタイミングを追加（部分バリデーション、required チェック、エラー形式）
-  - 既存エンティティへの影響を説明（データモデル作成・更新時の挙動）
-  - 制限事項とベストプラクティスを追加（ReDoS 対策、推奨値、段階的ロールアウト）
-  - エラーハンドリングの詳細を追加（ステータスコード、409 Conflict、エラーメッセージの読み方）
-- **API**: `/admin/cadde` エンドポイント追加（GET/PUT/DELETE）(#439)
-- **Backend**: CADDE 設定を MongoDB 管理に移行、環境変数を廃止 (#439)
-- **MCP**: CADDE 設定を config tools に追加 (#439)
-- **Critical**: OpenAPI/メタ情報の完全欠落を修正 (#418)
-  - Snapshots API（7 エンドポイント）を `meta.controller.ts` に追加
-  - Quotas/Usage API（3 エンドポイント）を `meta.controller.ts` に追加
-  - API ドキュメント・OpenAPI 仕様・AI Tools ドキュメントに反映
-- **Documentation**: NGSIv2 ドキュメント拡充（`docs/API_NGSIV2.md`）(#418)
-  - `id`、`typePattern`、`options=upsert/append/keyValues` パラメータ追加
-  - HTTP エラー 411/413/422 のドキュメント追加
-  - `orderBy`/`metadata` の仕様差異を「GeonicDB 独自拡張」として明記
-- **Documentation**: NGSI-LD ドキュメント拡充（`docs/API_NGSILD.md`）(#418)
-  - Multi-Attribute（datasetId）の全操作詳述（CREATE/UPDATE/RETRIEVE/DELETE）
-  - Temporal API `lastN` パラメータ追加
-  - `id` 複数指定、`NGSILD-EntityMap` ヘッダー追加
-  - `NGSILD-Results-Count` ヘッダーの記述修正（「常に返却」）
-- **Documentation**: REACTIVCORE_RULES.md チュートリアル修正 (#418)
-  - 古い構文（`trigger`/`action`）を正しい構文（`conditions`/`actions`）に修正
-- **Testing**: instruction.feature 拡充（31 → 46 シナリオ）(#418)
-  - セクション 10（時系列データ管理）のテストシナリオ追加
-  - セクション 5.4（NGSIv2 属性操作）のテストシナリオ追加
-  - セクション 9.3（バッチ全アクション）のテストシナリオ追加
-  - セクション 3.7（NGSI-LD q パラメータ検索）のテストシナリオ追加
-  - INSTRUCTION.md との整合性を 60% から大幅に向上
-- **Testing**: spec-compliance.feature 拡充 (#418)
-  - NGSIv2: 4 シナリオ追加（orderBy、Subscription throttling、Batch appendStrict）
-  - NGSI-LD: 8 シナリオ追加（Multi-Attribute CRUD、Subscription/Registration PATCH、lastN）
-- **Bug Fix**: `api.json` temporal section のメソッド不整合修正 (#418)
-  - `/temporal/entities/{entityId}` に PATCH メソッド追加
-  - `/temporal/.../attrs/{attrName}/{instanceId}` に DELETE メソッド追加
-- **Bug Fix**: OpenAPI spec 修正 (#418)
-  - temporal attribute instance の DELETE operation 追加
-  - 未定義タグ 4 件追加（NGSI-LD Attributes、Info、JSON-LD Context Management、Rules）
-- **Bug Fix**: コメント・パス参照修正 (#418)
-  - `rules.feature`: `docs/RULES.md` → `docs/REACTIVCORE_RULES.md`  - `instruction.feature`: セクション番号ずれ修正
-- **Bug Fix**: NGSIv2 appendStrict 仕様準拠修正 (#418)
-  - 既存属性を含む場合に 422 Unprocessable を返すように修正（仕様準拠）
-  - 従来は既存属性を黙って上書きする仕様違反の動作だった
-  - バッチ操作の全件失敗時に 422 を返すように修正
-  - 仕様違反のテストを削除、仕様準拠のテストを追加
-- **Bug Fix**: Change Stream の watch オプションに `fullDocument: 'updateLookup'` を追加 (#442)
-- update 操作時に `fullDocument: null` となりルールエンジンが発火しなかった問題を修正
-  - `src/local-server.ts`（ローカル開発サーバー）と `src/handlers/streams/change-stream.ts`（Lambda ハンドラー）の両方を修正
-  - ユニットテストに `fullDocument: 'updateLookup'` オプションの検証を追加
-- **Testing**: ユニットテストカバレッジを大幅に向上 (#440)
-  - Lines: 90.97% → 99.08%（+8.11 ポイント）
-  - Statements: 90.68% → 98.84%（+8.16 ポイント）
-  - Branches: 84.05% → 93.99%（+9.94 ポイント）
-  - Functions: 91.75% → 96.88%（+5.13 ポイント）
-  - テスト数: 6015 件（200 スイート）
-- **Testing**: 新規テストファイル追加 (#440)
-  - Admin API: tenants、policies、metrics、users、oauth-clients コントローラーテスト、routes テスト
-  - MCP: entity.tools、batch.tools、config.tools、admin.tools テスト拡充
-  - NGSI-LD: tiles、attributes、types、entity-maps、snapshots コントローラーテスト拡充
-  - NGSIv2: tiles コントローラーテスト、entities.controller 追加カバレッジ
-  - Core: rules、subscriptions、custom-data-models、auth、geo、temporal サービステスト拡充
-  - Handlers: matcher、notifier テスト拡充
-  - Infrastructure: template-parser、mqtt client、audit logger テスト拡充
-- **Documentation**: CLAUDE.md にカバレッジ検証の必須チェックリストを追加 (#440)
-  - Pre-Push Verification セクション追加
-  - Documentation Update Checklist にカバレッジ検証を追加
-  - Endpoint Implementation Checklist にカバレッジ確認ステップを追加
-- **依存関係**: `eslint` を 9.39.2 → 10.0.0 にメジャーアップグレード (#438)
-- **依存関係**: `typescript-eslint` を 8.55.0 → 8.55.1-alpha.4 に更新（ESLint 10 対応 canary 版）(#438)
-- **依存関係**: `@typescript-eslint/eslint-plugin`、`@typescript-eslint/parser` を直接依存から削除（`typescript-eslint` ラッパーに統合）(#438)
+
+
+* **Documentation**: `docs/INSTRUCTION.md` のカスタムデータモデルセクション(14.9)を大幅に拡充 (#445)
+  
+  * `isActive` フラグの詳細な説明を追加(バリデーション、OpenAPI、一覧取得への影響)
+    
+  * Smart Data Models との違いを明記(用途、バリデーション、管理方法の比較表)
+    
+  * バリデーションの詳細とタイミングを追加(部分バリデーション、required チェック、エラー形式)
+    
+  * 既存エンティティへの影響を説明(データモデル作成・更新時の挙動)
+    
+  * 制限事項とベストプラクティスを追加(ReDoS 対策、推奨値、段階的ロールアウト)
+    
+  * エラーハンドリングの詳細を追加(ステータスコード、409 Conflict、エラーメッセージの読み方)
+    
+* **API**: `/admin/cadde` エンドポイント追加(GET/PUT/DELETE)(#439)
+  
+* **Backend**: CADDE 設定を MongoDB 管理に移行、環境変数を廃止 (#439)
+  
+* **MCP**: CADDE 設定を config tools に追加 (#439)
+  
+* **Critical**: OpenAPI/メタ情報の完全欠落を修正 (#418)
+  
+  * Snapshots API (7 エンドポイント)を `meta.controller.ts` に追加
+    
+  * Quotas/Usage API (3 エンドポイント)を `meta.controller.ts` に追加
+    
+  * API ドキュメント・OpenAPI 仕様・AI Tools ドキュメントに反映
+    
+* **Documentation**: NGSIv2 ドキュメント拡充 (`docs/API_NGSIV2.md`)(#418)
+  
+  * `id`, `typePattern`, `options=upsert/append/keyValues` パラメータ追加
+    
+  * HTTP エラー 411/413/422 のドキュメント追加
+    
+  * `orderBy`/`metadata` の仕様差異を「GeonicDB 独自拡張」として明記
+    
+* **Documentation**: NGSI-LD ドキュメント拡充 (`docs/API_NGSILD.md`)(#418)
+  
+  * Multi-Attribute (datasetId)の全操作詳述 (CREATE/UPDATE/RETRIEVE/DELETE)
+    
+  * Temporal API `lastN` パラメータ追加
+    
+  * `id` 複数指定、`NGSILD-EntityMap` ヘッダー追加
+    
+  * `NGSILD-Results-Count` ヘッダーの記述修正(「常に返却」)
+    
+* **Documentation**: REACTIVCORE\_RULES.md チュートリアル修正 (#418)
+  
+  * 古い構文 (`trigger`/`action`)を正しい構文 (`conditions`/`actions`)に修正
+    
+* **Testing**: instruction.feature 拡充 (31 → 46 シナリオ)(#418)
+  
+  * セクション 10 (時系列データ管理)のテストシナリオ追加
+    
+  * セクション 5.4 (NGSIv2 属性操作)のテストシナリオ追加
+    
+  * セクション 9.3 (バッチ全アクション)のテストシナリオ追加
+    
+  * セクション 3.7 (NGSI-LD q パラメータ検索)のテストシナリオ追加
+    
+  * INSTRUCTION.md との整合性を 60% から大幅に向上
+    
+* **Testing**: spec-compliance.feature 拡充 (#418)
+  
+  * NGSIv2: 4 シナリオ追加 (orderBy, Subscription throttling, Batch appendStrict)
+    
+  * NGSI-LD: 8 シナリオ追加 (Multi-Attribute CRUD, Subscription/Registration PATCH, lastN)
+    
+* **Bug Fix**: `api.json` temporal section のメソッド不整合修正 (#418)
+  
+  * `/temporal/entities/{entityId}` に PATCH メソッド追加
+    
+  * `/temporal/.../attrs/{attrName}/{instanceId}` に DELETE メソッド追加
+    
+* **Bug Fix**: OpenAPI spec 修正 (#418)
+  
+  * temporal attribute instance の DELETE operation 追加
+    
+  * 未定義タグ 4 件追加 (NGSI-LD Attributes, Info, JSON-LD Context Management, Rules)
+    
+* **Bug Fix**: コメント・パス参照修正 (#418)
+  
+  * `rules.feature`: `docs/RULES.md` → `docs/REACTIVCORE_RULES.md`
+    
+  * `instruction.feature`: セクション番号ずれ修正
+    
+* **Bug Fix**: NGSIv2 appendStrict 仕様準拠修正 (#418)
+  
+  * 既存属性を含む場合に 422 Unprocessable を返すように修正(仕様準拠)
+    
+  * 従来は既存属性を黙って上書きする仕様違反の動作だった
+    
+  * バッチ操作の全件失敗時に 422 を返すように修正
+    
+  * 仕様違反のテストを削除、仕様準拠のテストを追加
+    
+* **Bug Fix**: Change Stream の watch オプションに `fullDocument: 'updateLookup'` を追加 (#442)
+  
+
+* update 操作時に `fullDocument: null` となりルールエンジンが発火しなかった問題を修正
+  
+* `src/local-server.ts`（ローカル開発サーバー）と `src/handlers/streams/change-stream.ts`（Lambda ハンドラー）の両方を修正
+  
+* ユニットテストに `fullDocument: 'updateLookup'` オプションの検証を追加
+  
+* **Testing**: ユニットテストカバレッジを大幅に向上 (#440)
+  
+  * Lines: 90.97% → 99.08%(+8.11 ポイント)
+    
+  * Statements: 90.68% → 98.84%(+8.16 ポイント)
+    
+  * Branches: 84.05% → 93.99%(+9.94 ポイント)
+    
+  * Functions: 91.75% → 96.88%(+5.13 ポイント)
+    
+  * テスト数: 6015 件(200 スイート)
+    
+* **Testing**: 新規テストファイル追加 (#440)
+  
+  * Admin API: tenants、policies、metrics、users、oauth-clients コントローラーテスト、routes テスト
+    
+  * MCP: entity.tools、batch.tools、config.tools、admin.tools テスト拡充
+    
+  * NGSI-LD: tiles、attributes、types、entity-maps、snapshots コントローラーテスト拡充
+    
+  * NGSIv2: tiles コントローラーテスト、entities.controller 追加カバレッジ
+    
+  * Core: rules、subscriptions、custom-data-models、auth、geo、temporal サービステスト拡充
+    
+  * Handlers: matcher、notifier テスト拡充
+    
+  * Infrastructure: template-parser、mqtt client、audit logger テスト拡充
+    
+* **Documentation**: CLAUDE.md にカバレッジ検証の必須チェックリストを追加 (#440)
+  
+  * Pre-Push Verification セクション追加
+    
+  * Documentation Update Checklist にカバレッジ検証を追加
+    
+  * Endpoint Implementation Checklist にカバレッジ確認ステップを追加
+    
+* **依存関係**: `eslint` を 9.39.2 → 10.0.0 にメジャーアップグレード (#438)
+  
+* **依存関係**: `typescript-eslint` を 8.55.0 → 8.55.1-alpha.4 に更新(ESLint 10 対応 canary 版)(#438)
+  
+* **依存関係**: `@typescript-eslint/eslint-plugin`、`@typescript-eslint/parser` を直接依存から削除(`typescript-eslint` ラッパーに統合)(#438)
 
 ### 2026-02-14
-- **Infrastructure**: Lambda Runtime を `nodejs20.x` → `nodejs24.x` に更新（Node.js 24 LTS に統一）(#437)
-- **CI**: Dependabot で `@types/node` のメジャーバージョンアップを抑制（LTS 以外への更新を防止）(#437)
-- **Branding**: プロダクト名を VelaOS から GeonicDB に変更 (#436)
-  - ソースコード、ドキュメント、テスト全体のリネーム
-  - Prometheus メトリクスプレフィックス: `vela_` → `geonicdb_`  - DynamoDB テーブル名デフォルト: `vela-rate-limits` → `geonicdb-rate-limits`  - GitHub リポジトリ URL: `geolonia/vela` → `geolonia/geonicdb`- **依存関係**: AWS SDK グループを 3.985.0 → 3.990.0 に更新 (#435)
-  - `@aws-sdk/client-apigatewaymanagementapi`, `client-dynamodb`, `client-eventbridge`, `client-sqs`, `lib-dynamodb`- **依存関係**: OpenTelemetry グループを更新 (#435)
-  - `sdk-node` 0.211.0 → 0.212.0, `exporter-trace-otlp-http` 0.211.0 → 0.212.0
-  - `sdk-trace-base`, `resources`, `context-async-hooks` 2.5.0 → 2.5.1
-- **依存関係**: `typescript-eslint` グループを 8.54.0 → 8.55.0 に更新 (#435)
-- **依存関係**: `@types/node` を 25.2.2 → 24.10.13 にダウングレード（Node 24 ランタイムに合わせて v24 系に変更）(#435)
-- **Changed**: プロジェクトライセンスを GPL-3.0 から AGPL-3.0 に変更 (#424)
-  - `LICENSE.md` を AGPL-3.0 全文に差替え
-  - 全ソースファイル（530+ ファイル）のライセンスヘッダーを一括更新
-  - `package.json`、`README.md`、`CLAUDE.md`、各ドキュメントのライセンス記述を更新
-  - OpenAPI 仕様のライセンス情報を更新
-  - E2E テストのライセンス検証シナリオを更新
-- **Enhancement**: ローカル開発サーバーのポートを柔軟に設定可能に (#423)
-  - `--port` CLI 引数対応（`npm start -- --port 3001`）
-  - `PORT` 環境変数対応（`PORT=3001 npm start`）
-  - デフォルトポート（3000）が使用中の場合、自動的に空きポートを選択（最大 10 ポート探索）
-  - ポートフォールバック時にコンソールへ警告メッセージを表示
-  - git worktree との併用で複数インスタンスの同時起動が可能に
-- **Added**: CEL 式でカスタム関数 `distance()`, `within()`, `now()`, `dayOfWeek()` を利用可能に (#422)
-  - `distance(location1, location2)` — Haversine formula による 2 点間距離計算（メートル）
-  - `within(location, polygon)` — Ray casting による Point-in-Polygon 判定
-  - `now()` — 現在 UTC 時刻（ISO 8601 文字列）
-  - `dayOfWeek()` — 現在の曜日（0=日〜6=土、UTC ベース）
-- **Changed**: CEL 評価を `evaluate()` から `Environment` ベースに切り替え、カスタム関数登録に対応 (#422)
-- **Documentation**: `docs/REACTIVCORE_RULES.md` にカスタム関数の仕様・使用例を追加 (#422)
-- **Testing**: ユニットテスト 32 件、E2E テスト 5 シナリオを追加 (#422)
-- **Feature**: テナントごとに独自の IP アドレス制限を設定可能に (#395)
-  - GET/PUT/DELETE `/admin/tenants/:tenantId/ip-restrictions` エンドポイント追加
-  - `admin`（管理 API のみ）と `all`（全 API）の 2 つのスコープに対応
-  - テナント設定未設定時はグローバル設定（`ADMIN_ALLOWED_IPS`）にフォールバック
-  - 既存の認証ミドルウェアをテナント対応に更新
-- **Added**: ReactiveCore Rules に CEL (Common Expression Language) 式条件タイプを追加 (#387)
-  - `celExpression` 条件タイプ: 複雑な計算、文字列操作、複数属性評価が可能
-  - CEL コンテキスト変数: `entity.id`, `entity.type`, `attribute.<name>.value`, `attribute.<name>.type`  - 式の最大長制限 (1000 文字)、構文バリデーション、非 boolean 結果のハンドリング
-  - `@marcbachmann/cel-js` ライブラリ使用（ゼロ依存、TypeScript 対応）
-- **OpenAPI**: `CelExpressionCondition` スキーマを `/openapi.json` に追加 (#387)
-- **Documentation**: `docs/REACTIVCORE_RULES.md` に CEL 式条件の仕様・使用例を追加 (#387)
+
+
+* **Infrastructure**: Lambda Runtime を `nodejs20.x` → `nodejs24.x` に更新(Node.js 24 LTS に統一)(#437)
+  
+* **CI**: Dependabot で `@types/node` のメジャーバージョンアップを抑制(LTS 以外への更新を防止)(#437)
+  
+* **Branding**: プロダクト名を VelaOS から GeonicDB に変更 (#436)
+  
+  * ソースコード、ドキュメント、テスト全体のリネーム
+    
+  * Prometheus メトリクスプレフィックス: `vela_` → `geonicdb_`
+    
+  * DynamoDB テーブル名デフォルト: `vela-rate-limits` → `geonicdb-rate-limits`
+    
+  * GitHub リポジトリ URL: `geolonia/vela` → `geolonia/geonicdb`
+    
+* **依存関係**: AWS SDK グループを 3.985.0 → 3.990.0 に更新 (#435)
+  
+  * `@aws-sdk/client-apigatewaymanagementapi`、`client-dynamodb`、`client-eventbridge`、`client-sqs`、`lib-dynamodb`
+    
+* **依存関係**: OpenTelemetry グループを更新 (#435)
+  
+  * `sdk-node` 0.211.0 → 0.212.0、`exporter-trace-otlp-http` 0.211.0 → 0.212.0
+    
+  * `sdk-trace-base`、`resources`、`context-async-hooks` 2.5.0 → 2.5.1
+    
+* **依存関係**: `typescript-eslint` グループを 8.54.0 → 8.55.0 に更新 (#435)
+  
+* **依存関係**: `@types/node` を 25.2.2 → 24.10.13 にダウングレード(Node 24 ランタイムに合わせて v24 系に変更)(#435)
+  
+* **Changed**: プロジェクトライセンスを GPL-3.0 から AGPL-3.0 に変更 (#424)
+  
+  * `LICENSE.md` を AGPL-3.0 全文に差替え
+    
+  * 全ソースファイル(530+ ファイル)のライセンスヘッダーを一括更新
+    
+  * `package.json`、`README.md`、`CLAUDE.md`、各ドキュメントのライセンス記述を更新
+    
+  * OpenAPI 仕様のライセンス情報を更新
+    
+  * E2E テストのライセンス検証シナリオを更新
+    
+* **Enhancement**: ローカル開発サーバーのポートを柔軟に設定可能に (#423)
+  
+  * `--port` CLI 引数対応(`npm start -- --port 3001`)
+    
+  * `PORT` 環境変数対応(`PORT=3001 npm start`)
+    
+  * デフォルトポート(3000)が使用中の場合、自動的に空きポートを選択(最大 10 ポート探索)
+    
+  * ポートフォールバック時にコンソールへ警告メッセージを表示
+    
+  * git worktree との併用で複数インスタンスの同時起動が可能に
+    
+* **Added**: CEL 式でカスタム関数 `distance()`、`within()`、`now()`、`dayOfWeek()` を利用可能に (#422)
+  
+  * `distance(location1, location2)` — Haversine formula による 2 点間距離計算(メートル)
+    
+  * `within(location, polygon)` — Ray casting による Point-in-Polygon 判定
+    
+  * `now()` — 現在 UTC 時刻(ISO 8601 文字列)
+    
+  * `dayOfWeek()` — 現在の曜日(0=日〜6=土、UTC ベース)
+    
+* **Changed**: CEL 評価を `evaluate()` から `Environment` ベースに切り替え、カスタム関数登録に対応 (#422)
+  
+* **Documentation**: `docs/REACTIVCORE_RULES.md` にカスタム関数の仕様・使用例を追加 (#422)
+  
+* **Testing**: ユニットテスト 32 件、E2E テスト 5 シナリオを追加 (#422)
+  
+* **Feature**: テナントごとに独自の IP アドレス制限を設定可能に (#395)
+  
+  * GET/PUT/DELETE `/admin/tenants/:tenantId/ip-restrictions` エンドポイント追加
+    
+  * `admin`(管理 API のみ)と `all`(全 API)の 2 つのスコープに対応
+    
+  * テナント設定未設定時はグローバル設定(`ADMIN_ALLOWED_IPS`)にフォールバック
+    
+  * 既存の認証ミドルウェアをテナント対応に更新
+    
+* **Added**: ReactiveCore Rules に CEL (Common Expression Language) 式条件タイプを追加 (#387)
+  
+  * `celExpression` 条件タイプ: 複雑な計算、文字列操作、複数属性評価が可能
+    
+  * CEL コンテキスト変数: `entity.id`、`entity.type`、`attribute.<name>.value`、`attribute.<name>.type`
+    
+  * 式の最大長制限 (1000 文字)、構文バリデーション、非 boolean 結果のハンドリング
+    
+  * `@marcbachmann/cel-js` ライブラリ使用 (ゼロ依存、TypeScript 対応)
+    
+* **OpenAPI**: `CelExpressionCondition` スキーマを `/openapi.json` に追加 (#387)
+  
+* **Documentation**: `docs/REACTIVCORE_RULES.md` に CEL 式条件の仕様・使用例を追加 (#387)
 
 ### 2026-02-13
-- **Documentation**: ReactiveCore Rules に不快指数（DI）による熱中症アラート通知の使用例を追加しました (#419)
-  - `docs/REACTIVCORE_RULES.md` — 例6: CEL 式による不快指数計算、sendNotification/Webhook アクション
-  - `docs/INSTRUCTION.md` — セクション13.7 例4: ステップバイステップの導入手順
-- **Testing**: 不快指数アラートの E2E テストシナリオを 7 件追加しました（`@rules-discomfort-index` タグ）(#419)
-  - WARNING（DI > 75）/DANGER（DI > 80）レベルのルール実行テスト
-  - 閾値以下でのルール非トリガー確認
-  - 優先度制御と範囲条件（75 < DI <= 80）の動作確認
-  - sendNotification/webhook アクションの構成検証
-- **Added**: CADDE コネクタ v4 API エンドポイントを追加しました (#409)
-  - `GET /cadde/api/v4/catalog` — カタログ検索（横断検索/詳細検索）
-  - `GET /cadde/api/v4/entities` — NGSI データ交換（NGSIv2/NGSI-LD 形式対応）
-- **Added**: カタログ横断検索（`x-cadde-search: meta`）— キーワードフィルタ付き CKAN 形式レスポンス (#409)
-- **Added**: カタログ詳細検索（`x-cadde-search: detail`）— データセット個別取得 (#409)
-- **Added**: CADDE 固有メタデータフィールド（`caddec_dataset_id_for_detail`、`caddec_provider_id`、`caddec_resource_type`）を追加しました (#409)
-- **Added**: `x-cadde-resource-url` からクエリパラメータ解析によるエンティティ取得機能を追加しました (#409)
-- **Added**: `x-cadde-resource-api-type` による NGSIv2/NGSI-LD レスポンス形式切替機能を追加しました (#409)
-- **Added**: CADDE v4 エンドポイントの来歴ヘッダー（provenance headers）付与機能を追加しました (#409)
-- **Added**: CADDE エラーレスポンス形式（`{ detail, status }`）を追加しました (#409)
-- **Added**: `x-cadde-search` ヘッダー定数を `CADDE_HEADERS` に追加しました (#409)
-- **Infrastructure**: SAM テンプレートに CADDE v4 API ルートを追加しました (#409)
-- **OpenAPI**: `/openapi.json` に Rule Engine の詳細スキーマを追加しました (#410)
-  - `RulePublic`、`CreateRuleInput`、`UpdateRuleInput` スキーマを追加
-  - `RuleCondition`（8 種類の条件型）、`RuleAction`（5 種類のアクション型）スキーマを追加
-  - `/rules` 系エンドポイントの定義を `$ref` によるスキーマ参照に更新
-- **BREAKING CHANGE**: カスタムデータモデル管理エンドポイントを `/admin/data-models` から `/custom-data-models` に変更しました (#376)
-  - テナント固有のリソースのため Admin API から独立した API として再編成
-  - ルートパスの変更に伴い、エンドポイントは `/custom-data-models` および `/custom-data-models/:type` になりました
-- **BREAKING CHANGE**: Phase 2 の自動生成機能（`POST /admin/data-models/generate`）を削除しました (#376)
-  - AI ツールを使った生成機能は Phase 3 で再設計予定です
-- **Changed**: 認証・認可の変更 (#376)
-  - `requireAdminAuth()` から `requireAuth()` + XACML ポリシーベース認可に変更
-  - `tenant_admin` および `user` ロールもテナント内のカスタムデータモデルを管理可能（ポリシー設定による）
-- **Added**: カスタムデータモデル管理機能 Phase 1 を追加しました (#376)
-  - `GET /custom-data-models` - データモデル一覧取得
-  - `POST /custom-data-models` - データモデル作成
-  - `GET /custom-data-models/:type` - データモデル取得
-  - `PATCH /custom-data-models/:type` - データモデル更新
-  - `DELETE /custom-data-models/:type` - データモデル削除
-  - テナントごとに独自のデータモデルを定義可能
-  - Version 管理機能（作成時 = 1、更新時に自動インクリメント）
-  - 19 種類の既存 Smart Data Models に加えて、カスタムデータモデルをサポート
-- **Added**: ExtendedPropertyDetail 型定義を追加しました - PropertyDetail を拡張し defaultValue、validation、indexed をサポート (#376)
-- **Added**: MCP ツールに custom data models 統合機能を追加しました (#376)
-  - `config` ツールの `data_models` リソースに新アクション追加
-  - list、get、create、update、delete（認証必須）
-  - Smart Data Models（カタログ）とカスタムデータモデル（テナント固有）を統合検索
-- **Added**: Phase 3 - エンティティバリデーション・@context 解決拡張・JSON Schema 生成機能を追加しました (#376)
-  - カスタムデータモデルに基づくエンティティの自動バリデーション（作成・更新時）
-  - 型チェック（string、number、integer、boolean、array、object、GeoJSON）
-- バリデーションルール: minLength、maxLength、minimum、maximum、pattern、enum
-- 必須フィールド (`required`) チェック
-- NGSI-LD @context 解決をカスタムデータモデルの `contextUrl` に拡張
-- カスタムデータモデルから JSON Schema (Draft 2020-12) を自動生成
-- `jsonSchema` フィールドをカスタムデータモデルレスポンスに追加
-- **Added**: Phase 4 - エンティティテンプレート生成・OpenAPI 動的統合 (#376)
-  - MCP `config` ツールに `generate_template` アクション追加 - カスタムデータモデルからエンティティテンプレートを自動生成
-  - テンプレートは `defaultValue`、`example`、`valueType` に基づきプレースホルダ値を含む NGSI-LD 形式で生成
-  - `contextUrl` が定義されている場合は `@context` も自動付与
-  - OpenAPI 仕様 (`/openapi.json`) にカスタムデータモデルの JSON Schema を動的統合
-  - 認証済みユーザーのテナントに紐づくアクティブなカスタムデータモデルが `components/schemas` に自動追加
-- **Tests**: E2E テスト 7 シナリオ追加 (CRUD、ページネーション、権限、テナント分離、バリデーション、フィルタリング、バージョニング) (#376)
+
+
+* **Documentation**: ReactiveCore Rules に不快指数(DI)による熱中症アラート通知の使用例を追加(#419)
+  
+  * `docs/REACTIVCORE_RULES.md` — 例 6: CEL 式による不快指数計算、sendNotification/Webhook アクション
+    
+  * `docs/INSTRUCTION.md` — セクション 13.7 例 4: ステップバイステップの導入手順
+    
+* **Testing**: 不快指数アラートの E2E テストシナリオを 7 件追加(`@rules-discomfort-index`タグ)(#419)
+  
+  * WARNING(DI > 75)/DANGER(DI > 80)レベルのルール実行テスト
+    
+  * 閾値以下でのルール非トリガー確認
+    
+  * 優先度制御と範囲条件(75 < DI <= 80)の動作確認
+    
+  * sendNotification/webhook アクションの構成検証
+    
+* **Added**: CADDE コネクタ v4 API エンドポイントを追加(#409)
+  
+  * `GET /cadde/api/v4/catalog` — カタログ検索(横断検索/詳細検索)
+    
+  * `GET /cadde/api/v4/entities` — NGSI データ交換(NGSIv2/NGSI-LD 形式対応)
+    
+* **Added**: カタログ横断検索(`x-cadde-search: meta`)— キーワードフィルタ付き CKAN 形式レスポンス(#409)
+  
+* **Added**: カタログ詳細検索(`x-cadde-search: detail`)— データセット個別取得(#409)
+  
+* **Added**: CADDE 固有メタデータフィールド(`caddec_dataset_id_for_detail`、`caddec_provider_id`、`caddec_resource_type`)(#409)
+  
+* **Added**: `x-cadde-resource-url` からクエリパラメータ解析によるエンティティ取得(#409)
+  
+* **Added**: `x-cadde-resource-api-type` による NGSIv2/NGSI-LD レスポンス形式切替(#409)
+  
+* **Added**: CADDE v4 エンドポイントの来歴ヘッダー(provenance headers)付与(#409)
+  
+* **Added**: CADDE エラーレスポンス形式(`{ detail, status }`)(#409)
+  
+* **Added**: `x-cadde-search` ヘッダー定数を `CADDE_HEADERS` に追加(#409)
+  
+* **Infrastructure**: SAM テンプレートに CADDE v4 API ルートを追加(#409)
+  
+* **OpenAPI**: `/openapi.json` に Rule Engine の詳細スキーマを追加(#410)
+  
+  * `RulePublic`、`CreateRuleInput`、`UpdateRuleInput` スキーマを追加
+    
+  * `RuleCondition`(8 種類の条件型)、`RuleAction`(5 種類のアクション型)スキーマを追加
+    
+  * `/rules` 系エンドポイントの定義を `$ref` によるスキーマ参照に更新
+    
+* **BREAKING CHANGE**: カスタムデータモデル管理エンドポイントを `/admin/data-models` から `/custom-data-models` に変更(#376)
+  
+  * テナント固有のリソースのため Admin API から独立した API として再編成
+    
+  * ルートパスの変更に伴い、エンドポイントは `/custom-data-models` および `/custom-data-models/:type` に
+    
+* **BREAKING CHANGE**: Phase 2 の自動生成機能(`POST /admin/data-models/generate`)を削除(#376)
+  
+  * AI ツールを使った生成機能は Phase 3 で再設計予定
+    
+* **Changed**: 認証・認可の変更(#376)
+  
+  * `requireAdminAuth()` から `requireAuth()` + XACML ポリシーベース認可に変更
+    
+  * `tenant_admin` および `user` ロールもテナント内のカスタムデータモデルを管理可能(ポリシー設定による)
+    
+* **Added**: カスタムデータモデル管理機能 Phase 1(#376)
+  
+  * `GET /custom-data-models` - データモデル一覧取得
+    
+  * `POST /custom-data-models` - データモデル作成
+    
+  * `GET /custom-data-models/:type` - データモデル取得
+    
+  * `PATCH /custom-data-models/:type` - データモデル更新
+    
+  * `DELETE /custom-data-models/:type` - データモデル削除
+    
+  * テナントごとに独自のデータモデルを定義可能
+    
+  * Version 管理機能(作成時 = 1、更新時に自動インクリメント)
+    
+  * 19 種類の既存 Smart Data Models に加えて、カスタムデータモデルをサポート
+    
+* **Added**: ExtendedPropertyDetail 型定義 - PropertyDetail を拡張し defaultValue、validation、indexed をサポート(#376)
+  
+* **Added**: MCP ツールに custom data models 統合(#376)
+  
+  * `config` ツールの `data_models` リソースに新アクション追加
+    
+  * list, get, create, update, delete(認証必須)
+    
+  * Smart Data Models(カタログ)とカスタムデータモデル(テナント固有)を統合検索
+    
+* **Added**: Phase 3 - エンティティバリデーション・@context 解決拡張・JSON Schema 生成(#376)
+  
+  * カスタムデータモデルに基づくエンティティの自動バリデーション(作成・更新時)
+    
+  * 型チェック(string, number, integer, boolean, array, object, GeoJSON)
+    
+
+* バリデーションルール: minLength, maxLength, minimum, maximum, pattern, enum
+  
+* 必須フィールド（`required`）チェック
+  
+* NGSI-LD @context 解決をカスタムデータモデルの `contextUrl` に拡張
+  
+* カスタムデータモデルから JSON Schema (Draft 2020-12) を自動生成
+  
+* `jsonSchema` フィールドをカスタムデータモデルレスポンスに追加
+  
+* **追加**: フェーズ 4 - エンティティテンプレート生成・OpenAPI 動的統合 (#376)
+  
+  * MCP `config` ツールに `generate_template` アクション追加 - カスタムデータモデルからエンティティテンプレートを自動生成
+    
+  * テンプレートは `defaultValue`、`example`、`valueType` に基づきプレースホルダ値を含む NGSI-LD 形式で生成
+    
+  * `contextUrl` が定義されている場合は `@context` も自動付与
+    
+  * OpenAPI 仕様 (`/openapi.json`) にカスタムデータモデルの JSON Schema を動的統合
+    
+  * 認証済みユーザーのテナントに紐づくアクティブなカスタムデータモデルが `components/schemas` に自動追加
+    
+* **テスト**: E2E テスト 7 シナリオ追加（CRUD、ページネーション、権限、テナント分離、バリデーション、フィルタリング、バージョニング）(#376)
 
 ### 2026-02-11
 
-- **Documentation**: ドキュメントを 30 ファイルから 17 ファイルに統合 (43% 削減) (#405)
-  - PAGINATION.md、STATUS_CODES.md、DEPLOYMENT.md を DEVELOPMENT.md に統合
-  - WEBAPP_INTEGRATION.md を EVENT_STREAMING.md に統合
-  - CATALOG.md、TELEMETRY.md を INTEGRATIONS.md に統合
-  - AUTH_ADMIN.md、AUTH_OAUTH.md、AUTH_SCENARIOS.md を AUTH.md に統合
-  - API_ENDPOINTS*.md を API.md、API_NGSIV2.md、API_NGSILD.md に統合
-  - RULES.md を REACTIVCORE_RULES.md にリネーム
-  - SUBSCRIPTIONS.md を新規作成 - HTTP/MQTT 通知の実践例を含む包括的ガイド
-- **BREAKING**: `AUTHZ_ENABLED` 環境変数を削除。XACML ポリシー評価は `AUTH_ENABLED=true` の場合に自動的に有効化されるよう変更 (#403)
-- **Changed**: `/rules` エンドポイントは `AUTH_ENABLED` 設定に関わらずアクセス可能に (`/v2/*` および `/ngsi-ld/*` エンドポイントと同様) (#403)
+
+* **ドキュメント**: ドキュメントを 30 ファイルから 17 ファイルに統合（43% 削減）(#405)
+  
+  * PAGINATION.md、STATUS\_CODES.md、DEPLOYMENT.md を DEVELOPMENT.md に統合
+    
+  * WEBAPP\_INTEGRATION.md を EVENT\_STREAMING.md に統合
+    
+  * CATALOG.md、TELEMETRY.md を INTEGRATIONS.md に統合
+    
+  * AUTH\_ADMIN.md、AUTH\_OAUTH.md、AUTH\_SCENARIOS.md を AUTH.md に統合
+    
+  * API\_ENDPOINTS\*.md を API.md、API\_NGSIV2.md、API\_NGSILD.md に統合
+    
+  * RULES.md を REACTIVCORE\_RULES.md にリネーム
+    
+  * SUBSCRIPTIONS.md を新規作成 - HTTP/MQTT 通知の実践例を含む包括的ガイド
+    
+* **破壊的変更**: `AUTHZ_ENABLED` 環境変数を削除。XACML ポリシー評価は `AUTH_ENABLED=true` の場合に自動的に有効化されるよう変更 (#403)
+  
+* **変更**: `/rules` エンドポイントは `AUTH_ENABLED` 設定に関わらずアクセス可能に（`/v2/*` および `/ngsi-ld/*` エンドポイントと同様）(#403)
 
 ### 2026-02-10
 
-- **MCP**: MCP ツール構造を再編成 - 8 ツールから 5 ツールに統合して保守性を向上 (#402)
-- `rules` と `contexts` (JSON-LD コンテキストと Smart Data Models) を新しい `config` ツールに移動 (#402)
-- `admin` ツールはユーザー、テナント、ポリシーの管理のみに集中 (#402)
+
+* **MCP**: MCP ツール構造を再編成 - 8 ツールから 5 ツールに統合して保守性を向上 (#402)
+  
+* `rules` と `contexts`（JSON-LD コンテキストと Smart Data Models）を新しい `config` ツールに移動 (#402)
+  
+* `admin` ツールはユーザー、テナント、ポリシーの管理のみに集中 (#402)
 
 ### 2026-02-08
 
-- **BREAKING**: Rules API を `/admin/rules` から `/rules` に移動し、XACML ベースの認可を導入 (#401)
-- Rules エンドポイントはロールベース認証ではなく XACML ポリシーで保護されるようになり、きめ細かなアクセス制御が可能に (#401)
+
+* **破壊的変更**: Rules API を `/admin/rules` から `/rules` に移動し、XACML ベースの認可を導入 (#401)
+  
+* Rules エンドポイントはロールベース認証ではなく XACML ポリシーで保護されるようになり、きめ細かなアクセス制御が可能に (#401)
 
 ### 2026-02-07
 
-- **Documentation**: GeonicDB 取扱説明書 (docs/INSTRUCTION.md) を追加 (#400)
-- PDF 生成スクリプトを追加 (`npm run docs:pdf`) (#400)
-- INSTRUCTION.md の全サンプルを検証する E2E テスト (tests/e2e/features/common/instruction.feature) を追加 (#400)
+
+* **ドキュメント**: GeonicDB 取扱説明書（docs/INSTRUCTION.md）を追加 (#400)
+  
+* PDF 生成スクリプトを追加（`npm run docs:pdf`）(#400)
+  
+* INSTRUCTION.md の全サンプルを検証する E2E テスト（tests/e2e/features/common/instruction.feature）を追加 (#400)
 
 ### 2026-02-05
 
-- **Fixed**: ローカルサーバーの MongoDB シャットダウン時のエラーメッセージを抑制 (#394)
+
+* **修正**: ローカルサーバーの MongoDB シャットダウン時のエラーメッセージを抑制 (#394)
 
 ### 2026-02-04
 
-- **Changed**: バージョン番号を集約し、package.json からインポートするよう変更 (#393)
+
+* **変更**: バージョン番号を集約し、package.json からインポートするよう変更 (#393)
 
 ### 2026-02-03
 
-- **Added**: MCP (Model Context Protocol) サーバー統合 (#392)
-  - AI 駆動型エンティティ管理のための 5 つの統合ツール
-  - エンティティ CRUD 操作
-  - バッチ操作
-  - 時系列クエリ
-  - JSON-LD コンテキスト管理
-  - 管理操作
+
+* **追加**: MCP (Model Context Protocol) サーバー統合 (#392)
+  
+  * AI 駆動型エンティティ管理のための 5 つの統合ツール
+    
+  * エンティティ CRUD 操作
+    
+  * バッチ操作
+    
+  * 時系列クエリ
+    
+  * JSON-LD コンテキスト管理
+    
+  * 管理操作
 
 ### 2026-02-02
-- **Fixed**: クォータシステムのバグ修正 (#391)
-  - Retry-After ヘッダーの修正
-  - 負数カウントバイパスの修正
-  - 時間単位の不一致を解決
+
+
+* **Fixed**: クォータシステムのバグ修正 (#391)
+  
+  * Retry-After ヘッダーの修正
+    
+  * 負数カウントバイパスの修正
+    
+  * 時間単位の不一致を解決
 
 ### 2026-02-01
-- **Added**: ReactiveCore Rules - パターンマッチング、条件式、アクションを備えた自動エンティティ処理ルールエンジン (#389)
-  - エンティティタイプ、ID、属性名のパターンマッチング
-  - 論理演算子（AND/OR）を使用した条件式
-  - 複数のアクション: createEntity、updateEntity、deleteEntity、sendNotification
-  - 無限ループ防止機構
-  - リアルタイムイベント処理のための Change Stream 統合
-  - `npm start` によるローカルテストサポート
+
+
+* **Added**: ReactiveCore Rules - パターンマッチング、条件式、アクションを備えた自動エンティティ処理ルールエンジン (#389)
+  
+  * エンティティタイプ、ID、属性名のパターンマッチング
+    
+  * 論理演算子(AND/OR)を使用した条件式
+    
+  * 複数のアクション: createEntity、updateEntity、deleteEntity、sendNotification
+    
+  * 無限ループ防止機構
+    
+  * リアルタイムイベント処理のための Change Stream 統合
+    
+  * `npm start` によるローカルテストサポート
 
 ### 2026-01-28
-- **Documentation**: 包括的な AWS デプロイ手順を含む DEPLOYMENT.md を追加 (#382)
+
+
+* **Documentation**: 包括的な AWS デプロイ手順を含む DEPLOYMENT.md を追加 (#382)
 
 ### 2026-01-25
-- **Added**: Smart Data Models サポートを強化 (#373)
-  - プロパティ詳細を含む 19 の標準データモデル
-  - AI 駆動型エンティティ作成ガイダンス
-  - 全モデルの propertyDetails メタデータ
+
+
+* **Added**: Smart Data Models サポートを強化 (#373)
+  
+  * プロパティ詳細を含む 19 の標準データモデル
+    
+  * AI 駆動型エンティティ作成ガイダンス
+    
+  * 全モデルの propertyDetails メタデータ
 
 ### 2026-01-24
-- **Documentation**: 新規ユーザー向け QUICKSTART.md ガイドを追加 (#372)
+
+
+* **Documentation**: 新規ユーザー向け QUICKSTART.md ガイドを追加 (#372)
 
 ### 2026-01-23
-- **Fixed**: NGSI-LD スキーマ検証を強化 (#370)
+
+
+* **Fixed**: NGSI-LD スキーマ検証を強化 (#370)
 
 ### 2026-01-22
-- **Security**: エンティティ ID(256文字)、タイプ(256文字)、属性名(256文字)の長さ制限を追加 (#369)
+
+
+* **Security**: エンティティ ID(256文字)、タイプ(256文字)、属性名(256文字)の長さ制限を追加 (#369)
 
 ### 2026-01-20
-- **Fixed**: NGSI-LD URI パターンの不整合を解決 (#364)
+
+
+* **Fixed**: NGSI-LD URI パターンの不整合を解決 (#364)
 
 ### 2026-01-18
-- **Added**: 全 API エンドポイントの Zod v4 ランタイム型検証を追加 (#358)
+
+
+* **Added**: 全 API エンドポイントの Zod v4 ランタイム型検証を追加 (#358)
 
 ### 2026-01-17
-- **Changed**: 設定値を `src/config/defaults.ts` に集約 (#357)
+
+
+* **Changed**: 設定値を `src/config/defaults.ts` に集約 (#357)
 
 ### 2026-01-16
-- **Added**: SaaS ローンチ向けの包括的なクォータシステム (#356)
-  - リクエストクォータ(レート制限、日次/月次制限)
-  - ストレージクォータ(エンティティ/属性数)
-  - DynamoDB によるリアルタイム監視
-  - テナント固有のクォータ設定
-  - レート制限レスポンスの Retry-After ヘッダー
 
-### 初期実装（〜2026-01-15）
-- GeonicDB 初回実装 - AWS Lambda 上で動作する FIWARE Orion 互換 Context Broker
-- NGSIv2 API 実装
-  - エンティティ CRUD 操作
-  - サブスクリプション
-  - レジストレーション
-  - バッチ操作
-  - クエリ言語サポート（q、mq パラメータ）
-- NGSI-LD API 実装
-  - エンティティ操作
-  - サブスクリプション
-  - コンテキストソースレジストレーション
-  - バッチ操作
-  - クエリ言語サポート（q、scopeQ、pick、omit、lang パラメータ）
-- NGSIv2 と NGSI-LD API 間の完全な相互運用性
-- Fiware-Service ヘッダーによるマルチテナンシーサポート
-- コンテキストプロバイダ転送によるフェデレーション機能
-- 空間 ID を使用した地理空間クエリサポート
-- JWT 認証・認可
-- テナントおよびユーザー管理のための管理 API
-- レプリカセット対応の MongoDB ストレージ
-- SAM テンプレートによる AWS Lambda デプロイ
-- サブスクリプションマッチングのための EventBridge 統合
-- 通知配信のための SQS FIFO キュー
-- 通知のための MQTT サポート
-- 包括的な E2E テストスイート（Cucumber.js）
-- 単体テストカバレッジ 〜99%（Jest）
-- インメモリ MongoDB を使用したローカル開発サーバー（`npm start`）
-- Node.js 要件: >=24.13.0
-- MongoDB 要件: 7.1.0
-- テストフレームワーク: Cucumber.js（Gherkin 日本語）
-- ベクタータイル生成 API
-- 時系列データの Temporal API
-- エンティティスナップショット機能
-- JSON-LD コンテキスト管理
-- データカタログ API（CKAN/DCAT 互換）
-- CADDE（データ連携）サービス統合
-- セキュリティ強化のためのテナント単位の IP ホワイトリスト
-- ReDoS（正規表現サービス拒否）防止
-- 全 API エンドポイントの入力検証
+
+* **Added**: SaaS ローンチ向けの包括的なクォータシステム (#356)
+  
+  * リクエストクォータ(レート制限、日次/月次制限)
+    
+  * ストレージクォータ(エンティティ/属性数)
+    
+  * DynamoDB によるリアルタイム監視
+    
+  * テナント固有のクォータ設定
+    
+  * レート制限レスポンスの Retry-After ヘッダー
+
+### 初期実装(〜2026-01-15)
+
+
+* GeonicDB 初回実装 - AWS Lambda 上で動作する FIWARE Orion 互換 Context Broker
+  
+* NGSIv2 API 実装
+  
+  * エンティティ CRUD 操作
+    
+  * サブスクリプション
+    
+  * レジストレーション
+    
+  * バッチ操作
+    
+  * クエリ言語サポート(q、mq パラメータ)
+    
+* NGSI-LD API 実装
+  
+  * エンティティ操作
+    
+  * サブスクリプション
+    
+  * コンテキストソースレジストレーション
+    
+  * バッチ操作
+    
+  * クエリ言語サポート(q、scopeQ、pick、omit、lang パラメータ)
+    
+* NGSIv2 と NGSI-LD API 間の完全な相互運用性
+  
+* Fiware-Service ヘッダーによるマルチテナンシーサポート
+  
+* コンテキストプロバイダ転送によるフェデレーション機能
+  
+* 空間 ID を使用した地理空間クエリサポート
+  
+* JWT 認証・認可
+  
+* テナントおよびユーザー管理のための管理 API
+  
+* レプリカセット対応の MongoDB ストレージ
+  
+* SAM テンプレートによる AWS Lambda デプロイ
+  
+* サブスクリプションマッチングのための EventBridge 統合
+  
+* 通知配信のための SQS FIFO キュー
+  
+* 通知のための MQTT サポート
+  
+* 包括的な E2E テストスイート(Cucumber.js)
+  
+* 単体テストカバレッジ〜99%(Jest)
+  
+* インメモリ MongoDB を使用したローカル開発サーバー(`npm start`)
+  
+* Node.js 要件: >=24.13.0
+  
+* MongoDB 要件: 7.1.0
+  
+* テストフレームワーク: Cucumber.js(Gherkin 日本語)
+  
+* ベクタータイル生成 API
+  
+* 時系列データの Temporal API
+  
+* エンティティスナップショット機能
+  
+* JSON-LD コンテキスト管理
+  
+* データカタログ API(CKAN/DCAT 互換)
+  
+* CADDE(データ連携)サービス統合
+  
+* セキュリティ強化のためのテナント単位の IP ホワイトリスト
+  
+* ReDoS(正規表現サービス拒否)防止
+  
+* 全 API エンドポイントの入力検証
 
 [unreleased]: https://github.com/geolonia/geonicdb/compare/v0.1.0...HEAD
+
 [0.1.0]: https://github.com/geolonia/geonicdb/releases/tag/v0.1.0

--- a/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
+++ b/docs/ja/core-concepts/ngsiv2-vs-ngsild.md
@@ -5,27 +5,38 @@ outline: deep
 ---
 # NGSIv2 / NGSI-LD プロトコル分離
 
-GeonicDB は、単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートしています。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルごとに分離されています** -- NGSIv2 で作成されたエンティティは NGSIv2 でのみアクセス可能で、NGSI-LD についても同様です。
+GeonicDB は単一の Context Broker で NGSIv2 と NGSI-LD の両方の API をサポートしています。両方の API は統一された内部ストレージ形式を共有していますが、**エンティティはプロトコルによって分離されます** -- NGSIv2 経由で作成されたエンティティは NGSIv2 経由でのみアクセス可能であり、NGSI-LD についても同様です。
 
 ## 目次
 
-- [概要](#概要)
-- [統一された内部形式](#統一された内部形式)
-- [プロトコルアイソレーション](#プロトコルアイソレーション)
-- [属性タイプマッピングテーブル](#属性タイプマッピングテーブル)
-- [システム属性の違い](#システム属性の違い)
-- [出力フォーマットの違い](#出力フォーマットの違い)
-- [共有機能](#共有機能)
-- [NGSI-LD 固有の機能](#ngsi-ld-固有の機能)
-- [エンティティ ID の考慮事項](#エンティティ-id-の考慮事項)
-- [フェデレーション](#フェデレーション)
-- [ユースケースとベストプラクティス](#ユースケースとベストプラクティス)
 
----
+* [概要](#overview)
+  
+* [統一された内部形式](#unified-internal-format)
+  
+* [プロトコル分離](#プロトコル分離)
+  
+* [属性タイプマッピングテーブル](#属性タイプマッピングテーブル)
+  
+* [システム属性の違い](#システム属性の違い)
+  
+* [出力形式の違い](#output-format-differences)
+  
+* [共有機能](#shared-features)
+  
+* [NGSI-LD 固有の機能](#ngsi-ld-固有の機能)
+  
+* [エンティティ ID の考慮事項](#エンティティ-id-の考慮事項)
+  
+* [フェデレーション](#フェデレーション)
+  
+* [ユースケースとベストプラクティス](#ユースケースとベストプラクティス)
+
+***
 
 ## 概要
 
-GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートしています。各エンティティには、それを作成したプロトコルのタグが付けられ、2 つの API 間の厳格な分離が保証されます。
+GeonicDB のデュアル API アーキテクチャは、FIWARE NGSIv2 と ETSI NGSI-LD の両方の仕様をサポートします。各エンティティは、それを作成したプロトコルでタグ付けされ、2 つの API 間の厳格な分離が保証されます。
 
 ### アーキテクチャ
 
@@ -35,23 +46,31 @@ NGSIv2 API (/v2) ──────> [protocol: 'ngsiv2'] ──┐
 NGSI-LD API (/ngsi-ld/v1) ──> [protocol: 'ngsild'] ┘
 ```
 
-- 両方の API は同じ MongoDB ストレージと統一された内部形式を共有します
-- 各エンティティには作成時に設定される `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)があります
-- クエリはプロトコルでフィルタリングされます: NGSIv2 API は `protocol: 'ngsiv2'` エンティティのみを返し、NGSI-LD API は `protocol: 'ngsild'` エンティティのみを返します
-- `protocol` フィールドを持たない既存のエンティティは `'ngsild'` として扱われます
 
-### メリット
+* 両方の API は同じ MongoDB ストレージと統一された内部形式を共有します
+  
+* 各エンティティは作成時に設定される `protocol` フィールド(`'ngsiv2'` または `'ngsild'`)を持ちます
+  
+* クエリはプロトコルによってフィルタリングされます: NGSIv2 API は `protocol: 'ngsiv2'` エンティティのみを返し、NGSI-LD API は `protocol: 'ngsild'` エンティティのみを返します
+  
+* &#x20;フィールドを持たない既存のエンティティは `protocol` として扱われます`'ngsild'`
 
-- **プロトコル分離** - 明確な境界により、意図しないクロスプロトコルデータ漏洩を防ぎ、各 API が仕様に準拠したエンティティのみを返すことを保証します
-- **仕様準拠** - 各 API は独自の仕様内で厳密に動作し、形式変換によるエッジケースを回避します
-- **既存システムとの統合** - NGSIv2 と NGSI-LD のワークロードを干渉なく並行して実行できます
-- **API 選択の自由** - 各ユースケースに最適な API を選択できます。クロスプロトコルのニーズには Federation を使用します
+### 利点
 
----
 
-## 統一された内部形式
+* **プロトコル分離** - 明確な境界により、意図しないクロスプロトコルデータリークを防ぎ、各 API が仕様に準拠したエンティティのみを返すことを保証します
+  
+* **仕様準拠** - 各 API は独自の仕様内で厳密に動作し、形式変換によるエッジケースを回避します
+  
+* **既存システムとの統合** - NGSIv2 と NGSI-LD のワークロードを干渉なしに並行して実行できます
+  
+* **API 選択の自由** - 各ユースケースに最適な API を選択できます; クロスプロトコルのニーズには Federation を使用します
 
-GeonicDB は、両方の API からのデータを統一された内部形式に変換します。
+***
+
+## 統一内部フォーマット
+
+GeonicDB は両方の API からのデータを統一内部フォーマットに変換します。
 
 ### 内部エンティティ構造
 
@@ -82,7 +101,7 @@ interface EntityMetadata {
 }
 ```
 
-### MongoDB ストレージ形式
+### MongoDB ストレージフォーマット
 
 ```typescript
 interface EntityDocument {
@@ -106,30 +125,30 @@ interface EntityDocument {
 }
 ```
 
----
+***
 
-## プロトコルアイソレーション
+## プロトコル分離
 
-エンティティは、それらを作成したプロトコルによって分離されています。各エンティティには `protocol` フィールド (`'ngsiv2'` または `'ngsild'`) があり、どの API がそれにアクセスできるかを決定します。
+エンティティは、それらを作成したプロトコルによって分離されます。各エンティティは`protocol` フィールド(`'ngsiv2'` または `'ngsild'`)を持ち、どの API がそれにアクセスできるかを決定します。
 
 ### ルール
 
-| 操作 | NGSIv2 エンティティ (`protocol: 'ngsiv2'`) | NGSI-LD エンティティ (`protocol: 'ngsild'`) |
-|-----------|--------------------------------------|---------------------------------------|
-| NGSIv2 GET/LIST | 可視 | 不可視 |
-| NGSIv2 UPDATE/DELETE | 許可 | 見つからない (404) |
-| NGSI-LD GET/LIST | 不可視 | 可視 |
-| NGSI-LD UPDATE/DELETE | 見つからない (404) | 許可 |
+| 操作                    | NGSIv2 エンティティ(`protocol: 'ngsiv2'`) | NGSI-LD エンティティ(`protocol: 'ngsild'`) |
+| --------------------- | ----------------------------------- | ------------------------------------ |
+| NGSIv2 GET/LIST       | 表示                                  | 非表示                                  |
+| NGSIv2 UPDATE/DELETE  | 許可                                  | 見つかりません(404)                         |
+| NGSI-LD GET/LIST      | 非表示                                 | 表示                                   |
+| NGSI-LD UPDATE/DELETE | 見つかりません(404)                        | 許可                                   |
 
 ### レガシーエンティティ
 
-プロトコルアイソレーション導入以前に作成されたエンティティ (つまり、データベースに `protocol` フィールドがないもの) は `'ngsild'` として扱われます。これらは NGSI-LD API を介してのみアクセス可能です。
+プロトコル分離の導入前に作成されたエンティティ(つまり、データベースに`protocol` フィールドを持たないもの)は `'ngsild'` として扱われます。これらは NGSI-LD API 経由でのみアクセス可能です。
 
 ### フェデレーション経由のクロスプロトコルアクセス
 
-直接的なクロスプロトコルアクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション** (Context Source Registration) を使用して、一方の GeonicDB インスタンスを他方のプロトコルのコンテキストプロバイダーとして登録してください。詳細は [フェデレーション](#federation) セクションを参照してください。
+直接のクロスプロトコルアクセスはサポートされていません。プロトコル間でエンティティにアクセスする必要がある場合は、**フェデレーション**(コンテキストソース登録)を使用して、1 つの GeonicDB インスタンスを他のプロトコルのコンテキストプロバイダーとして登録してください。詳細については、[フェデレーション](#フェデレーション) セクションを参照してください。
 
-### 例: プロトコルアイソレーションの動作
+### 例:プロトコル分離の動作
 
 ```bash
 # Create an entity via NGSIv2
@@ -147,72 +166,72 @@ curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001 -H "Fiware-S
 # => 404 Not Found
 ```
 
----
+***
 
 ## 属性タイプマッピングテーブル
 
-GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ、NGSI-LD タイプを変換します。
+GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ、NGSI-LD タイプの間で変換を行います。
 
 ### 基本データタイプ
 
-| NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
-|-------------|---------------|--------------|-------------|
-| `Number` | `Number` | `Property` | 数値 (整数または小数) |
-| `Text` / `String` | `String` | `Property` | 文字列 |
-| `Boolean` | `Boolean` | `Property` | 真偽値 |
-| `DateTime` | `DateTime` | `Property` または `TemporalProperty` | ISO 8601 日時文字列 |
-| `Null` | `Null` | `Property` | null 値 |
+| NGSIv2 タイプ        | 内部タイプ      | NGSI-LD タイプ                       | 説明             |
+| ----------------- | ---------- | --------------------------------- | -------------- |
+| `Number`          | `Number`   | `Property`                        | 数値(整数または小数)    |
+| `Text` / `String` | `String`   | `Property`                        | 文字列            |
+| `Boolean`         | `Boolean`  | `Property`                        | 真偽値            |
+| `DateTime`        | `DateTime` | `Property` または `TemporalProperty` | ISO 8601 日時文字列 |
+| `Null`            | `Null`     | `Property`                        | null 値         |
 
 ### 構造化データタイプ
 
-| NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
-|-------------|---------------|--------------|-------------|
-| `Object` | `Object` | `Property` | JSON オブジェクト |
-| `Array` | `Array` | `Property` または `ListProperty` | JSON 配列 |
-| `StructuredValue` | `Object` | `Property` | 構造化データ |
+| NGSIv2 タイプ        | 内部タイプ    | NGSI-LD タイプ                   | 説明          |
+| ----------------- | -------- | ----------------------------- | ----------- |
+| `Object`          | `Object` | `Property`                    | JSON オブジェクト |
+| `Array`           | `Array`  | `Property` または `ListProperty` | JSON 配列     |
+| `StructuredValue` | `Object` | `Property`                    | 構造化データ      |
 
 ### 地理空間タイプ
 
-| NGSIv2 タイプ | 内部タイプ | NGSI-LD タイプ | 説明 |
-|-------------|---------------|--------------|-------------|
-| `geo:json` | `GeoJSON` | `GeoProperty` | GeoJSON (Point、LineString、Polygon) |
-| `geo:point` | `GeoJSON` (Point) | `GeoProperty` | 緯度/経度ポイント |
+| NGSIv2 タイプ  | 内部タイプ             | NGSI-LD タイプ   | 説明                                 |
+| ----------- | ----------------- | ------------- | ---------------------------------- |
+| `geo:json`  | `GeoJSON`         | `GeoProperty` | GeoJSON (Point、LineString、Polygon) |
+| `geo:point` | `GeoJSON` (Point) | `GeoProperty` | 緯度/経度ポイント                          |
 
-### NGSI-LD 固有タイプ
+### NGSI-LD 固有のタイプ
 
-以下の NGSI-LD 固有タイプは内部的に保持されますが、NGSIv2 API では `Property` として扱われます。
+以下の NGSI-LD 固有のタイプは内部的に保持されますが、NGSIv2 API では `Property` として扱われます。
 
-| NGSI-LD タイプ | 内部タイプ | NGSIv2 変換 | 説明 |
-|--------------|---------------|-------------------|-------------|
-| `Relationship` | `Relationship` | `Relationship` (カスタムタイプ) | エンティティ参照 (`object` プロパティを含む) |
-| `LanguageProperty` | `LanguageProperty` | `StructuredValue` | 多言語文字列 (`languageMap` プロパティを含む) |
-| `JsonProperty` | `JsonProperty` | `Object` | JSON データ (`json` プロパティを含む) |
-| `VocabProperty` | `VocabProperty` | `Object` | ボキャブラリーデータ (`vocab` または `vocabMap` プロパティを含む) |
-| `ListProperty` | `ListProperty` | `Array` | 順序付き配列 (`valueList` プロパティを含む) |
-| `ListRelationship` | `ListRelationship` | `Array` | エンティティ参照の配列 (`objectList` プロパティを含む) |
+| NGSI-LD タイプ        | 内部タイプ              | NGSIv2 変換                | 説明                                           |
+| ------------------ | ------------------ | ------------------------ | -------------------------------------------- |
+| `Relationship`     | `Relationship`     | `Relationship` (カスタムタイプ) | エンティティ参照( `object` プロパティを含む)                 |
+| `LanguageProperty` | `LanguageProperty` | `StructuredValue`        | 多言語文字列( `languageMap` プロパティを含む)              |
+| `JsonProperty`     | `JsonProperty`     | `Object`                 | JSON データ( `json` プロパティを含む)                   |
+| `VocabProperty`    | `VocabProperty`    | `Object`                 | ボキャブラリーデータ( `vocab` または `vocabMap` プロパティを含む) |
+| `ListProperty`     | `ListProperty`     | `Array`                  | 順序付き配列( `valueList` プロパティを含む)                |
+| `ListRelationship` | `ListRelationship` | `Array`                  | エンティティ参照の配列( `objectList` プロパティを含む)          |
 
 ### メタデータタイプマッピング
 
-| NGSIv2 メタデータ名 | NGSI-LD プロパティ | 説明 |
-|----------------------|------------------|-------------|
-| `unit` (Text) | `unitCode` (string) | 単位 (例: "CEL"、"KMH") |
-| `observedAt` (DateTime) | `observedAt` (ISO 8601) | 観測タイムスタンプ |
-| `datasetId` (Text) | `datasetId` (URI) | データセット ID |
+| NGSIv2 メタデータ名           | NGSI-LD プロパティ           | 説明                |
+| ----------------------- | ----------------------- | ----------------- |
+| `unit` (Text)           | `unitCode` (string)     | 単位(例:"CEL"、"KMH") |
+| `observedAt` (DateTime) | `observedAt` (ISO 8601) | 観測タイムスタンプ         |
+| `datasetId` (Text)      | `datasetId` (URI)       | データセット ID         |
 
----
+***
 
 ## システム属性の違い
 
-エンティティメタデータ (作成および変更タイムスタンプ) は、API によって異なる名前を使用します。
+エンティティのメタデータ(作成および変更のタイムスタンプ)は、API によって異なる名前を使用します。
 
 ### NGSIv2 システム属性
 
-| 属性名 | タイプ | 説明 |
-|----------------|------|-------------|
-| `dateCreated` | `DateTime` | エンティティ作成タイムスタンプ (ISO 8601) |
+| 属性名            | タイプ        | 説明                           |
+| -------------- | ---------- | ---------------------------- |
+| `dateCreated`  | `DateTime` | エンティティ作成タイムスタンプ (ISO 8601)   |
 | `dateModified` | `DateTime` | エンティティ最終変更タイムスタンプ (ISO 8601) |
 
-**例 (NGSIv2 レスポンス、`options=dateCreated,dateModified` 使用時):**
+**例 (NGSIv2 レスポンス with `options=dateCreated,dateModified`):**
 
 ```json
 {
@@ -235,14 +254,14 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 
 ### NGSI-LD システム属性
 
-| 属性名 | タイプ | 説明 |
-|----------------|------|-------------|
-| `createdAt` | ISO 8601 文字列 | エンティティ作成タイムスタンプ |
+| 属性名          | タイプ          | 説明                |
+| ------------ | ------------ | ----------------- |
+| `createdAt`  | ISO 8601 文字列 | エンティティ作成タイムスタンプ   |
 | `modifiedAt` | ISO 8601 文字列 | エンティティ最終変更タイムスタンプ |
 
-**注意:** `pick` パラメータを使用した場合、レスポンスには明示的にリクエストされた属性と、常に存在する `@context`、`id`、`type` が含まれます。ただし、`createdAt` と `modifiedAt` は `pick` を使用しても返されません。これらのシステム属性には `sysAttrs` オプションが必要です。
+**注意:** パラメータを使用する場合、レスポンスには明示的に要求された属性と `pick` パラメータを使用する場合、レスポンスには明示的に要求された属性と `@context`、`id`、および `type`(これらは常に存在します)が含まれます。ただし、`createdAt` および `modifiedAt` は `pick` が使用されても返されません — これらのシステム属性には `sysAttrs` オプションが必要です。
 
-**例 (NGSI-LD レスポンス、システム属性は常に含まれる):**
+**例 (NGSI-LD レスポンス、システム属性は常に含まれます):**
 
 ```json
 {
@@ -270,19 +289,19 @@ GeonicDB は、以下のルールに従って NGSIv2 タイプ、内部タイプ
 }
 ```
 
----
+***
 
 ## 出力フォーマットの違い
 
 各 API は複数のレスポンスフォーマットをサポートしています。
 
-### NGSIv2 の出力フォーマット
+### NGSIv2 出力フォーマット
 
-| フォーマット | options パラメータ | 説明 |
-|--------|-------------------|-------------|
-| **normalized** (デフォルト) | (なし) | タイプとメタデータを含む完全フォーマット |
-| **keyValues** | `options=keyValues` | キー・バリューペアのみ (メタデータなし) |
-| **values** | `options=values` | 属性値の配列のみ |
+| フォーマット                 | options パラメータ       | 説明                  |
+| ---------------------- | ------------------- | ------------------- |
+| **normalized** (デフォルト) | (なし)                | 型とメタデータを含む完全なフォーマット |
+| **keyValues**          | `options=keyValues` | キーと値のペアのみ (メタデータなし) |
+| **values**             | `options=values`    | 属性値の配列のみ            |
 
 **例:**
 
@@ -297,13 +316,13 @@ curl http://localhost:3000/v2/entities/Room1?options=keyValues
 curl 'http://localhost:3000/v2/entities?type=Room&options=values&attrs=temperature,humidity'
 ```
 
-### NGSI-LD の出力フォーマット
+### NGSI-LD 出力フォーマット
 
-| フォーマット | Accept ヘッダー | 説明 |
-|--------|---------------|-------------|
-| **normalized** (デフォルト) | `application/ld+json` | タイプとメタデータを含む完全フォーマット |
-| **concise** | `application/ld+json` + `options=concise` | 簡潔フォーマット (省略記法) |
-| **keyValues** | `application/ld+json` + `options=keyValues` | キー・バリューペアのみ |
+| フォーマット                 | Accept ヘッダー                                 | 説明                  |
+| ---------------------- | ------------------------------------------- | ------------------- |
+| **normalized** (デフォルト) | `application/ld+json`                       | 型とメタデータを含む完全なフォーマット |
+| **concise**            | `application/ld+json` + `options=concise`   | 簡潔なフォーマット (省略記法)    |
+| **keyValues**          | `application/ld+json` + `options=keyValues` | キーと値のペアのみ           |
 
 **例:**
 
@@ -318,21 +337,21 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1?options=c
 curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:Room1?options=keyValues'
 ```
 
----
+***
 
-## 共有機能
+## 共通機能
 
-以下の機能は両方の API で共有されています。
+以下の機能は両方の API で共通です。
 
 ### 1. クエリ言語
 
-| 機能 | NGSIv2 | NGSI-LD | 説明 |
-|---------|--------|---------|-------------|
-| **シンプルクエリ** | `q` パラメータ | `q` パラメータ | 属性値フィルタ (例: `temperature>20;humidity<80`) |
-| **メタデータクエリ** | `mq` パラメータ | `q` パラメータ (メタデータもクエリ可能) | メタデータフィルタ |
-| **スコープクエリ** | `Fiware-ServicePath` ヘッダー (スコープから独立) | `scopeQ` パラメータ | スコープ階層フィルタ |
+| 機能           | NGSIv2                               | NGSI-LD                 | 説明                                        |
+| ------------ | ------------------------------------ | ----------------------- | ----------------------------------------- |
+| **シンプルクエリ**  | `q` パラメータ                            | `q` パラメータ               | 属性値フィルタ (例: `temperature>20;humidity<80`) |
+| **メタデータクエリ** | `mq` パラメータ                           | `q` パラメータ (メタデータもクエリ可能) | メタデータフィルタ                                 |
+| **スコープクエリ**  | `Fiware-ServicePath` ヘッダー (スコープから独立) | `scopeQ` パラメータ          | スコープ階層フィルタ                                |
 
-**基本例:**
+**基本的な例:**
 
 ```bash
 # NGSIv2: Entities with temperature greater than 20
@@ -344,20 +363,20 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?type=Room&q=temperature>20'
 
 #### メタデータクエリ (mq) の詳細
 
-NGSIv2 の `mq` パラメータは、属性メタデータに対するクエリをサポートしています。
+NGSIv2 の `mq` パラメータは属性メタデータに対するクエリをサポートしています。
 
 **サポートされる演算子:**
 
-| 演算子 | 説明 | 例 |
-|----------|-------------|---------|
-| `==` | 等しい | `mq=temperature.accuracy==0.95` |
-| `!=` | 等しくない | `mq=temperature.accuracy!=0` |
-| `>`、`<`、`>=`、`<=` | 比較演算子 | `mq=temperature.accuracy>0.9` |
-| `~=` | パターンマッチ | `mq=temperature.unit~=Cel.*` |
-| `..` | 範囲 (両端を含む) | `mq=temperature.accuracy==0.9..1.0` |
-| `,` | リスト (OR) | `mq=temperature.unit==Celsius,Fahrenheit` |
-| `;` | AND 条件 | `mq=temperature.accuracy>0.9;temperature.unit==Celsius` |
-| `|` | OR 条件 | `mq=temperature.accuracy>0.9|humidity.accuracy>0.8` |
+| 演算子               | 説明         | 例                                                       |                               |                         |
+| ----------------- | ---------- | ------------------------------------------------------- | ----------------------------- | ----------------------- |
+| `==`              | 等しい        | `mq=temperature.accuracy==0.95`                         |                               |                         |
+| `!=`              | 等しくない      | `mq=temperature.accuracy!=0`                            |                               |                         |
+| `>`、`<`、`>=`、`<=` | 比較演算子      | `mq=temperature.accuracy>0.9`                           |                               |                         |
+| `~=`              | パターンマッチ    | `mq=temperature.unit~=Cel.*`                            |                               |                         |
+| `..`              | 範囲 (両端を含む) | `mq=temperature.accuracy==0.9..1.0`                     |                               |                         |
+| `,`               | リスト (OR)   | `mq=temperature.unit==Celsius,Fahrenheit`               |                               |                         |
+| `;`               | AND 条件     | `mq=temperature.accuracy>0.9;temperature.unit==Celsius` |                               |                         |
+| \`                | \`         | OR 条件                                                   | \`mq=temperature.accuracy>0.9 | humidity.accuracy>0.8\` |
 
 **例:**
 
@@ -377,16 +396,16 @@ curl 'http://localhost:3000/v2/entities?type=Room&mq=temperature.accuracy>0.9;te
 
 #### スコープクエリ (scopeQ) の詳細
 
-NGSI-LD の `scopeQ` パラメータは、エンティティのスコープ階層に対するクエリをサポートしています。
+NGSI-LD の `scopeQ` パラメータはエンティティのスコープ階層に対するクエリをサポートしています。
 
 **サポートされる演算子:**
 
-| 演算子 | 説明 | 例 |
-|----------|-------------|---------|
-| `/path` | 完全一致 | `scopeQ=/Japan/Tokyo` |
-| `/path/+` | 1 階層下のみ | `scopeQ=/Japan/+` (例: Tokyo) |
-| `/path/#` | すべての子孫 | `scopeQ=/Japan/#` (例: Tokyo、Tokyo/Shibuya) |
-| `;` | AND 条件 (複数のスコープ) | `scopeQ=/Japan/Tokyo;/IoT` |
+| 演算子       | 説明               | 例                                          |
+| --------- | ---------------- | ------------------------------------------ |
+| `/path`   | 完全一致             | `scopeQ=/Japan/Tokyo`                      |
+| `/path/+` | 直下の 1 レベルのみ      | `scopeQ=/Japan/+` (例: Tokyo)               |
+| `/path/#` | すべての子孫           | `scopeQ=/Japan/#` (例: Tokyo、Tokyo/Shibuya) |
+| `;`       | AND 条件 (複数のスコープ) | `scopeQ=/Japan/Tokyo;/IoT`                 |
 
 **例:**
 
@@ -406,13 +425,13 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo;/IoT'
 
 ### 2. ジオクエリ
 
-| ジオクエリ演算子 | NGSIv2 | NGSI-LD | 説明 |
-|--------------------|--------|---------|-------------|
-| `near` | ✅ | ✅ | 指定された地点の近く |
-| `coveredBy` | ✅ | ✅ | 領域内に完全に含まれる |
-| `within` | ✅ | ✅ | 領域と交差するか領域内に含まれる |
-| `intersects` | ✅ | ✅ | 領域と交差する |
-| `disjoint` | ✅ | ✅ | 領域と交差しない |
+| ジオクエリ演算子     | NGSIv2 | NGSI-LD | 説明               |
+| ------------ | ------ | ------- | ---------------- |
+| `near`       | ✅      | ✅       | 指定された地点の近く       |
+| `coveredBy`  | ✅      | ✅       | 領域内に完全に含まれる      |
+| `within`     | ✅      | ✅       | 領域と交差するか領域内に含まれる |
+| `intersects` | ✅      | ✅       | 領域と交差する          |
+| `disjoint`   | ✅      | ✅       | 領域と交差しない         |
 
 **例:**
 
@@ -426,35 +445,35 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 
 ### 3. ページネーション
 
-| ヘッダー | NGSIv2 | NGSI-LD | 説明 |
-|--------|--------|---------|-------------|
-| **合計数** | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数 |
-| **次のリンク** | `Link` (rel="next") | `Link` (rel="next") | 次のページへのリンク |
+| ヘッダー      | NGSIv2               | NGSI-LD                | 説明         |
+| --------- | -------------------- | ---------------------- | ---------- |
+| **合計数**   | `Fiware-Total-Count` | `NGSILD-Results-Count` | クエリ結果の総数   |
+| **次のリンク** | `Link` (rel="next")  | `Link` (rel="next")    | 次のページへのリンク |
 
 詳細については、[ページネーション](/ja/api-reference/pagination)を参照してください。
 
 ### 4. サブスクリプション
 
-| 通知方法 | NGSIv2 | NGSI-LD | 説明 |
-|--------------------|--------|---------|-------------|
-| **HTTP Webhook** | ✅ | ✅ | REST エンドポイントへの POST |
-| **MQTT** | ✅ | ✅ | MQTT ブローカーへの発行 (QoS 0/1/2、TLS) |
-| **WebSocket** | ✅ | ✅ | リアルタイムイベントストリーム |
+| 通知方法             | NGSIv2 | NGSI-LD | 説明                                 |
+| ---------------- | ------ | ------- | ---------------------------------- |
+| **HTTP Webhook** | ✅      | ✅       | REST エンドポイントへの POST                |
+| **MQTT**         | ✅      | ✅       | MQTT ブローカーへのパブリッシュ (QoS 0/1/2、TLS) |
+| **WebSocket**    | ✅      | ✅       | リアルタイムイベントストリーム                    |
 
 ### 5. フェデレーション (コンテキストソース登録)
 
-| 機能 | NGSIv2 | NGSI-LD | 説明 |
-|---------|--------|---------|-------------|
-| **登録 API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダー登録 |
-| **並列クエリ** | ✅ | ✅ | 複数のプロバイダーへの同時クエリ |
-| **結果のマージ** | ✅ | ✅ | ローカルとリモートの結果のマージ |
-| **ループ検出** | ✅ | ✅ | `Via` ヘッダーによるループ検出 |
+| 機能         | NGSIv2              | NGSI-LD                            | 説明                   |
+| ---------- | ------------------- | ---------------------------------- | -------------------- |
+| **登録 API** | `/v2/registrations` | `/ngsi-ld/v1/csourceRegistrations` | リモートプロバイダーの登録        |
+| **並列クエリ**  | ✅                   | ✅                                  | 複数のプロバイダーへの同時クエリ     |
+| **結果のマージ** | ✅                   | ✅                                  | ローカルおよびリモート結果のマージ    |
+| **ループ検出**  | ✅                   | ✅                                  | ループ検出 (`Via` ヘッダー経由) |
 
----
+***
 
 ## NGSI-LD 固有の機能
 
-以下の機能は NGSI-LD API でのみサポートされており、NGSIv2 API では直接利用できません。
+以下の機能は NGSI-LD API のみでサポートされており、NGSIv2 API では直接利用できません。
 
 ### 1. Relationship
 
@@ -473,7 +492,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 }
 ```
 
-> **注意:** プロトコル分離により、NGSI-LD エンティティ (Relationship 属性を含むもの) は NGSIv2 API 経由ではアクセスできません。
+> **注意:** プロトコルの分離により、NGSI-LD エンティティ (Relationship 属性を持つものを含む) は NGSIv2 API 経由ではアクセスできません。
 
 ### 2. LanguageProperty (多言語プロパティ)
 
@@ -495,9 +514,9 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 }
 ```
 
-**NGSI-LD で `lang=ja` を使用する場合:**
+**NGSI-LD で`lang=ja`を使用する場合:**
 
-`lang` クエリパラメータを使用すると、LanguageProperty は標準の Property に変換され、指定された言語の値が `value` フィールドに設定されます。
+When using the `lang` クエリパラメータを使用すると、LanguageProperty は標準の Property に変換され、指定された言語の値が`value` フィールドに設定されます。
 
 ```bash
 curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
@@ -515,11 +534,11 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Museum:M001?lang=ja'
 }
 ```
 
-> **注意:** プロトコル分離により、NGSI-LD エンティティ (LanguageProperty 属性を含むもの) は NGSIv2 API 経由ではアクセスできません。
+> **注意:** プロトコルの分離により、NGSI-LD エンティティ (LanguageProperty 属性を持つものを含む) は NGSIv2 API 経由ではアクセスできません。
 
 ### 3. Scope (スコープ階層)
 
-エンティティの論理階層を表します。
+エンティティの論理的な階層を表します。
 
 **NGSI-LD:**
 
@@ -540,12 +559,18 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?scopeQ=/Japan/Tokyo'
 
 **NGSIv2 互換性:**
 
-- NGSIv2 は階層的なエンティティ管理のために `Fiware-ServicePath` ヘッダを使用します
-- `servicePath` は `?attrs=servicePath` 経由で組み込み属性として利用可能です
-- **servicePath と scope は独立した概念です (#964):** これらは自動的には同期されません
-  - NGSIv2 `Fiware-ServicePath` → DB に `servicePath` として保存されます (インフラレベルの分離)
-  - NGSI-LD `scope` → DB に `scope` として保存されます (ユーザ定義の論理階層)
-  - NGSI-LD は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダを無視します
+
+* NGSIv2 は`Fiware-ServicePath` ヘッダーを階層的なエンティティ管理に使用します
+  
+* `servicePath` は組み込み属性として`?attrs=servicePath` 経由で利用可能です
+  
+* **servicePath と scope は独立した概念です (#964):** これらは自動的に同期されません
+  
+  * NGSIv2`Fiware-ServicePath` → DB に`servicePath` として格納されます (インフラストラクチャレベルの分離)
+    
+  * NGSI-LD`scope` → DB に`scope` として格納されます (ユーザー定義の論理階層)
+    
+  * NGSI-LD は ETSI GS CIM 009 仕様に従い`Fiware-ServicePath` ヘッダーを無視します
 
 ### 4. 属性プロジェクション (pick / omit パラメータ)
 
@@ -553,7 +578,7 @@ NGSI-LD では、`pick` と `omit` クエリパラメータを使用して、レ
 
 #### pick パラメータ (属性選択)
 
-指定された属性のみをレスポンスに含めます。
+レスポンスに指定された属性のみを含めます。
 
 **例:**
 
@@ -582,7 +607,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?pick=temper
 
 #### omit パラメータ (属性除外)
 
-指定された属性をレスポンスから除外します。
+レスポンスから指定された属性を除外します。
 
 **例:**
 
@@ -611,23 +636,28 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?omit=locati
 
 **注意事項:**
 
-- `pick` と `omit` を同時に使用することはできません
-- `pick` を使用する場合: `@context`、`id`、`type`、および指定された属性のみが含まれます。`createdAt` と `modifiedAt` は含まれません。
-- `omit` を使用する場合: 指定されたもの以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様に基づく)
+
+* `pick` と `omit` は同時に使用できません
+  
+* 使用時:`pick` のみ `@context`、`id`、`type`、および指定された属性が含まれます。`createdAt` と `modifiedAt` は含まれません。
+  
+* 使用時:`omit` 指定されたもの以外のすべての属性が含まれます。`id` と `type` は除外できません (ETSI GS CIM 009 V1.9.1 仕様による)
 
 **NGSIv2 互換性:**
 
-- NGSIv2 API では、`attrs` パラメータが同等の機能を提供します (選択のみ)
-- `omit` に相当する NGSIv2 の機能はありません
+
+* NGSIv2 API では、`attrs` パラメータが同等の機能を提供します (pick のみ)
+  
+* には NGSIv2 の同等機能はありません`omit`
 
 ```bash
 # Retrieve only temperature and humidity with NGSIv2 (equivalent to pick)
 curl 'http://localhost:3000/v2/entities/urn:ngsi-ld:Room:001?attrs=temperature,humidity'
 ```
 
-### 5. @context (JSON-LD コンテキスト)
+### 5. @context (JSON-LD Context)
 
-NGSI-LD では、エンティティに `@context` を含めることで語彙を定義します。
+NGSI-LD において、`@context` をエンティティに含めることで、ボキャブラリを定義します。
 
 **NGSI-LD:**
 
@@ -645,37 +675,47 @@ NGSI-LD では、エンティティに `@context` を含めることで語彙を
 
 **NGSIv2 互換性:**
 
-- NGSIv2 には `@context` の概念がありません
-- GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API によって返されません
 
----
+* NGSIv2 には `@context`
+  
+* GeonicDB は Smart Data Models の `@context` の自動補完をサポートしていますが、`@context` は NGSIv2 API では返されません
+
+***
 
 ## エンティティ ID の考慮事項
 
-### エンティティ ID の一意性 (GeonicDB 拡張)
+### エンティティ ID の一意性(GeonicDB 拡張)
 
-> **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント (`Fiware-Service`) とServicePath (`Fiware-ServicePath`) のスコープ内で一意です。エンティティ `type` は一意性制約の一部では**ありません**。
+> **GeonicDB 拡張**: GeonicDB では、エンティティ ID はテナント(`Fiware-Service`)とServicePath(`Fiware-ServicePath`)のスコープ内で一意です。エンティティ`type`は**一意性制約の対象ではありません**。
 
-これは、両方の API 間で ID のセマンティクスを統一するための意図的な設計上の決定です。
+これは両方の API における ID セマンティクスを統一する意図的な設計上の決定です:
 
-- **NGSI-LD** はエンティティ ID を URI として扱い、本質的に一意です
-- **NGSIv2** (標準) は同じ ID を持つが異なるタイプのエンティティの共存を許可します — GeonicDB はこの動作を**サポートしていません**
+
+* **NGSI-LD** はエンティティ ID を URI として扱い、本質的に一意です
+  
+* **NGSIv2** (標準)は同じ ID でも異なるタイプのエンティティの共存を許可しますが、GeonicDB は**この動作をサポートしていません** support this behavior
 
 **影響:**
 
-- **直接作成** (`POST /v2/entities`, `POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID を持つエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- **バッチ更新** (`POST /v2/op/update` と `append`/`appendStrict`): `entityId` のみでエンティティをマッチングします。属性は更新されますが、元の `type` は保持されます
-- **バッチ upsert** (`POST /ngsi-ld/v1/entityOperations/upsert`): `entityId` のみでエンティティをマッチングします。属性は更新されます (タイプ処理は upsert セマンティクスに従います)
-- **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複する ID に対してエンティティごとのエラー詳細を含む `207` を返します
-- 同じ ID のエンティティ間のタイプの曖昧性解消のための NGSIv2 `?type=` パラメータは適用されなくなりました
+* **直接作成** (`POST /v2/entities`, `POST /ngsi-ld/v1/entities`): 既存のエンティティと同じ ID のエンティティを作成すると(異なる`type`でも)`409 AlreadyExists`を返します
+  
+* **バッチ更新** (`POST /v2/op/update` と `append`/`appendStrict`): `entityId` のみでエンティティをマッチします。属性は更新されますが、元の`type`は保持されます
+  
+* **バッチアップサート** (`POST /ngsi-ld/v1/entityOperations/upsert` のみでエンティティをマッチします。属性は更新されます(タイプの処理はアップサートのセマンティクスに従います)
+  
+`entityId` only. Attributes are updated (type handling follows upsert semantics)
+  
+* **バッチ作成** (`POST /ngsi-ld/v1/entityOperations/create`): 重複 ID に対してエンティティごとのエラー詳細を含む`207`を返します
+  
+* 同じ ID のエンティティ間のタイプ曖昧性解消のための NGSIv2 `?type=` パラメータは適用されなくなりました
 
 この統一により、NGSIv2 のタイプベースの曖昧性解消が NGSI-LD の一意 ID モデルと競合する相互運用性の問題のクラスが排除されます。
 
 ### NGSI-LD URI 要件
 
-NGSI-LD 仕様では、エンティティ ID は URI 形式であることが推奨されています。
+NGSI-LD 仕様では、エンティティ ID を URI 形式にすることを推奨しています。
 
-**推奨形式 (URN):**
+**推奨形式(URN):**
 
 ```text
 urn:ngsi-ld:{EntityType}:{LocalId}
@@ -691,29 +731,38 @@ urn:ngsi-ld:WeatherObserved:Tokyo-2026-02-08
 
 **NGSIv2 互換性:**
 
-- NGSIv2 では任意の文字列を ID として使用できます (例: `Room1`, `sensor-abc`)
-- 使用する API に関係なく、一貫性と将来の移行のために URN 形式の使用が推奨されます
+
+* NGSIv2 では任意の文字列を ID として使用できます(例: `Room1`, `sensor-abc`)
+  
+* どちらの API を使用する場合でも、一貫性と将来の移行のために URN 形式の使用を推奨します
 
 **ベストプラクティス:**
 
-- NGSIv2 API を使用する場合でも、すべてのエンティティに URN 形式を使用してください
-- NGSIv2 から NGSI-LD に移行する場合、エンティティは NGSI-LD API 経由で再作成する必要があります (プロトコル分離により API 間のアクセスができません)
 
----
+* NGSIv2 API を使用する場合でも、すべてのエンティティに URN 形式を使用してください
+  
+* NGSIv2 から NGSI-LD に移行する場合、エンティティは NGSI-LD API を介して再作成する必要があります(プロトコル分離により API 間アクセスは防止されます)
 
-## Federation
+***
 
-GeonicDB のフェデレーション機能は、リモートコンテキストプロバイダのプロトコルを自動的に検出します。
+## フェデレーション
 
-### プロトコルの自動検出
+GeonicDB のフェデレーション機能は、リモートコンテキストプロバイダーのプロトコルを自動的に検出します。
 
-登録されたリモートプロバイダに対して、GeonicDB は以下の順序でプロトコルを検出します:
+### 自動プロトコル検出
 
-1. **明示的な指定** - 登録時に `information.format` が指定されている場合、そのプロトコルが使用されます
+登録されたリモートプロバイダーについて、GeonicDB は次の順序でプロトコルを検出します:
+
+
+1. **明示的な指定** - 登録時に`information.format`が指定されている場合、そのプロトコルが使用されます
+   
 2. **自動検出** - URL パスからの自動検出:
-   - `/v2/` を含む → NGSIv2
-   - `/ngsi-ld/` を含む → NGSI-LD
-   - それ以外 → NGSIv2 (デフォルト)
+   
+   * &#x20;を含む`/v2/` → NGSIv2
+     
+   * &#x20;を含む`/ngsi-ld/` → NGSI-LD
+     
+   * それ以外 → NGSIv2 (デフォルト)
 
 ### NGSIv2 からのフェデレーション
 
@@ -738,7 +787,7 @@ curl -X POST http://localhost:3000/v2/registrations \
   }'
 ```
 
-**NGSIv2 でクエリすると、NGSI-LD プロバイダに自動的に転送されます:**
+**NGSIv2 でのクエリは自動的に NGSI-LD プロバイダーに転送されます:**
 
 ```bash
 curl http://localhost:3000/v2/entities/urn:ngsi-ld:Vehicle:V999 \
@@ -747,9 +796,14 @@ curl http://localhost:3000/v2/entities/urn:ngsi-ld:Vehicle:V999 \
 
 **動作:**
 
-1. GeonicDB は `urn:ngsi-ld:Vehicle:V999` がローカルに存在しないことを検出します
-2. 登録情報から `http://remote-provider.example.com/ngsi-ld/v1` を特定します
-3. NGSI-LD プロトコルを使用してクエリを転送します: `GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`4. レスポンスを NGSI-LD → 内部フォーマット → NGSIv2 に変換し、クライアントに返します
+
+1. GeonicDB がローカルに存在しないことを検出`urn:ngsi-ld:Vehicle:V999`
+   
+2. 登録情報から特定`http://remote-provider.example.com/ngsi-ld/v1`
+   
+3. NGSI-LD プロトコルを使用してクエリを転送:`GET /ngsi-ld/v1/entities/urn:ngsi-ld:Vehicle:V999`
+   
+4. NGSI-LD → 内部形式 → NGSIv2 からのレスポンスを変換してクライアントに返します
 
 ### NGSI-LD からのフェデレーション
 
@@ -773,7 +827,7 @@ curl -X POST http://localhost:3000/ngsi-ld/v1/csourceRegistrations \
   }'
 ```
 
-**NGSI-LD でクエリすると、NGSIv2 プロバイダに自動的に転送されます:**
+**NGSI-LD でのクエリは自動的に NGSIv2 プロバイダーに転送されます:**
 
 ```bash
 curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:S888 \
@@ -782,52 +836,75 @@ curl http://localhost:3000/ngsi-ld/v1/entities/urn:ngsi-ld:Sensor:S888 \
 
 **動作:**
 
-1. GeonicDB は `urn:ngsi-ld:Sensor:S888` がローカルに存在しないことを検出します
-2. 登録情報から `http://legacy-system.example.com/v2` を特定します
-3. NGSIv2 プロトコルを使用してクエリを転送します: `GET /v2/entities/urn:ngsi-ld:Sensor:S888`4. レスポンスを NGSIv2 → 内部フォーマット → NGSI-LD に変換し、クライアントに返します
 
----
+1. GeonicDB がローカルに存在しないことを検出`urn:ngsi-ld:Sensor:S888`
+   
+2. 登録情報から特定`http://legacy-system.example.com/v2`
+   
+3. NGSIv2 プロトコルを使用してクエリを転送:`GET /v2/entities/urn:ngsi-ld:Sensor:S888`
+   
+4. NGSIv2 → 内部形式 → NGSI-LD からのレスポンスを変換してクライアントに返します
+
+***
 
 ## ユースケースとベストプラクティス
 
-### どの API を使用すべきか？
+### どの API を使うべきか?
 
-#### NGSIv2 を選択すべき場合
+#### NGSIv2 を選ぶべき場合
 
-- **既存の FIWARE Orion 互換システム** - レガシーシステムとの統合
-- **シンプルな IoT データ管理** - センサーデータの収集と可視化
-- **学習曲線が低い** - NGSI-LD よりもシンプルな仕様
-- **豊富な既存のドキュメントとツール** - 成熟した NGSIv2 エコシステム
 
-**推奨されるユースケース：**
+* **既存の FIWARE Orion 互換システム** - レガシーシステムとの統合
+  
+* **シンプルな IoT データ管理** - センサーデータの収集と可視化
+  
+* **低い学習曲線** - NGSI-LD よりもシンプルな仕様
+  
+* **豊富な既存ドキュメントとツール** - 成熟した NGSIv2 エコシステム
 
-- IoT センサーネットワーク
-- 基本的なスマートシティデータ収集
-- プロトタイピングと PoC
+**推奨される使用例:**
 
-#### NGSI-LD を選択すべき場合
 
-- **セマンティック Web / リンクトデータ** - JSON-LD と RDF の活用
-- **複雑なエンティティ関係** - Relationship と LanguageProperty の使用
-- **国際標準への準拠** - ETSI 標準に準拠したシステム
-- **将来の拡張性** - NGSI-LD 仕様は継続的に拡張されています
+* IoT センサーネットワーク
+  
+* 基本的なスマートシティデータ収集
+  
+* プロトタイピングと PoC
 
-**推奨されるユースケース：**
+#### NGSI-LD を選ぶべき場合
 
-- Smart Data Models を活用したデータカタログ
-- 多言語サポートが必要なシステム
-- エンティティ間の複雑な関係を表現する必要があるシステム
-- データ統合とオープンデータ公開
 
-#### 両方の API の同時実行
+* **セマンティック Web / リンクトデータ** - JSON-LD と RDF の活用
+  
+* **複雑なエンティティ関係** - Relationship と LanguageProperty の使用
+  
+* **国際標準への準拠** - ETSI 標準に準拠したシステム
+  
+* **将来の拡張性** - NGSI-LD 仕様は継続的に拡張されています
 
-GeonicDB は両方の API を同時にサポートしていますが、エンティティはプロトコルごとに分離されています。各 API は独自のエンティティセットで独立して動作します。
+**推奨される使用例:**
 
-**推奨されるアプローチ：**
 
-1. **ユースケースごとに 1 つの API を選択** - 同じデータに対してプロトコルを混在させないでください。要件に基づいて NGSIv2 または NGSI-LD を選択し、それに従ってください
-2. **クロスプロトコルのニーズには Federation を使用** - NGSIv2 クライアントが NGSI-LD エンティティにアクセスする必要がある場合（またはその逆）、Federation を介してコンテキストソースを登録します
-3. **マイグレーションには再作成が必要** - エンティティを NGSIv2 から NGSI-LD に移行するには、NGSIv2 API からエクスポートし、NGSI-LD API を介して再作成します。自動的なクロスプロトコルマイグレーションはありません
+* Smart Data Models を活用したデータカタログ
+  
+* 多言語サポートが必要なシステム
+  
+* エンティティ間の複雑な関係を表現する必要があるシステム
+  
+* データ統合とオープンデータ公開
+
+#### 両方の API を同時実行する
+
+GeonicDB は両方の API を同時にサポートしていますが、エンティティはプロトコルごとに分離されています。各 API は独自のエンティティセットに対して独立して動作します。
+
+**推奨されるアプローチ:**
+
+
+1. **使用例ごとに 1 つの API を選択する** - 同じデータに対してプロトコルを混在させないでください。要件に基づいて NGSIv2 または NGSI-LD を選び、それを使い続けてください
+   
+2. **プロトコル間の必要性には Federation を使用する** - NGSIv2 クライアントが NGSI-LD エンティティにアクセスする必要がある場合(またはその逆)、Federation を介してコンテキストソースを登録してください
+   
+3. **マイグレーションには再作成が必要** - エンティティを NGSIv2 から NGSI-LD に移行するには、NGSIv2 API からエクスポートし、NGSI-LD API を介して再作成してください。自動的なプロトコル間マイグレーションはありません
 
 ### ベストプラクティス
 
@@ -846,7 +923,7 @@ Room1
 sensor-abc
 ```
 
-理由: NGSI-LD 仕様に準拠し、両方の API で互換性を維持できます。
+理由: NGSI-LD 仕様に準拠し、両方の API 間で互換性を維持します。
 
 #### 2. 地理空間データに GeoJSON を使用する
 
@@ -882,7 +959,7 @@ sensor-abc
 
 #### 3. Smart Data Models を活用する
 
-GeonicDB は Smart Data Models の `@context` を自動補完します。
+GeonicDB は Smart Data Models を自動的に補完します`@context`。
 
 **推奨 (NGSI-LD):**
 
@@ -897,19 +974,19 @@ GeonicDB は Smart Data Models の `@context` を自動補完します。
 }
 ```
 
-理由: `type` が Smart Data Models のモデル名と一致する場合、適切な `@context` が自動的に補完されます。
+理由: `type`が Smart Data Models のモデル名と一致する場合、適切な`@context`が自動的に補完されます。
 
 #### 4. 目的に応じてサブスクリプションを選択する
 
-| 目的 | 推奨チャネル | 理由 |
-|------|-------------|------|
-| Web アプリ (リアルタイム更新) | WebSocket | 低レイテンシ、サーバ不要 |
-| サーバ間連携 | HTTP Webhook | 信頼性、リトライ機能 |
-| IoT デバイス | MQTT | 軽量、QoS 保証 |
+| 目的                 | 推奨チャネル       | 理由             |
+| ------------------ | ------------ | -------------- |
+| Web アプリ (リアルタイム更新) | WebSocket    | 低レイテンシー、サーバー不要 |
+| サーバー間統合            | HTTP Webhook | 信頼性、リトライ機能     |
+| IoT デバイス           | MQTT         | 軽量、QoS 保証      |
 
 #### 5. テナント分離を活用する
 
-`Fiware-Service` ヘッダを使用してテナントを分離します。
+テナントを分離するには`Fiware-Service`ヘッダーを使用します。
 
 ```bash
 # Create entity in tenant "demo"
@@ -923,33 +1000,38 @@ curl -X POST http://localhost:3000/v2/entities \
   -d '{...}'
 ```
 
-理由: 開発環境と本番環境の分離、顧客ごとのデータ分離が可能になります。
+理由: 開発環境と本番環境の分離、および顧客ごとのデータの分離が可能になります。
 
----
+***
 
-## まとめ
+## 概要
 
-| 項目 | NGSIv2 | NGSI-LD | GeonicDB の動作 |
-|------|--------|---------|----------------|
-| **プロトコル** | REST/JSON | REST/JSON-LD | 両方サポート; エンティティは `protocol` フィールドで分離 |
-| **エンティティ分離** | `protocol: 'ngsiv2'` | `protocol: 'ngsild'` | 各 API は自身のエンティティのみを参照 |
-| **エンティティ ID** | 任意の文字列 | URI (URN 推奨) | URN 推奨。**ID はテナント + servicePath ごとに一意** (タイプによる曖昧性排除は削除) |
-| **属性タイプ** | シンプル (Number、Text など) | セマンティック (Property、Relationship など) | タイプマッピングルールで対応関係を定義 (上記の表を参照) |
-| **システム属性** | `dateCreated`、`dateModified` | `createdAt`、`modifiedAt` | 内部的に統一、API ごとに変換 |
-| **ジオクエリ** | ✅ | ✅ | 共有機能 |
-| **サブスクリプション** | ✅ (HTTP、MQTT、WebSocket) | ✅ (HTTP、MQTT、WebSocket) | 共有機能 |
-| **フェデレーション** | ✅ | ✅ | 自動プロトコル検出; プロトコル間アクセスを実現 |
-| **プロトコル間アクセス** | 直接サポートなし | 直接サポートなし | プロトコル間アクセスにはフェデレーションを使用 |
-| **ユースケース** | IoT、レガシーシステム | Semantic Web、オープンデータ | ユースケースごとに 1 つの API を選択 |
+| 項目               | NGSIv2                       | NGSI-LD                            | GeonicDB の動作                                           |
+| ---------------- | ---------------------------- | ---------------------------------- | ------------------------------------------------------ |
+| **プロトコル**        | REST/JSON                    | REST/JSON-LD                       | 両方サポート。エンティティは `protocol` フィールドで分離                     |
+| **エンティティの分離**    | `protocol: 'ngsiv2'`         | `protocol: 'ngsild'`               | 各 API は自身のエンティティのみを参照                                  |
+| **エンティティ ID**    | 任意の文字列                       | URI (URN 推奨)                       | URN 推奨。**ID はテナント + servicePath ごとに一意** (型による曖昧性解消は削除) |
+| **属性タイプ**        | シンプル (Number、Text など)        | セマンティック (Property、Relationship など) | 型マッピングルールが対応関係を定義 (上記の表を参照)                            |
+| **システム属性**       | `dateCreated`、`dateModified` | `createdAt`、`modifiedAt`           | 内部的に統一、API ごとに変換                                       |
+| **ジオクエリ**        | ✅                            | ✅                                  | 共有機能                                                   |
+| **サブスクリプション**    | ✅ (HTTP、MQTT、WebSocket)      | ✅ (HTTP、MQTT、WebSocket)            | 共有機能                                                   |
+| **フェデレーション**     | ✅                            | ✅                                  | 自動プロトコル検出。クロスプロトコルアクセスを実現                              |
+| **クロスプロトコルアクセス** | 直接サポートなし                     | 直接サポートなし                           | クロスプロトコルのニーズにはフェデレーションを使用                              |
+| **ユースケース**       | IoT、レガシーシステム                 | Semantic Web、オープンデータ               | ユースケースごとに 1 つの API を選択                                 |
 
-GeonicDB は NGSIv2 と NGSI-LD の両方の API を提供し、厳格なプロトコル分離を行います。ユースケースに最適な API を選択し、プロトコル間アクセスが必要な場合はフェデレーションを活用してください。
+GeonicDB は NGSIv2 と NGSI-LD の両方の API を厳密なプロトコル分離で提供します。ユースケースに最適な API を選択し、クロスプロトコルアクセスが必要な場合はフェデレーションを活用してください。
 
----
+***
 
 ## 関連ドキュメント
 
-- [API 共通仕様](../api-reference/endpoints.md)
-- [NGSIv2 API](../api-reference/ngsiv2.md)
-- [NGSI-LD API](../api-reference/ngsild.md)
-- [Smart Data Models](../features/smart-data-models.md)
-- [FIWARE Orion 比較](../migration/compatibility-matrix.md)
+
+* [API 共通仕様](../api-reference/endpoints.md)
+  
+* [NGSIv2 API](../api-reference/ngsiv2.md)
+  
+* [NGSI-LD API](../api-reference/ngsild.md)
+  
+* [Smart Data Models](../features/smart-data-models.md)
+  
+* [FIWARE Orion 比較](../migration/compatibility-matrix.md)

--- a/docs/ja/features/subscriptions.md
+++ b/docs/ja/features/subscriptions.md
@@ -5,34 +5,42 @@ outline: deep
 ---
 # WebSocket イベントストリーミング
 
-GeonicDB は WebSocket によるリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムで購読し、Web アプリケーションやダッシュボードに即座に反映できます。
+GeonicDB は WebSocket 経由でリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムでサブスクリプションライブし、Web アプリケーションやダッシュボードに即座に反映させることができます。
 
 ## 目次
 
-- [概要](#概要)
-- [アーキテクチャと有効化](#アーキテクチャと有効化)
-- [接続](#接続)
-- [メッセージ形式とフィルタリング](#メッセージ形式とフィルタリング)
-- [クライアント実装](#クライアント実装)
-- [ベストプラクティス](#ベストプラクティス)
-- [トラブルシューティング](#トラブルシューティング)
-- [制約](#制約)
 
----
+* [概要](#概要)
+  
+* [アーキテクチャと有効化](#アーキテクチャと有効化)
+  
+* [接続](#接続)
+  
+* [メッセージフォーマットとフィルタリング](#message-format-and-filtering)
+  
+* [クライアント実装](#クライアント実装)
+  
+* [ベストプラクティス](#ベストプラクティス)
+  
+* [トラブルシューティング](#トラブルシューティング)
+  
+* [制約事項](#制約事項)
+
+***
 
 ## 概要
 
-イベントストリーミングは、既存の MongoDB Change Streams → EventBridge パイプラインに並行パスを追加し、エンティティの変更を WebSocket クライアントにブロードキャストします。
+イベントストリーミングは、既存の MongoDB Change Streams → EventBridge パイプラインに並列パスを追加し、エンティティの変更を WebSocket クライアントにブロードキャストします。
 
 ### 通知チャネルの比較
 
-| チャネル | 方向 | フィルタリング | レイテンシ |
-|---------|-----------|-----------|---------|
-| HTTP Webhook (既存) | Push | サブスクリプション条件 | 約 1 分 |
-| MQTT (既存) | Push | サブスクリプション条件 | 約 1 分 |
-| WebSocket (本機能) | Push | テナント + エンティティタイプ/ID パターン | 約 1 分 |
+| チャネル              | 方向   | フィルタリング                    | レイテンシ |
+| ----------------- | ---- | -------------------------- | ----- |
+| HTTP Webhook (既存) | Push | サブスクリプション条件                | \~1 分 |
+| MQTT (既存)         | Push | サブスクリプション条件                | \~1 分 |
+| WebSocket (本機能)   | Push | テナント + エンティティタイプ / ID パターン | \~1 分 |
 
----
+***
 
 ## アーキテクチャと有効化
 
@@ -43,9 +51,12 @@ EventBridge ─┬─> SubscriptionMatcher -> SQS -> HTTP/MQTT  [existing]
              └─> WsBroadcastFunction -> API GW WebSocket -> client  [new]
 ```
 
-- **接続状態**: DynamoDB (PAY_PER_REQUEST、自動 TTL クリーンアップ)
-- **接続管理**: 3 つの Lambda 関数 (connect、disconnect、default)
-- **ブロードキャスト**: EventBridge から直接トリガーされる Lambda 関数
+
+* **接続状態**: DynamoDB (PAY\_PER\_REQUEST、自動 TTL クリーンアップ)
+  
+* **接続管理**: 3 つの Lambda 関数 (connect、disconnect、default)
+  
+* **ブロードキャスト**: EventBridge から直接トリガーされる Lambda 関数
 
 ### 有効化
 
@@ -53,13 +64,13 @@ GeonicDB SaaS ではイベントストリーミングは既定で有効です。
 
 ### 環境変数
 
-| 変数 | 説明 |
-|----------|-------------|
-| `EVENT_STREAMING_ENABLED` | `true` に設定して有効化 |
-| `WS_CONNECTIONS_TABLE` | DynamoDB 接続テーブル名 (自動設定) |
-| `WS_API_ENDPOINT` | WebSocket API エンドポイント (自動設定) |
+| 変数                        | 説明                          |
+| ------------------------- | --------------------------- |
+| `EVENT_STREAMING_ENABLED` |  に設定して有効化`true`             |
+| `WS_CONNECTIONS_TABLE`    | DynamoDB 接続テーブル名(自動設定)      |
+| `WS_API_ENDPOINT`         | WebSocket API エンドポイント(自動設定) |
 
----
+***
 
 ## 接続
 
@@ -77,48 +88,59 @@ ws://localhost:3000?tenant={tenantName}
 
 ### クエリパラメータ
 
-| パラメータ | 必須 | 説明 |
-|-----------|------|------|
-| `tenant` | ✅ | テナント名 (`Fiware-Service` ヘッダーと同等) |
+| パラメータ    | 必須 | 説明                              |
+| -------- | -- | ------------------------------- |
+| `tenant` | ✅  | テナント名(`Fiware-Service` ヘッダーと同等) |
 
 ### 認証
 
-`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは次の優先順位で抽出されます:
+When `AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは以下の優先順位で抽出されます:
 
-1. **`Authorization` ヘッダー (推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
-2. **`Sec-WebSocket-Protocol` ヘッダー (ブラウザ向け)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用
 
-> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。これまで URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
+1. **`Authorization` ヘッダー(推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
+   
+2. **`Sec-WebSocket-Protocol` ヘッダー(ブラウザ用)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用します
 
-- REST API `/auth/login` エンドポイントから取得した `accessToken` をトークンとして直接使用してください。
-- `super_admin` ロールは、WebSocket ストリーミングのために任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API (`/v2/*`、`/ngsi-ld/*`) にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
-- `tenant_admin` / `user` ロールは自分のテナントにのみ接続できます。
+> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは使用できなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。以前 URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
 
-| 条件 | 結果 |
-|------|------|
-| `AUTH_ENABLED=false`、トークンなし | ✅ 接続許可 |
-| `AUTH_ENABLED=true`、トークンなし | ❌ 接続拒否 (1008) |
-| `AUTH_ENABLED=true`、無効なトークン | ❌ 接続拒否 (1008) |
-| `AUTH_ENABLED=true`、有効なトークン、自分のテナント | ✅ 接続許可 |
-| `AUTH_ENABLED=true`、有効なトークン、他のテナント | ❌ 接続拒否 (1008) |
-| `AUTH_ENABLED=true`、super_admin、任意のテナント | ✅ 接続許可 |
+
+* REST API `accessToken` エンドポイントから取得した `/auth/login` をトークンとして直接使用します。
+  
+* The `super_admin` ロールは WebSocket ストリーミングのために任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API(`/v2/*`、`/ngsi-ld/*`)にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
+  
+* The `tenant_admin` / `user` ロールは自分のテナントにのみ接続できます。
+
+| 条件                                       | 結果           |
+| ---------------------------------------- | ------------ |
+| `AUTH_ENABLED=false`、トークンなし              | ✅ 接続許可       |
+| `AUTH_ENABLED=true`、トークンなし               | ❌ 接続拒否(1008) |
+| `AUTH_ENABLED=true`、無効なトークン              | ❌ 接続拒否(1008) |
+| `AUTH_ENABLED=true`、有効なトークン、自テナント        | ✅ 接続許可       |
+| `AUTH_ENABLED=true`、有効なトークン、他テナント        | ❌ 接続拒否(1008) |
+| `AUTH_ENABLED=true`、super\_admin、任意のテナント | ✅ 接続許可       |
 
 ### 接続フロー
 
-1. クライアントが WebSocket URL に接続 (`tenant` クエリパラメータは必須; 認証が有効な場合はトークンも必須)
-2. サーバーがトークンを検証し、テナントアクセス権限を確認 (認証が有効な場合)
-3. トークンに `cnf.jkt` クレーム (DPoP バインドトークン) が含まれている場合、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります (下記の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
-4. サーバーが DynamoDB に接続を記録 (TTL: 2 時間)
-5. オプション: `subscribe` メッセージでフィルター条件を設定
-6. エンティティが変更されると、サーバーがクライアントにイベントをプッシュ
 
----
+1. クライアントが WebSocket URL に接続します(`tenant` クエリパラメータは必須です。認証が有効な場合はトークンも必要です)
+   
+2. サーバーがトークンを検証し、テナントアクセス権限を確認します(認証が有効な場合)
+   
+3. トークンに `cnf.jkt` クレームが含まれている場合(DPoP バインドトークン)、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります(以下の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
+   
+4. サーバーが DynamoDB に接続を記録します(TTL: 2 時間)
+   
+5. オプション: `subscribe` メッセージでフィルタ条件を設定します
+   
+6. エンティティが変更されると、サーバーがクライアントにイベントをプッシュします
 
-## メッセージフォーマットとフィルタリング
+***
+
+## メッセージ形式とフィルタリング
 
 ### クライアント → サーバー
 
-#### subscribe (フィルタ設定)
+#### subscribe (フィルター設定)
 
 ```json
 {
@@ -128,13 +150,13 @@ ws://localhost:3000?tenant={tenantName}
 }
 ```
 
-| フィールド | 型 | 説明 |
-|-------|------|-------------|
-| `action` | string | `subscribe` |
-| `entityTypes` | string[] | フィルタリングするエンティティタイプ |
-| `idPattern` | string | エンティティ ID の正規表現パターン |
+| フィールド         | 型         | 説明                  |
+| ------------- | --------- | ------------------- |
+| `action`      | string    | `subscribe`         |
+| `entityTypes` | string\[] | フィルタリングするエンティティタイプ  |
+| `idPattern`   | string    | エンティティ ID の正規表現パターン |
 
-#### dpop_bind (DPoP 証明検証)
+#### dpop\_bind (DPoP 証明検証)
 
 ```json
 {
@@ -143,9 +165,9 @@ ws://localhost:3000?tenant={tenantName}
 }
 ```
 
-DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する場合に必要です。接続後 5 秒以内に送信する必要があります。サーバーは証明の JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` で応答します。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否されます。
+DPoP バインドトークン (JWT に含まれる`cnf.jkt`) で接続する場合は必須です。接続から 5 秒以内に送信する必要があります。サーバーは証明の JWK Thumbprint がトークンの`cnf.jkt`クレームと一致することを検証し、`{"type": "dpop_verified"}`で応答します。検証されるまで、他のすべてのメッセージは`{"type": "error", "message": "DPoP proof required"}`で拒否されます。
 
-詳細は AUTH.md — DPoP Token Binding を参照してください。
+詳細については AUTH.md — DPoP Token Binding を参照してください。
 
 #### ping (キープアライブ)
 
@@ -155,7 +177,7 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 }
 ```
 
-サーバーは `{"type": "pong"}` を返します。10 分間のアイドルタイムアウトを防ぐため、5 分ごとに ping を送信してください。
+サーバーは`{"type": "pong"}`を返します。10 分間のアイドルタイムアウトを防ぐために、5 分ごとに ping を送信してください。
 
 ### サーバー → クライアント
 
@@ -176,48 +198,53 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 }
 ```
 
-| フィールド | 型 | 説明 |
-|-------|------|-------------|
-| `type` | string | `entityCreated`、`entityUpdated`、`entityDeleted` |
-| `tenant` | string | テナント名 |
-| `servicePath` | string | ServicePath |
-| `entityId` | string | エンティティ ID |
-| `entityType` | string | エンティティタイプ |
-| `data` | object | エンティティ属性データ |
-| `changedAttributes` | string[] | 変更された属性の名前 (更新時のみ) |
-| `timestamp` | string | イベントタイムスタンプ (ISO 8601) |
+| フィールド               | 型         | 説明                                              |
+| ------------------- | --------- | ----------------------------------------------- |
+| `type`              | string    | `entityCreated`、`entityUpdated`、`entityDeleted` |
+| `tenant`            | string    | テナント名                                           |
+| `servicePath`       | string    | ServicePath                                          |
+| `entityId`          | string    | エンティティ ID                                       |
+| `entityType`        | string    | エンティティタイプ                                       |
+| `data`              | object    | エンティティ属性データ                                     |
+| `changedAttributes` | string\[] | 変更された属性の名前 (更新時のみ)                              |
+| `timestamp`         | string    | イベントタイムスタンプ (ISO 8601)                          |
 
 ### フィルタリング
 
 フィルタリングは次の順序で 3 つの層で適用されます:
 
-1. **テナントフィルタ (必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
-2. **接続側の `subscribe` フィルタ (オプション)** — クライアントが受信したい内容を絞り込みます:
-   - `entityTypes`: 受信するエンティティタイプの配列
-   - `idPattern`: `entityId` に対してマッチングされる正規表現
+
+1. **テナントフィルタ(必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
+   
+2. **接続側の `subscribe` フィルタ(オプション)** — クライアントが必要なものを絞り込みます:
+   
+   * `entityTypes`: 受信するエンティティタイプの配列
+     
+   * `idPattern`: `entityId` に対してマッチングされる正規表現
+     
 3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターはアクティブな XACML ポリシーを実行します。サブジェクトがイベントに対して `Permit` された接続のみに配信されます。
 
-#### XACML で利用可能なイベントごとのリソース属性 (#1107)
+#### XACML で利用可能なイベントごとのリソース属性(#1107)
 
-ブロードキャスターが配信を認可する際、以下のエンティティごとのリソース属性を AuthzRequest に注入します:
+ブロードキャスターが配信を認可する際、次のエンティティごとのリソース属性を AuthzRequest に注入します:
 
-| attributeId | ソース |
-|-------------|--------|
-| `entityType` | イベントのエンティティタイプ |
-| `entityId` | イベントのエンティティ ID |
-| `entityOwner` | イベントエンティティの `createdBy` (元々エンティティを `POST` したユーザー) |
+| attributeId   | ソース                                              |
+| ------------- | ------------------------------------------------ |
+| `entityType`  | イベントのエンティティタイプ                                   |
+| `entityId`    | イベントのエンティティ ID                                   |
+| `entityOwner` | イベントエンティティの `createdBy`(元々エンティティを `POST` したユーザー) |
 
-これにより、`${subject.userId}` テンプレート展開と `entityOwner` を使用して、単一の XACML ポリシーで「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった**ユーザーごとの配信フィルタ**を記述できます。完全なポリシー例については `docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性 を参照してください。
+これにより、**ユーザーごとの配信フィルタ** を記述できます。例えば「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といったルールを、`${subject.userId}` テンプレート展開と `entityOwner` を使用した単一の XACML ポリシーで実現できます。`docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性 を参照して、完全なポリシー例を確認してください。
 
-> 認証なしで書き込まれたエンティティ (または `createdBy` を設定しないレガシー / バッチパス経由) は、`owner` 属性のないイベントを発行します — 所有者ベースのルールはこれらのイベントにマッチしないため、このフォールバックを考慮してポリシーを設計してください。
+> 認証なしで書き込まれたエンティティ(または `createdBy` を設定しないレガシー/バッチパス経由)は、`owner` 属性なしのイベントを発行します — 所有者ベースのルールはこれらのイベントにマッチしないため、そのフォールバックを考慮してポリシーを設計してください。
 
----
+***
 
 ## クライアント実装
 
 ### JavaScript SDK (推奨)
 
-GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンの更新、DPoP バインディング、再接続を自動的に処理します。
+GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンのリフレッシュ、DPoP バインディング、再接続を自動的に処理します。
 
 ```bash
 npm install @geolonia/geonicdb-sdk
@@ -257,7 +284,7 @@ db.on('connected', function() {
 // db.reconnect();
 ```
 
-Bearer JWT 認証の場合(例: ログインフロー後)、`setCredentials()` で認証情報を注入します:
+Bearer JWT 認証の場合(例:ログインフロー後)、次の方法で認証情報を注入します`setCredentials()`:
 
 ```javascript
 import GeonicDB from '@geolonia/geonicdb-sdk';
@@ -555,11 +582,11 @@ wscat -c "wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant=smart
 > {"action": "ping"}
 ```
 
----
+***
 
-## WebSocket の DPoP バインディング {#dpop-binding-for-websocket}
+## WebSocket の DPoP バインディング
 
-DPoP バインドトークンを使用する WebSocket 接続には、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
+DPoP バインドトークンを使用する WebSocket 接続では、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
 
 ### フロー
 
@@ -582,22 +609,22 @@ Client                               Server
 
 ### 状態
 
-| 状態 | 説明 | 許可されるメッセージ |
-|-------|-------------|------------------|
-| `pending_dpop` | 接続後に DPoP 証明を待機中 | `dpop_bind` のみ |
-| `verified` | DPoP 証明が正常に検証された | `subscribe`、`ping` など |
+| 状態             | 説明               | 許可されるメッセージ            |
+| -------------- | ---------------- | --------------------- |
+| `pending_dpop` | 接続後の DPoP 証明待ち   | `dpop_bind` のみ        |
+| `verified`     | DPoP 証明の検証が正常に完了 | `subscribe`、`ping`、など |
 
-`dpop_bind` メッセージが 5 秒以内に受信されない場合、接続は終了されます。
+&#x20;メッセージが `dpop_bind` 秒以内に受信されない場合、接続は終了されます。
 
----
+***
 
 ## ベストプラクティス
 
 ### 1. 再接続ロジック
 
-> **注意**: JavaScript SDK を使用している場合、指数バックオフを使用した再接続が組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続試行を追跡できます。以下の例は、raw WebSocket 実装向けです。
+> **注意**: JavaScript SDK を使用している場合、指数バックオフによる再接続は組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続の試行を追跡してください。以下の例は、生の WebSocket 実装向けです。
 
-指数バックオフを使用した堅牢な再接続を実装します:
+指数バックオフによる堅牢な再接続を実装してください:
 
 ```javascript
 class GeonicDBWebSocket {
@@ -647,7 +674,7 @@ setInterval(() => {
 
 ### 3. イベント処理の最適化
 
-大量のイベントを受信する場合、デバウンシングで UI 更新を最適化します:
+大量のイベントを受信する場合、デバウンスを使用して UI の更新を最適化します:
 
 ```javascript
 import { debounce } from 'lodash';
@@ -681,7 +708,7 @@ async function getToken() {
 }
 ```
 
-**トークン有効期限の管理:**
+**トークンの有効期限管理:**
 
 ```javascript
 function isTokenExpired(token, bufferSeconds = 60) {
@@ -712,18 +739,21 @@ onUnmounted(() => {
 });
 ```
 
----
+***
 
 ## トラブルシューティング
 
-### 1. 接続が拒否される (1008 エラー)
+### 1. 接続が拒否される(1008 エラー)
 
 **原因:**
-- トークンが無効または期限切れ
-- テナントへのアクセス権限がない
-- `AUTH_ENABLED=true` にもかかわらずトークンが提供されていない
 
-**解決方法:**
+* トークンが無効または期限切れ
+  
+* テナントへのアクセス権限がない
+  
+* トークンが必要にもかかわらず提供されていない`AUTH_ENABLED=true`
+
+**解決策:**
 
 ```javascript
 ws.onclose = (event) => {
@@ -737,9 +767,9 @@ ws.onclose = (event) => {
 
 ### 2. 10 分後に接続が切断される
 
-**原因:** Keep-alive (ping) メッセージが送信されていない。
+**原因:**&#x4B;eep-alive(ping)メッセージが送信されていない。
 
-**解決方法:**
+**解決策:**
 
 ```javascript
 // Send a ping every 5 minutes
@@ -753,11 +783,14 @@ setInterval(() => {
 ### 3. イベントを受信できない
 
 **原因:**
-- フィルタが厳しすぎる
-- テナントが間違っている
-- エンティティの作成/更新が実際に発生していない
 
-**解決方法:**
+* フィルターが厳しすぎる
+  
+* 誤ったテナント
+  
+* エンティティの作成/更新が実際には発生していない
+
+**解決策:**
 
 ```javascript
 // Debug: log all messages
@@ -777,10 +810,12 @@ ws.send(JSON.stringify({
 ### 4. ローカル開発環境で接続できない
 
 **原因:**
-- ローカルサーバーが起動していない
-- WebSocket URL が間違っている
 
-**解決方法:**
+* ローカルサーバーが実行されていない
+  
+* WebSocket URL が間違っている
+
+**解決策:**
 
 ```bash
 # Start the local server
@@ -792,7 +827,7 @@ const wsUrl = 'ws://localhost:3000?tenant=demo';
 
 ### 5. デバッグ
 
-ブラウザの開発者ツールの Network タブで、WebSocket 接続と送受信されたメッセージを確認できます。
+ブラウザの開発者ツールの Network タブで WebSocket 接続と送受信メッセージを検査できます。
 
 ```javascript
 class DebugWebSocket {
@@ -812,24 +847,28 @@ class DebugWebSocket {
 }
 ```
 
----
+***
 
-## 制約
+## 制約事項
 
-| 項目 | 値 | 説明 |
-|------|-------|-------------|
-| アイドルタイムアウト | 10 分 | クライアントは 5 分ごとに ping を送信する必要があります |
-| 同時接続数 | 500 (デフォルト) | AWS Support 経由で増やすことができます |
-| フレームサイズ | 128KB | 大きなエンティティは切り詰めが必要です |
-| レイテンシ | ~1 分 | MongoDB Change Stream のポーリング間隔に依存します |
-| 接続 TTL | 2 時間 | DynamoDB TTL によって自動的にクリーンアップされます |
-| ローカル開発 | サポート対象 | ローカル WebSocket サーバー経由で利用可能 |
+| 項目         | 値          | 説明                                |
+| ---------- | ---------- | --------------------------------- |
+| アイドルタイムアウト | 10 分       | クライアントは 5 分ごとに ping を送信する必要があります  |
+| 同時接続数      | 500(デフォルト) | AWS Support 経由で増加可能               |
+| フレームサイズ    | 128KB      | 大きなエンティティは切り詰めが必要                 |
+| レイテンシー     | \~1 分      | MongoDB Change Stream のポーリング間隔に依存 |
+| 接続 TTL     | 2 時間       | DynamoDB TTL によって自動的にクリーンアップされます  |
+| ローカル開発     | サポート対象     | ローカル WebSocket サーバー経由で利用可能        |
 
----
+***
 
 ## 関連ドキュメント
 
-- JavaScript SDK - SDK API リファレンス (ブラウザアプリケーションに推奨)
-- [API 共通仕様](../api-reference/endpoints.md) - REST API ドキュメント
-- Authentication and Authorization - 認証設定
-- Development Guide - ローカル開発とデプロイ
+
+* JavaScript SDK - SDK API リファレンス(ブラウザアプリケーションに推奨)
+  
+* [API Common Specification](../api-reference/endpoints.md) - REST API ドキュメント
+  
+* Authentication and Authorization - 認証設定
+  
+* Development Guide - ローカル開発とデプロイ


### PR DESCRIPTION
## Automated Sync & Translation

**Trigger**: workflow_dispatch
**GeonicDB SHA**: N/A (manual dispatch)
**Base branch**: main

### Changed files
docs/en/ai-integration/examples.md
docs/en/ai-integration/overview.md
docs/en/ai-integration/tools-json.md
docs/en/api-reference/endpoints.md
docs/en/api-reference/ngsiv2.md
docs/en/changelog.md
docs/en/core-concepts/ngsiv2-vs-ngsild.md
docs/en/features/subscriptions.md

### Process
1. Synced English source docs from geolonia/geonicdb → docs/en/
2. Translated English docs to Japanese via yuuhitsu → docs/ja/
3. Build verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * AI統合機能のドキュメントを拡充し、エンドポイント仕様、MCP設定手順、認証フロー、テナント指定を詳細化
  * NGSI-v2とNGSI-LDのAPIリファレンスを再整理し、クエリパラメータや操作仕様を明確化
  * プロトコル分離、システム属性、フェデレーション機能の説明を強化
  * WebSocketイベントストリーミングのドキュメントを大幅刷新し、接続仕様とDPoP検証を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->