### PR TITLE
docs: sync and translate from geonicdb/docs

### DIFF
--- a/.changelog-hashes.json
+++ b/.changelog-hashes.json
@@ -1,4 +1,9 @@
 {
-  "unreleased": "61adf4cb7908db2a",
+  "unreleased": "cce50d6fee4318cb",
+  "0.8.x": "7716ec10d0b11a17",
+  "0.7.x": "497b3fa708ea1fe0",
+  "0.6.x": "fbded78281acf7de",
+  "0.4.x": "84a2ff318c16dc30",
+  "0.3.x": "a64dede3684db586",
   "_index": "eeae047ad0f874c5"
 }

--- a/docs/en/ai-integration/examples.md
+++ b/docs/en/ai-integration/examples.md
@@ -17,7 +17,9 @@ GeonicDB provides multiple AI-oriented interfaces so that AI agents (Claude, GPT
 | `GET /openapi.json` | JSON | OpenAPI 3.0 specification |
 | `GET /api.json` | JSON | API reference |
 
-## Tool Use Schema (`/tools.json`)
+## Tool Use Schema (`/tools.json`
+
+)
 
 Provides tool definitions compatible with Claude Tool Use and OpenAI Function Calling.
 
@@ -80,7 +82,9 @@ You can also specify the type explicitly:
 }
 ```
 
-## AI Plugin Manifest (`/.well-known/ai-plugin.json`)
+## AI Plugin Manifest (`/.well-known/ai-plugin.json`
+
+)
 
 Provides API discovery information.
 
@@ -318,7 +322,9 @@ entities tool:
   servicePath: "/hello"
 ```
 
-#### Hierarchical Search (`/#`)
+#### Hierarchical Search (`/#`
+
+)
 
 Using the `/#` suffix searches the specified path and all its child paths.
 

--- a/docs/en/ai-integration/overview.md
+++ b/docs/en/ai-integration/overview.md
@@ -17,7 +17,9 @@ GeonicDB provides multiple AI-oriented interfaces so that AI agents (Claude, GPT
 | `GET /openapi.json` | JSON | OpenAPI 3.0 specification |
 | `GET /api.json` | JSON | API reference |
 
-## Tool Use Schema (`/tools.json`)
+## Tool Use Schema (`/tools.json`
+
+)
 
 Provides tool definitions compatible with Claude Tool Use and OpenAI Function Calling.
 
@@ -80,7 +82,9 @@ You can also specify the type explicitly:
 }
 ```
 
-## AI Plugin Manifest (`/.well-known/ai-plugin.json`)
+## AI Plugin Manifest (`/.well-known/ai-plugin.json`
+
+)
 
 Provides API discovery information.
 
@@ -318,7 +322,9 @@ entities tool:
   servicePath: "/hello"
 ```
 
-#### Hierarchical Search (`/#`)
+#### Hierarchical Search (`/#`
+
+)
 
 Using the `/#` suffix searches the specified path and all its child paths.
 

--- a/docs/en/ai-integration/tools-json.md
+++ b/docs/en/ai-integration/tools-json.md
@@ -17,7 +17,9 @@ GeonicDB provides multiple AI-oriented interfaces so that AI agents (Claude, GPT
 | `GET /openapi.json` | JSON | OpenAPI 3.0 specification |
 | `GET /api.json` | JSON | API reference |
 
-## Tool Use Schema (`/tools.json`)
+## Tool Use Schema (`/tools.json`
+
+)
 
 Provides tool definitions compatible with Claude Tool Use and OpenAI Function Calling.
 
@@ -80,7 +82,9 @@ You can also specify the type explicitly:
 }
 ```
 
-## AI Plugin Manifest (`/.well-known/ai-plugin.json`)
+## AI Plugin Manifest (`/.well-known/ai-plugin.json`
+
+)
 
 Provides API discovery information.
 
@@ -318,7 +322,9 @@ entities tool:
   servicePath: "/hello"
 ```
 
-#### Hierarchical Search (`/#`)
+#### Hierarchical Search (`/#`
+
+)
 
 Using the `/#` suffix searches the specified path and all its child paths.
 

--- a/docs/en/api-reference/endpoints.md
+++ b/docs/en/api-reference/endpoints.md
@@ -145,7 +145,9 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /Madrid/Gardens"
 ```
 
-#### Hierarchical Search (`/#`)
+#### Hierarchical Search (`/#`
+
+)
 
 Using the `/#` suffix allows searching the specified path and all its child paths (**query operations only**).
 
@@ -347,6 +349,8 @@ Authentication is disabled by default. It can be enabled with the following envi
 | `SUPER_ADMIN_PASSWORD` | - | Super admin password set via environment variable |
 | `ADMIN_ALLOWED_IPS` | - | IPs/CIDRs allowed to access the Admin API (comma-separated) |
 
+> **SaaS users**: These environment variables are managed via the GeonicDB SaaS console. Direct configuration is not required.
+
 ### Roles and Permissions
 
 | Role | Description | Permissions |
@@ -381,7 +385,7 @@ Content-Type: application/json
 | `email` | string | Yes | Email address |
 | `password` | string | Yes | Password |
 | `tenantId` | string | No | If specified, issues a JWT scoped to that tenant. Defaults to primary tenant if omitted |
-| `resourceScopes` | ResourceScope[] | No | Entity-level access control scopes. Full access if omitted. See AUTH.md for details |
+| `resourceScopes` | ResourceScope[] | No | Entity-level access control scopes. Full access if omitted. See [AUTH.md](../reference/auth.md#resource-scopesgeonicdb-extension) for details |
 
 **Tenant Header Support**: Instead of `tenantId` in the body, you can specify a tenant via `NGSILD-Tenant` or `Fiware-Service` header (resolved by tenant name). Priority: `body.tenantId` > header > primary tenant. Header values must match `^[a-z0-9_]+$`.
 
@@ -518,7 +522,7 @@ Origin: https://example.com
 }
 ```
 
-**DPoP token binding** (optional): Include a `DPoP` header with an ECDSA P-256 proof JWT per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449). When present, the response `token_type` becomes `"DPoP"` and the JWT includes a `cnf.jkt` claim binding it to the proof key. The server requires a DPoP-Nonce (RFC 9449 §8) — the first request returns `400 use_dpop_nonce` with a `DPoP-Nonce` header; retry with the nonce in the proof's `nonce` claim. See AUTH.md for details.
+**DPoP token binding** (optional): Include a `DPoP` header with an ECDSA P-256 proof JWT per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449). When present, the response `token_type` becomes `"DPoP"` and the JWT includes a `cnf.jkt` claim binding it to the proof key. The server requires a DPoP-Nonce (RFC 9449 §8) — the first request returns `400 use_dpop_nonce` with a `DPoP-Nonce` header; retry with the nonce in the proof's `nonce` claim. See [AUTH.md](../reference/auth.md#dpop-token-binding-rfc-9449) for details.
 
 ### Admin API
 
@@ -688,6 +692,8 @@ Authorization: Bearer <accessToken>
 
 ### IP Restrictions
 
+**SaaS users**: This is configured via the tenant settings API. Contact Geolonia support for details.
+
 By setting the `ADMIN_ALLOWED_IPS` environment variable, you can restrict access to the Admin API (`/admin/*`) to specific IP addresses:
 
 ```bash
@@ -714,13 +720,13 @@ DELETE /admin/tenants/{tenantId}/ip-restrictions
 Authorization: Bearer <accessToken>
 ```
 
-The scope can be either `admin` (Admin API only) or `all` (all APIs). See AUTH.md for details.
+The scope can be either `admin` (Admin API only) or `all` (all APIs). See [AUTH.md](../reference/auth.md#per-tenant-ip-restrictions) for details.
 
 ### Rule Engine Management (tenant_admin)
 
 Manage rules that automatically process entity changes. Requires the `tenant_admin` role; `super_admin` cannot access `/rules*` endpoints when `AUTH_ENABLED=true`.
 
-- **REACTIVCORE_RULES.md** - User guide (usage examples, Admin API, etc.)
+- **[REACTIVCORE_RULES.md](../features/reactivcore-rules.md)** - User guide (usage examples, Admin API, etc.)
 
 #### List Rules
 
@@ -821,7 +827,7 @@ Rule actions (`createEntity`, `updateAttribute`, `deleteAttribute`) support an o
 
 When crossing protocols, servicePath ↔ scope is automatically mapped. Template variables `${trigger.protocol}`, `${trigger.servicePath}`, `${trigger.scope}`, `${trigger.service}` reference the trigger entity's context.
 
-See **REACTIVCORE_RULES.md** for detailed examples and mapping rules.
+See **[REACTIVCORE_RULES.md](../features/reactivcore-rules.md)** for detailed examples and mapping rules.
 
 ---
 
@@ -865,9 +871,9 @@ Machine-to-Machine (M2M) authentication using the OAuth 2.0 Client Credentials G
 
 > Role columns indicate which scopes can be requested via self-service (`/me/oauth-clients`). Admin-created clients (`/admin/oauth-clients`) are not subject to these restrictions.
 
-**Resource Scopes:** Specifying the `resource_scopes` parameter (JSON string) in `POST /oauth/token` issues a token with entity-level access control. See AUTH.md for details.
+**Resource Scopes:** Specifying the `resource_scopes` parameter (JSON string) in `POST /oauth/token` issues a token with entity-level access control. See [AUTH.md](../reference/auth.md#resource-scopesgeonicdb-extension) for details.
 
-**Details:** See the OAuth 2.0 section in AUTH.md.
+**Details:** See the OAuth 2.0 section in [AUTH.md](../reference/auth.md).
 
 ---
 
@@ -883,7 +889,7 @@ Browser-based applications can exchange an API key for a short-lived session JWT
 
 **Security Layers:** Origin validation → HMAC Nonce (60s TTL) → Proof of Work → Short-lived JWT (1h)
 
-**Details:** See the API Key Token Exchange section in AUTH.md and the SDK documentation for the full API reference.
+**Details:** See the [API Key Token Exchange](../reference/auth.md#api-key-token-exchange-browser-sdk) section in AUTH.md and the SDK documentation for the full API reference.
 
 ---
 
@@ -2351,7 +2357,9 @@ Reference: https://github.com/CADDE-sip/connector
 | GET | `/cadde/api/v4/catalog` | Catalog search (cross-domain search / detailed search) |
 | GET | `/cadde/api/v4/entities` | NGSI data exchange |
 
-#### Catalog Search (`/cadde/api/v4/catalog`)
+#### Catalog Search (`/cadde/api/v4/catalog`
+
+)
 
 Specify the search type using the `x-cadde-search` header:
 
@@ -2379,7 +2387,9 @@ curl "http://localhost:3000/cadde/api/v4/catalog?id=sensor" \
   -H "Fiware-Service: smartcity"
 ```
 
-#### NGSI Data Exchange (`/cadde/api/v4/entities`)
+#### NGSI Data Exchange (`/cadde/api/v4/entities`
+
+)
 
 Parses query parameters from the `x-cadde-resource-url` header to retrieve entities.
 

--- a/docs/en/api-reference/ngsild.md
+++ b/docs/en/api-reference/ngsild.md
@@ -943,7 +943,7 @@ DELETE /ngsi-ld/v1/subscriptions/{subscriptionId}
 
 #### Ownership Verification (GeonicDB Extension)
 
-When authentication is enabled (`AUTH_ENABLED=true`), subscription update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. Users other than the creator who attempt these operations will receive `403 Forbidden`. The `super_admin` and `tenant_admin` roles can bypass this verification. For details, see AUTH.md.
+When authentication is enabled (`AUTH_ENABLED=true`), subscription update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. Users other than the creator who attempt these operations will receive `403 Forbidden`. The `super_admin` and `tenant_admin` roles can bypass this verification. For details, see [AUTH.md](../reference/auth.md).
 
 ---
 
@@ -1073,7 +1073,7 @@ DELETE /ngsi-ld/v1/csourceRegistrations/{registrationId}
 
 #### Ownership Verification (GeonicDB Extension)
 
-When authentication is enabled (`AUTH_ENABLED=true`), registration update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. Users other than the creator who attempt these operations will receive `403 Forbidden`. The `super_admin` and `tenant_admin` roles can bypass this verification. For details, see AUTH.md.
+When authentication is enabled (`AUTH_ENABLED=true`), registration update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. Users other than the creator who attempt these operations will receive `403 Forbidden`. The `super_admin` and `tenant_admin` roles can bypass this verification. For details, see [AUTH.md](../reference/auth.md).
 
 #### CSR Advanced Fields (ETSI GS CIM 009 V1.9.1)
 

--- a/docs/en/api-reference/ngsiv2.md
+++ b/docs/en/api-reference/ngsiv2.md
@@ -462,7 +462,7 @@ curl -X PUT "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
 
 ## Batch Operations
 
-> **Note**: Batch operations can process up to **`MAX_BATCH_SIZE`** entities per request (default: 100, configurable up to 10,000 via the `MaxBatchSize` SAM parameter). Requests exceeding this limit will result in a `400 Bad Request` error. See DEVELOPMENT.md for configuration details.
+> **Note**: Batch operations can process up to **`MAX_BATCH_SIZE`** entities per request (default: 100). Requests exceeding this limit will result in a `400 Bad Request` error. 
 
 ### Batch Update
 
@@ -788,7 +788,7 @@ DELETE /v2/subscriptions/{subscriptionId}
 
 ### Ownership Verification (GeonicDB Extension)
 
-When authentication is enabled (`AUTH_ENABLED=true`), subscription update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. If a user other than the creator attempts these operations, `403 Forbidden` is returned. The `super_admin` and `tenant_admin` roles can bypass this verification. See AUTH.md for details.
+When authentication is enabled (`AUTH_ENABLED=true`), subscription update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. If a user other than the creator attempts these operations, `403 Forbidden` is returned. The `super_admin` and `tenant_admin` roles can bypass this verification. See [AUTH.md](../reference/auth.md) for details.
 
 ---
 
@@ -903,7 +903,7 @@ DELETE /v2/registrations/{registrationId}
 
 ### Ownership Verification (GeonicDB Extension)
 
-When authentication is enabled (`AUTH_ENABLED=true`), registration update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. If a user other than the creator attempts these operations, `403 Forbidden` is returned. The `super_admin` and `tenant_admin` roles can bypass this verification. See AUTH.md for details.
+When authentication is enabled (`AUTH_ENABLED=true`), registration update (PATCH) and delete (DELETE) operations perform ownership verification based on the `createdBy` field. If a user other than the creator attempts these operations, `403 Forbidden` is returned. The `super_admin` and `tenant_admin` roles can bypass this verification. See [AUTH.md](../reference/auth.md) for details.
 
 ---
 
@@ -1169,7 +1169,7 @@ FIWARE NGSIv2-compatible Context Broker API.
 
 ### Batch Operations
 
-> **Note**: Batch operations (excluding query) are limited to **`MAX_BATCH_SIZE`** entities per request (default: 100, configurable up to 10,000). Exceeding this limit returns `400 Bad Request`.
+> **Note**: Batch operations (excluding query) are limited to **`MAX_BATCH_SIZE`** entities per request (default: 100). Exceeding this limit returns `400 Bad Request`.
 
 | Endpoint | Method | Description | Success | Error | Pagination |
 |----------|--------|-------------|---------|-------|------------|

--- a/docs/en/changelog/unreleased.md
+++ b/docs/en/changelog/unreleased.md
@@ -5,5 +5,10 @@ outline: deep
 ---
 ## [Unreleased]
 
+### 2026-05-08
+
+*Changelog entries are documented in Japanese. English translations will be added in a future update.*
+
+
 [unreleased]: https://github.com/geolonia/geonicdb/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/geolonia/geonicdb/releases/tag/v0.1.0

--- a/docs/en/core-concepts/ngsiv2-vs-ngsild.md
+++ b/docs/en/core-concepts/ngsiv2-vs-ngsild.md
@@ -431,7 +431,7 @@ curl 'http://localhost:3000/ngsi-ld/v1/entities?georel=near;maxDistance==1000&ge
 | **Total count** | `Fiware-Total-Count` | `NGSILD-Results-Count` | Total number of query results |
 | **Next Link** | `Link` (rel="next") | `Link` (rel="next") | Link to the next page |
 
-For details, see the "API Specification" section in DEVELOPMENT.md.
+For details, see [Pagination](/en/api-reference/pagination).
 
 ### 4. Subscriptions
 

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -389,7 +389,7 @@ y: Y tile coordinate
 | `user` | Read/write entities (can be restricted by policy) |
 | `api_key` | Scope-based access via X-Api-Key header (origin/entity-type restrictions) |
 
-See Authentication and Authorization for details.
+See [Authentication and Authorization](./reference/auth.md) for details.
 
 ### Q: Is HTTPS required?
 
@@ -402,4 +402,4 @@ See Authentication and Authorization for details.
 - [API Specification](./api-reference/endpoints.md)
 - [FIWARE Orion Comparison](./migration/compatibility-matrix.md)
 - Development and Deployment Guide
-- Authentication and Authorization
+- [Authentication and Authorization](./reference/auth.md)

--- a/docs/en/features/ngsi-subscriptions.md
+++ b/docs/en/features/ngsi-subscriptions.md
@@ -3,9 +3,632 @@ title: "NGSI Subscriptions"
 description: "HTTP Webhook subscriptions for entity change notifications"
 outline: deep
 ---
+# Subscriptions
 
-# NGSI Subscriptions
+GeonicDB's subscription feature allows you to monitor entity changes in real time and automatically notify external systems.
 
-::: info Coming Soon
-This page is being synced from the GeonicDB upstream documentation. Full content will be available after the next documentation sync.
-:::
+## Table of Contents
+
+- [Overview](#overview)
+- [How Subscriptions Work](#how-subscriptions-work)
+- [Notification Methods](#notification-methods)
+- [Conditions and Filtering](#conditions-and-filtering)
+- [Practical Examples](#practical-examples)
+- [Best Practices](#best-practices)
+- [Access Control and Ownership (GeonicDB Extension)](#access-control-and-ownership-geonicdb-extension)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Subscriptions monitor entity creation, update, and deletion, and send notifications to a specified endpoint when the defined conditions are met.
+
+### Key Use Cases
+
+- **Sensor data monitoring**: Detect threshold exceedances for temperature, humidity, etc.
+- **Location tracking**: Track position changes of vehicles and devices
+- **Event-driven architecture**: Automated processing triggered by entity changes
+- **Data integration**: Real-time data delivery to other systems
+
+### Supported APIs
+
+| API | Endpoint | Support |
+|-----|----------|---------|
+| NGSIv2 | `/v2/subscriptions` | ✅ |
+| NGSI-LD | `/ngsi-ld/v1/subscriptions` | ✅ |
+
+---
+
+## How Subscriptions Work
+
+```text
+1. Entity creation/update
+   ↓
+2. MongoDB Change Stream detects the event
+   ↓
+3. Event is sent to EventBridge
+   ↓
+4. SubscriptionMatcher searches for subscriptions matching the conditions
+   ↓
+5. Notification message is sent to the SQS queue
+   ↓
+6. NotificationSender sends an HTTP/MQTT notification to the external endpoint
+```
+
+**Latency**: Approximately 1 minute from entity change to notification delivery (depends on the Change Stream polling interval).
+
+---
+
+## Notification Methods
+
+### HTTP Webhook
+
+Sends notifications as standard HTTP POST requests.
+
+**Example subscription creation:**
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{
+    "description": "Room temperature monitoring",
+    "subject": {
+      "entities": [{ "idPattern": ".*", "type": "Room" }],
+      "condition": {
+        "attrs": ["temperature"],
+        "expression": { "q": "temperature>25" }
+      }
+    },
+    "notification": {
+      "http": { "url": "https://webhook.example.com/notify" },
+      "attrs": ["temperature", "pressure"]
+    },
+    "expires": "2030-12-31T23:59:59.000Z",
+    "throttling": 5
+  }'
+```
+
+**Example notification payload:**
+
+```json
+{
+  "subscriptionId": "sub123",
+  "data": [
+    {
+      "id": "Room1",
+      "type": "Room",
+      "temperature": {
+        "type": "Number",
+        "value": 26.5,
+        "metadata": {}
+      },
+      "pressure": {
+        "type": "Number",
+        "value": 1013.25,
+        "metadata": {}
+      }
+    }
+  ]
+}
+```
+
+### httpCustom (Custom Template)
+
+Allows customization of the HTTP method, headers, and payload.
+
+**Example subscription creation:**
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{
+    "description": "Custom notification template",
+    "subject": {
+      "entities": [{ "type": "Room" }],
+      "condition": { "attrs": ["temperature"] }
+    },
+    "notification": {
+      "httpCustom": {
+        "url": "https://api.example.com/events",
+        "method": "PUT",
+        "headers": {
+          "X-Api-Key": "secret-key",
+          "Content-Type": "application/json"
+        },
+        "qs": {
+          "entityId": "${id}",
+          "temp": "${temperature}"
+        },
+        "payload": "{\"room\": \"${id}\", \"temp\": ${temperature}, \"timestamp\": \"${timestamp}\"}"
+      }
+    }
+  }'
+```
+
+**Macro substitution:**
+
+| Macro | Substituted value |
+|-------|-------------------|
+| `${id}` | Entity ID |
+| `${type}` | Entity type |
+| `${temperature}` | Attribute value (extracts `.value` from normalized attributes) |
+
+Non-existent attributes are replaced with the string `null`.
+
+### MQTT
+
+Publishes messages to an MQTT broker.
+
+**Example subscription creation:**
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{
+    "description": "MQTT notification",
+    "subject": {
+      "entities": [{ "type": "Sensor" }],
+      "condition": { "attrs": ["value"] }
+    },
+    "notification": {
+      "mqtt": {
+        "url": "mqtt://broker.example.com:1883",
+        "topic": "sensors/room/temperature",
+        "qos": 1,
+        "user": "username",
+        "passwd": "password"
+      },
+      "attrs": ["value"]
+    }
+  }'
+```
+
+**MQTT settings:**
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `url` | MQTT broker URL (`mqtt://` or `mqtts://`) | - |
+| `topic` | Topic to publish to | - |
+| `qos` | QoS level (0, 1, 2) | 0 |
+| `retain` | Message retain flag | false |
+| `user` | Authentication username | - |
+| `passwd` | Authentication password | - |
+
+---
+
+## Conditions and Filtering
+
+### Entity Specification
+
+**Specific ID:**
+
+```json
+{
+  "subject": {
+    "entities": [
+      { "id": "Room1", "type": "Room" }
+    ]
+  }
+}
+```
+
+**ID pattern (regular expression):**
+
+```json
+{
+  "subject": {
+    "entities": [
+      { "idPattern": "Room.*", "type": "Room" }
+    ]
+  }
+}
+```
+
+**All entities:**
+
+```json
+{
+  "subject": {
+    "entities": [
+      { "idPattern": ".*" }
+    ]
+  }
+}
+```
+
+### Condition Expressions (q parameter)
+
+**Comparison operators:**
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `>` | Greater than | `temperature>25` |
+| `<` | Less than | `temperature<10` |
+| `>=` | Greater than or equal to | `temperature>=20` |
+| `<=` | Less than or equal to | `temperature<=30` |
+| `==` | Equal to | `status==active` |
+| `!=` | Not equal to | `status!=inactive` |
+
+**Logical operators:**
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `;` | AND | `temperature>20;humidity<80` |
+| `,` | OR | `type==Room,type==Building` |
+
+**Example:**
+
+```json
+{
+  "subject": {
+    "condition": {
+      "attrs": ["temperature"],
+      "expression": {
+        "q": "temperature>25;temperature<40"
+      }
+    }
+  }
+}
+```
+
+### Notification Attribute Filtering
+
+**Notify only specific attributes:**
+
+```json
+{
+  "notification": {
+    "attrs": ["temperature", "humidity"]
+  }
+}
+```
+
+**Exclude specific attributes:**
+
+```json
+{
+  "notification": {
+    "exceptAttrs": ["metadata", "internalId"]
+  }
+}
+```
+
+**Notify only changed attributes:**
+
+```json
+{
+  "notification": {
+    "onlyChangedAttrs": true
+  }
+}
+```
+
+---
+
+## Practical Examples
+
+### Example 1: Temperature Threshold Monitoring
+
+A subscription that sends high-temperature alerts:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "description": "High temperature alert",
+    "subject": {
+      "entities": [{ "type": "TemperatureSensor" }],
+      "condition": {
+        "attrs": ["temperature"],
+        "expression": { "q": "temperature>35" }
+      }
+    },
+    "notification": {
+      "http": { "url": "https://alerts.example.com/high-temp" },
+      "attrs": ["temperature", "location"]
+    }
+  }'
+```
+
+### Example 2: Vehicle Location Tracking
+
+Track vehicle position changes:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: fleet" \
+  -d '{
+    "description": "Vehicle location tracking",
+    "subject": {
+      "entities": [{ "idPattern": "Vehicle.*", "type": "Vehicle" }],
+      "condition": { "attrs": ["location"] }
+    },
+    "notification": {
+      "http": { "url": "https://tracking.example.com/update" },
+      "attrs": ["location", "speed", "status"],
+      "attrsFormat": "keyValues"
+    }
+  }'
+```
+
+### Example 3: Custom Payload (Slack Notification)
+
+Send a custom-formatted notification to a Slack Webhook:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "description": "Slack notification for alerts",
+    "subject": {
+      "entities": [{ "type": "Alert" }],
+      "condition": { "attrs": ["severity"] }
+    },
+    "notification": {
+      "httpCustom": {
+        "url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+        "method": "POST",
+        "headers": { "Content-Type": "application/json" },
+        "payload": "{\"text\": \"⚠️ Alert: ${id} - Severity: ${severity}\"}"
+      }
+    }
+  }'
+```
+
+### Example 4: MQTT Sensor Data Delivery
+
+Deliver sensor data to an MQTT broker:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: iot" \
+  -d '{
+    "description": "Sensor data to MQTT",
+    "subject": {
+      "entities": [{ "type": "Sensor" }],
+      "condition": { "attrs": ["value"] }
+    },
+    "notification": {
+      "mqtt": {
+        "url": "mqtts://broker.hivemq.com:8883",
+        "topic": "sensors/${type}/${id}",
+        "qos": 1
+      },
+      "attrsFormat": "keyValues"
+    }
+  }'
+```
+
+---
+
+## Best Practices
+
+### 1. Configure Conditions Appropriately
+
+**❌ Bad example: monitoring all entities**
+
+```json
+{
+  "subject": {
+    "entities": [{ "idPattern": ".*" }],
+    "condition": { "attrs": [] }
+  }
+}
+```
+
+The volume of notifications will be excessive and put a load on the system.
+
+**✅ Good example: narrow down by specific type and conditions**
+
+```json
+{
+  "subject": {
+    "entities": [{ "type": "Sensor" }],
+    "condition": {
+      "attrs": ["temperature"],
+      "expression": { "q": "temperature>25" }
+    }
+  }
+}
+```
+
+### 2. Configure Throttling
+
+Set `throttling` (in seconds) to prevent excessive notifications:
+
+```json
+{
+  "throttling": 60
+}
+```
+
+This limits change notifications for the same entity to once every 60 seconds.
+
+### 3. Set an Expiry
+
+Set `expires` for test subscriptions:
+
+```json
+{
+  "expires": "2026-12-31T23:59:59.000Z"
+}
+```
+
+### 4. Notify Only Changed Attributes
+
+Reduce unnecessary notifications:
+
+```json
+{
+  "notification": {
+    "onlyChangedAttrs": true
+  }
+}
+```
+
+### 5. Status Management
+
+Set to `inactive` to temporarily stop notifications:
+
+```bash
+curl -X PATCH http://localhost:3000/v2/subscriptions/{id} \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{ "status": "inactive" }'
+```
+
+### 6. Error Handling
+
+Implement the following at the notification destination endpoint:
+- **Return a 2xx status code**: to indicate success
+- **Retry logic**: to handle transient failures
+- **Timeout settings**: to prevent long hangs
+
+---
+
+## Access Control and Ownership (GeonicDB Extension)
+
+> **Note**: `super_admin` cannot access subscription endpoints (`/v2/subscriptions`, `/ngsi-ld/v1/subscriptions`) as they are data APIs. Use `tenant_admin` or `user` role instead.
+
+In environments with authentication enabled, ownership-based access control is applied to subscriptions.
+
+### Behavior
+
+- When a subscription is created, the authenticated user's ID is recorded in the `createdBy` field.
+- **Update (PATCH) and deletion (DELETE)** can only be performed by users who meet one of the following conditions:
+  - The creator of the subscription (`createdBy` matches)
+  - The `tenant_admin` role
+- If the above conditions are not met, **403 Forbidden** is returned.
+- **Retrieval (GET) and listing (LIST)** are unrestricted for any authenticated user within the same tenant.
+
+> **Note**: The same ownership validation applies to registrations (`/v2/registrations`, `/ngsi-ld/v1/csourceRegistrations`).
+
+### XACML attribute-based control on Subscription create (NGSI-LD, #1104)
+
+For `POST /ngsi-ld/v1/subscriptions`, the XACML PIP injects subscription-target attributes into `AuthzRequest.resource`, enabling fine-grained policy control:
+
+| Resource attribute | Source field | Example use |
+|--------------------|--------------|-------------|
+| `entityType` | `entities[].type` | "Anonymous can subscribe only to `ActivityLog`" |
+| `entityId` | `entities[].id` | Restrict to specific entity IDs |
+| `entityIdPattern` | `entities[].idPattern` | Restrict by id pattern |
+| `notificationEndpoint` | `notification.endpoint.uri` | "Notifications may only be posted to `https://*.example.com/**`" — defence against SSRF / data exfiltration |
+
+When `entities[]` contains multiple elements, **every element must Permit** for the subscription creation to succeed (all-Permit semantics). A single mismatched type or id pattern rejects the entire request with `403 Forbidden`.
+
+> The literal `body.type === "Subscription"` is **not** propagated to `entityType`. Policies must target `entities[].type`, not the wrapper object's type.
+
+For details on authentication and authorization, see [AUTH.md § Subscription PIP attributes](../reference/auth.md#subscription-pip-attributes).
+
+---
+
+## Troubleshooting
+
+### 1. Notifications Are Not Being Delivered
+
+**Causes:**
+- Condition expression does not match
+- Notification destination URL is unreachable
+- Subscription is `inactive` or has expired
+
+**How to check:**
+
+```bash
+# Check subscription details
+curl http://localhost:3000/v2/subscriptions/{id} \
+  -H "Fiware-Service: demo"
+
+# Check status, expires, and lastNotification
+```
+
+**Resolution:**
+- Test the condition expression: manually update an entity and verify the condition is met
+- Test the notification URL: verify it is directly reachable via `curl`
+- Change the status to `active`
+
+### 2. Notifications Are Duplicated
+
+**Causes:**
+- `throttling` is not configured
+- Multiple subscriptions are monitoring the same entity
+
+**Resolution:**
+
+```bash
+# Configure throttling
+curl -X PATCH http://localhost:3000/v2/subscriptions/{id} \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{ "throttling": 30 }'
+
+# Check the subscription list
+curl http://localhost:3000/v2/subscriptions \
+  -H "Fiware-Service: demo"
+```
+
+### 3. Notification Payload Is Not as Expected
+
+**Causes:**
+- `attrs` filter is not configured correctly
+- `attrsFormat` is not appropriate
+- `httpCustom` macro syntax is incorrect
+
+**How to check:**
+
+```bash
+# Check subscription configuration
+curl http://localhost:3000/v2/subscriptions/{id} \
+  -H "Fiware-Service: demo" | jq '.notification'
+```
+
+**Resolution:**
+- Update `attrs` to include the required attributes
+- Change `attrsFormat` to `normalized` or `keyValues`
+- Verify `httpCustom` macro syntax (the `${attrName}` must match the attribute name)
+
+### 4. MQTT Notifications Are Not Being Sent
+
+**Causes:**
+- Cannot connect to the MQTT broker
+- Authentication credentials are incorrect
+- Topic name is invalid
+
+**How to check:**
+
+```bash
+# Test the connection to the MQTT broker (using mosquitto_sub)
+mosquitto_sub -h broker.example.com -p 1883 -t "sensors/#" -u username -P password
+```
+
+**Resolution:**
+- Verify the MQTT broker URL, port, and credentials
+- Check that the topic name does not contain special characters
+- Try lowering the QoS level to 0
+
+### 5. Subscription Automatically Becomes inactive
+
+**Causes:**
+- The notification destination is returning errors continuously (5xx, timeout)
+- GeonicDB automatically disabled the subscription
+
+**Resolution:**
+- Check the logs of the notification destination endpoint
+- Fix the endpoint so it responds correctly
+- Set the subscription back to `active`
+
+---
+
+## Related Documentation
+
+- [API Common Specification](../api-reference/endpoints.md) - REST API documentation
+- [API_NGSIV2.md](../api-reference/ngsiv2.md) - NGSIv2 Subscriptions API Reference
+- [API_NGSILD.md](../api-reference/ngsild.md) - NGSI-LD Subscriptions API Reference
+- [EVENT_STREAMING.md](./subscriptions.md) - WebSocket Event Streaming

--- a/docs/en/features/reactivcore-rules.md
+++ b/docs/en/features/reactivcore-rules.md
@@ -3,9 +3,2125 @@ title: "ReactiveCore Rules"
 description: "Reactive automation rules based on entity changes"
 outline: deep
 ---
-
 # ReactiveCore Rules
 
-::: info Coming Soon
-This page is being synced from the GeonicDB upstream documentation. Full content will be available after the next documentation sync.
-:::
+GeonicDB's **ReactiveCore Rules** is a reactive automation feature that automatically detects entity changes and executes actions based on defined rules. It monitors MongoDB changes in real time via Change Streams and performs automated processing when rule conditions are matched.
+
+## Table of Contents
+
+- [Overview](#overview)
+  - [Key Features](#key-features)
+  - [Enabling](#enabling)
+  - [Testing in a Local Development Environment](#testing-in-a-local-development-environment)
+  - [Use Cases](#use-cases)
+- [Architecture](#architecture)
+- [Rule Structure](#rule-structure)
+- [Conditions](#conditions)
+- [Actions](#actions)
+- [Template Variables](#template-variables)
+- [Rules API](#rules-api)
+- [Examples](#examples)
+- [Limitations](#limitations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+### Key Features
+
+- **Automatic entity processing**: Detects entity creation, updates, and deletion and automatically executes actions
+- **Flexible condition configuration**: Specify conditions based on attribute values, pattern matching, change detection, time ranges, and entity types
+- **Multiple action support**: Create derived entities, update attributes, delete attributes, send notifications, and invoke Webhooks
+- **Template variables**: Dynamically reference values using `${entity.id}`, `${attribute.temperature.value}`, etc.
+- **Priority control**: When multiple rules match, they are executed in ascending order of priority
+- **Tenant isolation**: Independent rule management per tenant
+
+### Enabling
+
+> **SaaS users**: ReactiveCore Rules is enabled by default in GeonicDB SaaS. No additional configuration is required.
+
+Enable ReactiveCore Rules via environment variable (disabled by default).
+
+```bash
+export RULES_ENABLED=true
+```
+
+### Testing in a Local Development Environment
+
+Follow these steps to try ReactiveCore Rules in a local development environment.
+
+#### 1. Start the local server
+
+Start the local server. MongoDB will automatically start in replica set mode, and the Change Stream Watcher will also be enabled automatically.
+
+```bash
+npm start
+```
+
+On startup, you will see output like the following.
+
+```text
+━━━ ReactiveCore Rules - Change Stream Started ━━━
+Watching for entity changes...
+```
+
+Entity changes are now automatically monitored and rules are ready to execute.
+
+#### 2. Create a rule
+
+Use the Rules API to create a rule.
+
+```bash
+# Rule to create a warning entity when a temperature sensor exceeds 30 degrees
+curl -X POST "http://localhost:3000/rules" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <accessToken>" \
+  -d '{
+    "name": "High Temperature Alert",
+    "description": "Automatically create a warning entity when temperature exceeds 30 degrees",
+    "conditions": [
+      {
+        "type": "entityType",
+        "entityTypes": ["TemperatureSensor"]
+      },
+      {
+        "type": "value",
+        "attributeName": "temperature",
+        "operator": ">",
+        "value": 30
+      }
+    ],
+    "actions": [
+      {
+        "type": "createEntity",
+        "entityId": "urn:ngsi-ld:Alert:${entity.id}",
+        "entityType": "Alert",
+        "attributes": {
+          "severity": "high",
+          "message": "Temperature exceeded 30°C",
+          "sourceEntity": "${entity.id}"
+        }
+      }
+    ],
+    "priority": 10
+  }'
+```
+
+#### 3. Create or update an entity to trigger the rule
+
+Create an entity using the Entity API.
+
+```bash
+# Create a sensor with a temperature of 31 degrees (rule will be triggered)
+curl -X POST "http://localhost:3000/v2/entities" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: test" \
+  -d '{
+    "id": "urn:ngsi-ld:TemperatureSensor:001",
+    "type": "TemperatureSensor",
+    "temperature": {
+      "value": 31,
+      "type": "Number"
+    }
+  }'
+```
+
+#### 4. Check the Change Stream output
+
+The terminal running `npm start` will display output like the following.
+
+```text
+━━━ Entity Change Detected ━━━
+Event: entity.created
+Entity: urn:ngsi-ld:TemperatureSensor:001 (TemperatureSensor)
+Changed attributes: temperature
+Executing ReactiveCore Rules...
+✓ Rules processed successfully
+```
+
+#### 5. Verify that the derived entity was created
+
+```bash
+# Verify that the alert entity was automatically created
+curl -X GET "http://localhost:3000/v2/entities?type=Alert" \
+  -H "Fiware-Service: test"
+```
+
+Example response:
+
+```json
+[
+  {
+    "id": "urn:ngsi-ld:Alert:urn:ngsi-ld:TemperatureSensor:001",
+    "type": "Alert",
+    "severity": {
+      "type": "Property",
+      "value": "high",
+      "metadata": {}
+    },
+    "message": {
+      "type": "Property",
+      "value": "Temperature exceeded 30°C",
+      "metadata": {}
+    },
+    "sourceEntity": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:TemperatureSensor:001",
+      "metadata": {}
+    }
+  }
+]
+```
+
+#### Notes
+
+- **Auto-start**: Running `npm start` alone automatically starts MongoDB (in replica set mode) and the Change Stream Watcher.
+- **Replica Set mode**: MongoDB starts in replica set mode because Change Streams require it (Change Streams do not work in standalone MongoDB mode).
+- **Resume Token**: Even if the server is stopped and restarted, Change Stream processing resumes from where it left off (the resume token is saved in MongoDB).
+- **Real-time processing**: When an entity is created or updated, the Change Stream immediately executes the rules.
+- **Background execution**: The Change Stream runs in the background in parallel with the HTTP server.
+
+### Use Cases
+
+1. **Automatic generation of derived entities**: Automatically create aggregation entities from sensor data
+2. **Automatic attribute calculation**: Automatically calculate and add the discomfort index from temperature and humidity
+3. **Threshold monitoring**: Automatically add a warning attribute when temperature exceeds 30 degrees
+4. **Time-based processing**: Automatically update the status attribute outside of business hours
+5. **Webhook integration**: Automatically notify external systems of entity changes
+
+---
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                    Entity Change Event                       │
+│          (EntityCreated, EntityUpdated, EntityDeleted)       │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+                            │ EntityService publishes to EventBridge
+                            │ (#1119: Rule firing migrated from
+                            │  scheduled change-stream to EventBridge)
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│              Rule Processor Handler (Lambda)                 │
+│              src/handlers/rules/processor.ts                 │
+│                                                              │
+│  - Consumes EventBridgeRule for                              │
+│    EntityCreated / EntityUpdated / EntityDeleted             │
+│  - Forwards EntityChangeEvent to RuleEngineService           │
+│                                                              │
+│  Local / standalone:                                         │
+│    local-server.ts watches the MongoDB Change Stream and     │
+│    invokes RuleEngineService directly. The E2E suite reuses  │
+│    the production handler via `@rules-auto-fire` hook for    │
+│    parity between local and Lambda paths.                    │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│                   RuleEngineService                          │
+│            src/core/rules/rule-engine.service.ts             │
+│                                                              │
+│  1. Retrieves active rules for the tenant                    │
+│  2. Evaluates conditions for each rule                       │
+│     - evaluateCondition() (recursive)                       │
+│     - value, pattern, change, time, entityType              │
+│     - and, or, not (logical operators)                      │
+│  3. Sorts matched rules by priority                          │
+│  4. Executes actions for each rule sequentially              │
+│     - executeAction()                                       │
+│     - createEntity, updateAttribute, deleteAttribute        │
+│     - sendNotification, webhook, appendToTemporal           │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│                  Action Execution                            │
+│                                                              │
+│  - EntityService: entity operations                          │
+│  - TemporalService: time-series data recording              │
+│  - HTTP Client: Webhook invocation                           │
+│  - EventBridge: subscription notification delivery           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Processing Flow
+
+1. **Entity change detection**
+   - On Lambda: `EntityService` publishes `EntityCreated/Updated/Deleted` to EventBridge directly. `RuleProcessorFunction` is invoked by an EventBridgeRule and constructs an `EntityChangeEvent`
+   - On local / standalone: `local-server.ts` tails the MongoDB Change Stream and constructs the same `EntityChangeEvent` in-process
+   - The legacy `ChangeStreamProcessorFunction` still calls `publishEntityChangeEvent()` to re-publish change-stream-derived events back onto the same EventBridge fan-out, so `RuleProcessorFunction`, `SubscriptionMatcherFunction`, and `WsBroadcastFunction` all receive and process those replayed events (rules and subscriptions are re-evaluated). It no longer invokes `RuleEngineService` directly itself, so the rule path is consolidated to a single EventBridge consumer (#1119)
+
+2. **Rule evaluation**
+   - Retrieves active rules for the tenant and servicePath
+   - Evaluates the conditions of each rule (AND-joined)
+   - Sorts matched rules in order of priority
+
+3. **Action execution**
+   - Executes actions for each rule sequentially
+   - Substitutes template variables with actual values
+   - Even if an error occurs, other actions continue to execute
+
+---
+
+## Rule Structure
+
+### Rule Interface
+
+```typescript
+interface Rule {
+  ruleId: string;           // Unique identifier for the rule
+  name: string;             // Rule name
+  description?: string;     // Description
+  tenantId: string | null;  // Tenant ID (null = applies to all tenants)
+  servicePath: string;      // Service path (e.g., "/sensors")
+  conditions: RuleConditionUnion[];  // Array of conditions (AND-joined)
+  actions: RuleActionUnion[];        // Array of actions (executed sequentially)
+  isActive: boolean;        // Enabled/disabled
+  priority: number;         // Priority (lower value = higher priority)
+  cooldownSeconds?: number; // Cooldown period (seconds) - prevents infinite loops
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+### Basic Rule Example
+
+```json
+{
+  "name": "High Temperature Warning",
+  "description": "Add a warning attribute when temperature exceeds 30 degrees",
+  "servicePath": "/sensors",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alert",
+      "value": "HIGH_TEMPERATURE"
+    }
+  ],
+  "isActive": true,
+  "priority": 10
+}
+```
+
+---
+
+## Conditions
+
+Conditions determine whether a rule matches. Multiple conditions are AND-joined.
+
+### Condition Types
+
+| Type | Description | Use Case |
+|--------|------|------|
+| `value` | Attribute value comparison | `temperature > 30` |
+| `pattern` | Regular expression match | `name matches "Sensor.*"` |
+| `change` | Whether an attribute has changed | `temperature was updated` |
+| `time` | Time range check | `09:00 to 18:00` |
+| `entityType` | Entity type | `["Sensor", "Actuator"]` |
+| `eventType` | Trigger event type (CREATE / UPDATE / DELETE) | `["create"]`, `["create", "delete"]` |
+| `celExpression` | CEL expression | Complex calculations, multi-attribute evaluation |
+| `and` | Logical AND | All conditions are true |
+| `or` | Logical OR | At least one condition is true |
+| `not` | Logical NOT | Condition is false |
+
+### 1. Value Condition
+
+Compares the value of an attribute. In addition to entity attribute names, the entity-level fields `"id"` and `"type"` can also be specified in `attributeName`.
+
+```typescript
+interface ValueCondition {
+  type: 'value';
+  attributeName: string;  // Attribute name, or "id" / "type"
+  operator: '==' | '!=' | '>' | '<' | '>=' | '<=';
+  value: string | number | boolean;
+}
+```
+
+**Example**:
+
+```json
+{
+  "type": "value",
+  "attributeName": "temperature",
+  "operator": ">",
+  "value": 30
+}
+```
+
+Example of filtering by entity ID:
+
+```json
+{
+  "type": "value",
+  "attributeName": "id",
+  "operator": "==",
+  "value": "urn:ngsi-ld:Sensor:001"
+}
+```
+
+### 2. Pattern Condition
+
+Matches an attribute value against a regular expression. In addition to entity attribute names, the entity-level fields `"id"` and `"type"` can also be specified in `attributeName`.
+
+```typescript
+interface PatternCondition {
+  type: 'pattern';
+  attributeName: string;  // Attribute name, or "id" / "type"
+  pattern: string;  // Regular expression pattern
+}
+```
+
+**Example**:
+
+```json
+{
+  "type": "pattern",
+  "attributeName": "name",
+  "pattern": "^Sensor.*"
+}
+```
+
+Example of filtering entity IDs by pattern:
+
+```json
+{
+  "type": "pattern",
+  "attributeName": "id",
+  "pattern": "urn:ngsi-ld:WaterLevelSensor:.*"
+}
+```
+
+### 3. Change Condition
+
+Checks whether a specific attribute has changed.
+
+```typescript
+interface ChangeCondition {
+  type: 'change';
+  attributeName: string;
+}
+```
+
+**Example**:
+
+```json
+{
+  "type": "change",
+  "attributeName": "status"
+}
+```
+
+### 4. Time Condition
+
+Checks whether the current time falls within the specified range.
+
+```typescript
+interface TimeCondition {
+  type: 'time';
+  startTime?: string;  // "HH:mm" format
+  endTime?: string;    // "HH:mm" format
+  timezone?: string;   // IANA timezone (e.g., "Asia/Tokyo")
+}
+```
+
+**Example**:
+
+```json
+{
+  "type": "time",
+  "startTime": "09:00",
+  "endTime": "18:00",
+  "timezone": "Asia/Tokyo"
+}
+```
+
+### 5. Entity Type Condition
+
+Checks the entity type.
+
+```typescript
+interface EntityTypeCondition {
+  type: 'entityType';
+  entityTypes: string[];  // List of matching types
+}
+```
+
+**Example**:
+
+```json
+{
+  "type": "entityType",
+  "entityTypes": ["TemperatureSensor", "HumiditySensor"]
+}
+```
+
+### 6. Event Type Condition
+
+Filters by the trigger event that produced the change. Maps the internal event names (`EntityCreated` / `EntityUpdated` / `EntityDeleted`) to the lowercase tokens `create` / `update` / `delete`.
+
+```typescript
+interface EventTypeCondition {
+  type: 'eventType';
+  eventTypes: Array<'create' | 'update' | 'delete'>;
+}
+```
+
+**Use cases**:
+
+- Run an action only on entity creation (e.g. write an `ActivityLog` only when a `GeoJSON` is created)
+- Run cleanup only on deletion
+- Skip update-induced cascading writes
+
+**Examples**:
+
+Create-only:
+
+```json
+{
+  "type": "eventType",
+  "eventTypes": ["create"]
+}
+```
+
+Create or delete (exclude updates):
+
+```json
+{
+  "type": "eventType",
+  "eventTypes": ["create", "delete"]
+}
+```
+
+Combine with `entityType` to scope to a specific type:
+
+```json
+{
+  "type": "and",
+  "conditions": [
+    { "type": "eventType",  "eventTypes": ["create"] },
+    { "type": "entityType", "entityTypes": ["GeoJSON"] }
+  ]
+}
+```
+
+> **Note**: For attribute-level filtering on UPDATE events, combine with `change` (e.g. `{type: "change", attributeName: "status"}`). On CREATE / DELETE, `change` always evaluates to false because `changedAttributes` is undefined.
+
+### 7. CEL Expression Condition
+
+A flexible condition expression using [Common Expression Language (CEL)](https://github.com/google/cel-spec). Supports complex calculations, string operations, and combined evaluation of multiple attributes.
+
+```typescript
+interface CelExpressionCondition {
+  type: 'celExpression';
+  expression: string;  // CEL expression (max 1000 characters)
+}
+```
+
+#### CEL Context Variables
+
+| Variable | Description | Example |
+|------|------|---|
+| `entity.id` | Entity ID | `"urn:ngsi-ld:Device:001"` |
+| `entity.type` | Entity type | `"Device"` |
+| `attribute.<name>.value` | Current attribute value | `attribute.temperature.value` → `35` |
+| `attribute.<name>.type` | Current attribute type | `attribute.temperature.type` → `"Number"` |
+| `previous.attribute.<name>.value` | Pre-change attribute value | `previous.attribute.temperature.value` → `25` |
+| `previous.attribute.<name>.type` | Pre-change attribute type | `previous.attribute.temperature.type` → `"Number"` |
+
+`previous` semantics by event type:
+
+| Event | `previous.attribute` |
+|---|---|
+| `EntityCreated` | Empty object — no previous state |
+| `EntityUpdated` | Pre-update attributes snapshot |
+| `EntityDeleted` | Final attributes before deletion |
+
+> **Tip — guard with `has()`**: when an attribute may not exist in the previous state (e.g. on `EntityCreated`, or for newly added attributes), wrap access with `has()`:
+>
+> ```text
+> has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30
+> ```
+>
+> Direct access without `has()` on a missing key raises an evaluation error, which is caught and treated as `false`.
+
+#### Examples
+
+**Attribute value comparison:**
+```json
+{
+  "type": "celExpression",
+  "expression": "attribute.temperature.value > 30"
+}
+```
+
+**Combining multiple attributes:**
+```json
+{
+  "type": "celExpression",
+  "expression": "attribute.temperature.value > 30 && attribute.status.value == \"active\""
+}
+```
+
+**Discomfort index calculation:**
+```json
+{
+  "type": "celExpression",
+  "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 75"
+}
+```
+
+**Entity ID/type conditions:**
+```json
+{
+  "type": "celExpression",
+  "expression": "entity.type == \"Device\" && entity.id.startsWith(\"urn:ngsi-ld:Device:\")"
+}
+```
+
+**Threshold crossing (fire only on the moment a value crosses the threshold):**
+```json
+{
+  "type": "celExpression",
+  "expression": "has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30"
+}
+```
+Idempotent updates (re-writing the same value) do not fire because `previous.attribute.temperature.value` is already > 30.
+
+**State transition (e.g. `draft` → `published`):**
+```json
+{
+  "type": "celExpression",
+  "expression": "has(previous.attribute.status) && previous.attribute.status.value == \"draft\" && attribute.status.value == \"published\""
+}
+```
+
+**Detect newly added attribute:**
+```json
+{
+  "type": "celExpression",
+  "expression": "!has(previous.attribute.description) && has(attribute.description)"
+}
+```
+
+**Detect type change (e.g. Text → Number):**
+```json
+{
+  "type": "celExpression",
+  "expression": "has(previous.attribute.reading) && previous.attribute.reading.type == \"Text\" && attribute.reading.type == \"Number\""
+}
+```
+
+#### Custom Functions
+
+The following custom functions are available in CEL expressions. They support geospatial calculations and time-based condition evaluation commonly needed in IoT and smart city use cases.
+
+##### `distance(location1, location2)` — Distance between two points (in meters)
+
+Great-circle distance calculation using the Haversine formula. Input is GeoJSON Point objects; output is meters (Number).
+
+```json
+{
+  "type": "celExpression",
+  "expression": "distance(attribute.location.value, {\"type\": \"Point\", \"coordinates\": [139.6503, 35.6762]}) < 1000"
+}
+```
+
+##### `within(location, polygon)` — Point-in-polygon check
+
+Point-in-Polygon determination using the Ray casting algorithm. Input is a GeoJSON Point and a GeoJSON Polygon; output is Boolean. Only the outer ring is supported (holes/inner rings are not supported), and the outer ring must be closed (start and end coordinates must be the same).
+
+```json
+{
+  "type": "celExpression",
+  "expression": "within(attribute.location.value, {\"type\": \"Polygon\", \"coordinates\": [[[139.6, 35.6], [139.8, 35.6], [139.8, 35.8], [139.6, 35.8], [139.6, 35.6]]]})"
+}
+```
+
+Use the negation operator to detect geofence exit:
+
+```json
+{
+  "type": "celExpression",
+  "expression": "!within(attribute.location.value, {\"type\": \"Polygon\", \"coordinates\": [[[139.6, 35.6], [139.8, 35.6], [139.8, 35.8], [139.6, 35.8], [139.6, 35.6]]]})"
+}
+```
+
+##### `now()` — Current time (ISO 8601 string)
+
+Returns the current UTC time as an ISO 8601 string.
+
+```json
+{
+  "type": "celExpression",
+  "expression": "now() > attribute.createdAt.value"
+}
+```
+
+##### `dayOfWeek()` — Current day of week (0-6, Sunday=0)
+
+Returns the UTC-based day of the week as a number (0=Sunday, 1=Monday, ..., 6=Saturday).
+
+```json
+{
+  "type": "celExpression",
+  "expression": "dayOfWeek() >= 1 && dayOfWeek() <= 5 && attribute.temperature.value > 30"
+}
+```
+
+##### Combining functions
+
+Custom functions can be freely combined with other CEL operators and context variables:
+
+```json
+{
+  "type": "celExpression",
+  "expression": "distance(attribute.location.value, {\"type\": \"Point\", \"coordinates\": [139.7671, 35.6812]}) < 5000 && dayOfWeek() >= 1 && dayOfWeek() <= 5"
+}
+```
+
+#### Limitations
+
+- Maximum expression length: 1000 characters
+- CEL is Turing-incomplete (no loops or recursion), so there is no risk of infinite loops
+- The expression must return a boolean (non-boolean results are treated as false)
+- If an evaluation error occurs, the condition is treated as false (no exception is thrown)
+- Custom functions execute within the existing CEL evaluation timeout (100ms)
+- Invalid input to custom functions (e.g., invalid GeoJSON) results in an error, and the condition is treated as false
+
+### 8. Logical Conditions
+
+#### AND Condition
+
+True when all child conditions are true.
+
+```json
+{
+  "type": "and",
+  "conditions": [
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    },
+    {
+      "type": "value",
+      "attributeName": "humidity",
+      "operator": "<",
+      "value": 40
+    }
+  ]
+}
+```
+
+#### OR Condition
+
+True when at least one child condition is true.
+
+```json
+{
+  "type": "or",
+  "conditions": [
+    {
+      "type": "value",
+      "attributeName": "status",
+      "operator": "==",
+      "value": "critical"
+    },
+    {
+      "type": "value",
+      "attributeName": "status",
+      "operator": "==",
+      "value": "error"
+    }
+  ]
+}
+```
+
+#### NOT Condition
+
+True when the child condition is false.
+
+```json
+{
+  "type": "not",
+  "condition": {
+    "type": "value",
+    "attributeName": "enabled",
+    "operator": "==",
+    "value": false
+  }
+}
+```
+
+---
+
+## Actions
+
+Operations executed when a condition is matched.
+
+### Action Types
+
+| Type | Description | Use Case |
+|--------|------|------|
+| `createEntity` | Create a new entity | Generate derived entities |
+| `updateAttribute` | Update an attribute | Add calculated results |
+| `deleteAttribute` | Delete an attribute | Remove unnecessary attributes |
+| `sendNotification` | Send a notification | Notify via subscription |
+| `webhook` | Invoke a Webhook | Integrate with external systems |
+| `appendToTemporal` | Append to the Temporal API | Automatically record time-series data |
+
+### 1. Create Entity Action
+
+Creates a new entity.
+
+```typescript
+interface CreateEntityAction {
+  type: 'createEntity';
+  entityId: string;               // Supports template variables
+  entityType: string;             // Supports template variables
+  attributes: Record<string, unknown>;  // Supports template variables
+  protocol?: 'ngsiv2' | 'ngsild';  // Target protocol (default: inherit from trigger)
+  servicePath?: string;              // Target servicePath for ngsiv2 (supports template variables)
+  scope?: string[];                  // Target scope for ngsild (supports template variables)
+}
+```
+
+**Example**: Create an aggregation entity from temperature sensor data
+
+```json
+{
+  "type": "createEntity",
+  "entityId": "summary-${entity.id}",
+  "entityType": "TemperatureSummary",
+  "attributes": {
+    "sensorId": "${entity.id}",
+    "currentTemperature": "${attribute.temperature.value}",
+    "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+  }
+}
+```
+
+**Example**: Cross-protocol — create an NGSI-LD alert from an NGSIv2 sensor
+
+```json
+{
+  "type": "createEntity",
+  "entityId": "urn:ngsi-ld:Alert:${entity.id}",
+  "entityType": "Alert",
+  "protocol": "ngsild",
+  "scope": ["${trigger.servicePath}"],
+  "attributes": {
+    "severity": { "type": "Property", "value": "high" },
+    "source": { "type": "Relationship", "value": "${entity.id}" }
+  }
+}
+```
+
+### 2. Update Attribute Action
+
+Updates an attribute of an existing entity.
+
+```typescript
+interface UpdateAttributeAction {
+  type: 'updateAttribute';
+  entityId: string;        // Supports template variables
+  attributeName: string;
+  value: unknown;          // Supports template variables
+  protocol?: 'ngsiv2' | 'ngsild';  // Target protocol (default: inherit from trigger)
+}
+```
+
+**Example**: Add a high-temperature warning flag
+
+```json
+{
+  "type": "updateAttribute",
+  "entityId": "${entity.id}",
+  "attributeName": "highTemperatureAlert",
+  "value": true
+}
+```
+
+### 3. Delete Attribute Action
+
+Deletes an attribute from an entity.
+
+```typescript
+interface DeleteAttributeAction {
+  type: 'deleteAttribute';
+  entityId: string;        // Supports template variables
+  attributeName: string;
+  protocol?: 'ngsiv2' | 'ngsild';  // Target protocol (default: inherit from trigger)
+}
+```
+
+**Example**: Delete a warning flag
+
+```json
+{
+  "type": "deleteAttribute",
+  "entityId": "${entity.id}",
+  "attributeName": "highTemperatureAlert"
+}
+```
+
+### 4. Send Notification Action
+
+Sends a notification via a subscription. Custom data can be sent to the notification endpoint of the specified subscription.
+
+#### Interface
+
+```typescript
+interface SendNotificationAction {
+  type: 'sendNotification';
+  subscriptionId?: string;        // Single subscription ID
+  subscriptionIds?: string[];     // Multiple subscription IDs
+  message?: string;               // Optional message
+  notificationData?: Record<string, unknown>;  // Custom data
+}
+```
+
+**Note:** At least one of `subscriptionId` or `subscriptionIds` must be specified.
+
+#### Examples
+
+**Notification to a single subscription:**
+```json
+{
+  "type": "sendNotification",
+  "subscriptionId": "urn:ngsi-ld:Subscription:sub001",
+  "message": "High temperature detected"
+}
+```
+
+**Notification to multiple subscriptions:**
+```json
+{
+  "type": "sendNotification",
+  "subscriptionIds": ["urn:ngsi-ld:Subscription:sub001", "urn:ngsi-ld:Subscription:sub002"],
+  "notificationData": {
+    "alertLevel": "high",
+    "sensorId": "${entity.id}",
+    "temperature": "${attribute.temperature.value}"
+  }
+}
+```
+
+#### Template Variables
+
+The following template variables can be used in `notificationData`:
+- `${entity.id}` - Entity ID
+- `${entity.type}` - Entity type
+- `${attribute.<name>.value}` - Attribute value
+- `${attribute.<name>.metadata.<metaName>.value}` - Attribute metadata value
+
+#### Limitations
+
+- Custom data size must be 200 KB or less (EventBridge limit)
+- Specified subscription IDs must exist within the same tenant
+- Non-existent subscription IDs are skipped with a warning log
+
+### 5. Webhook Action
+
+Invokes an external HTTP endpoint.
+
+```typescript
+interface WebhookAction {
+  type: 'webhook';
+  url: string;                        // Supports template variables
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  headers?: Record<string, string>;   // Supports template variables
+  body?: unknown;                     // Supports template variables
+}
+```
+
+**Example**: Send temperature data to an external API
+
+```json
+{
+  "type": "webhook",
+  "url": "https://api.example.com/temperature-alerts",
+  "method": "POST",
+  "headers": {
+    "Authorization": "Bearer token123",
+    "Content-Type": "application/json"
+  },
+  "body": {
+    "sensorId": "${entity.id}",
+    "temperature": "${attribute.temperature.value}",
+    "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+  }
+}
+```
+
+### 6. Append to Temporal Action
+
+Automatically appends entity attribute data to the Temporal API (time-series database). Internally calls `TemporalService.recordEntityChange()` to record data in the Time Series Collection.
+
+#### Interface
+
+```typescript
+interface AppendToTemporalAction {
+  type: 'appendToTemporal';
+  attributes?: string[];  // List of attribute names to record (defaults to changedAttributes if omitted)
+}
+```
+
+#### Examples
+
+**Record only specific attributes:**
+```json
+{
+  "type": "appendToTemporal",
+  "attributes": ["temperature", "humidity"]
+}
+```
+
+**Automatically record changed attributes (omit attributes):**
+```json
+{
+  "type": "appendToTemporal"
+}
+```
+
+#### Behavior Details
+
+- When `attributes` is specified: Only the specified attributes are recorded to the Temporal API
+- When `attributes` is omitted: The `changedAttributes` (changed attributes) from the entity change event are recorded
+- If an attribute has `observedAt` metadata, that value is used as the timestamp; otherwise the current time is used
+- Data is appended to the Time Series Collection (existing data is retained)
+
+#### Use Cases
+
+1. **Automatic archiving of IoT sensor data**: Automatically record temperature and humidity sensor values as time-series data each time they are updated
+2. **Snapshot recording on threshold breach**: Record time-series data only when specific conditions are met (used in combination with conditions)
+3. **Selective attribute recording**: Efficiently record only specific attributes rather than all attributes
+
+---
+
+## Cross-Protocol Entity Creation
+
+The rule engine supports creating entities across protocol boundaries — for example, an NGSIv2 sensor change can trigger creation of an NGSI-LD entity and vice versa.
+
+### Overview
+
+GeonicDB enforces protocol isolation: NGSIv2 entities are only accessible via NGSIv2 API, and NGSI-LD entities via NGSI-LD API. The rule engine bridges this gap by allowing actions to specify a target `protocol` different from the trigger entity's protocol.
+
+### Action Fields for Cross-Protocol
+
+| Field | Actions | Type | Default |
+|---|---|---|---|
+| `protocol` | createEntity, updateAttribute, deleteAttribute | `'ngsiv2' \| 'ngsild'` | Inherited from trigger |
+| `servicePath` | createEntity | `string` | Inherited or auto-mapped |
+| `scope` | createEntity | `string[]` | Inherited or auto-mapped |
+
+### Automatic servicePath ↔ scope Mapping
+
+When crossing protocols, the hierarchy system is automatically mapped:
+
+| Direction | Condition | Mapping |
+|---|---|---|
+| NGSIv2 → NGSI-LD | `servicePath != '/'` | `scope = [servicePath]` |
+| NGSI-LD → NGSIv2 | `scope` has elements | `servicePath = scope[0]` |
+| Root servicePath `'/'` | (always) | No scope generated |
+
+Explicit `servicePath` or `scope` on the action overrides the automatic mapping. Template variables (`${trigger.servicePath}`, `${trigger.scope}`) can be used for custom mapping logic.
+
+### Example: NGSIv2 Sensor → NGSI-LD Alert
+
+```json
+{
+  "name": "Cross-protocol temperature alert",
+  "conditions": [
+    { "type": "entityType", "entityTypes": ["TemperatureSensor"] },
+    { "type": "value", "attributeName": "temperature", "operator": ">", "value": 35 }
+  ],
+  "actions": [{
+    "type": "createEntity",
+    "protocol": "ngsild",
+    "entityId": "urn:ngsi-ld:Alert:heat-${entity.id}",
+    "entityType": "Alert",
+    "scope": ["${trigger.servicePath}"],
+    "attributes": {
+      "severity": { "type": "Property", "value": "high" },
+      "source": { "type": "Relationship", "value": "${entity.id}" },
+      "temperature": { "type": "Property", "value": "${attribute.temperature.value}" }
+    }
+  }]
+}
+```
+
+### Example: NGSI-LD Entity → NGSIv2 Mirror
+
+```json
+{
+  "name": "NGSI-LD to NGSIv2 mirror",
+  "conditions": [
+    { "type": "entityType", "entityTypes": ["Device"] }
+  ],
+  "actions": [{
+    "type": "createEntity",
+    "protocol": "ngsiv2",
+    "entityId": "v2-${entity.id}",
+    "entityType": "DeviceMirror",
+    "attributes": {
+      "source": "${entity.id}",
+      "status": "mirrored"
+    }
+  }]
+}
+```
+
+### Limitations
+
+- **Multiple scopes**: When mapping scope → servicePath, only the first element (`scope[0]`) is used, since servicePath is a single string
+- **Root servicePath**: `'/'` is not mapped to scope (it has no semantic meaning in NGSI-LD)
+- **Backward compatible**: If `protocol` is omitted, the action inherits the trigger entity's protocol (existing behavior)
+
+---
+
+## Template Variables
+
+Dynamic variables can be embedded in action values.
+
+### Syntax
+
+Written in the format `${path.to.value}`.
+
+### Available Paths
+
+| Path | Description | Example |
+|------|------|---|
+| `${entity.id}` | Entity ID | `"Sensor001"` |
+| `${entity.type}` | Entity type | `"TemperatureSensor"` |
+| `${attribute.<name>.value}` | Attribute value | `${attribute.temperature.value}` → `25.5` |
+| `${attribute.<name>.type}` | Attribute type | `${attribute.temperature.type}` → `"Number"` |
+| `${attribute.<name>.metadata.<key>.value}` | Metadata value | `${attribute.temperature.metadata.unit.value}` → `"Celsius"` |
+| `${trigger.protocol}` | Trigger entity's protocol | `"ngsiv2"` or `"ngsild"` |
+| `${trigger.servicePath}` | Trigger entity's servicePath | `"/Madrid/Sensors"` |
+| `${trigger.scope}` | Trigger entity's scope array (JSON) | `["/Madrid/Sensors"]` |
+| `${trigger.service}` | Trigger entity's tenant service | `"smartcity"` |
+
+### Examples
+
+#### Generating a derived entity ID
+
+```json
+{
+  "entityId": "summary-${entity.id}"
+}
+```
+
+If `entity.id` is `"Sensor001"`, this becomes `"summary-Sensor001"`.
+
+#### Copying an attribute value
+
+```json
+{
+  "attributes": {
+    "originalTemperature": "${attribute.temperature.value}",
+    "sensor": "${entity.id}"
+  }
+}
+```
+
+#### Dynamic Webhook URL
+
+```json
+{
+  "url": "https://api.example.com/sensors/${entity.id}/alerts"
+}
+```
+
+### Template Functions
+
+In addition to path resolution, action templates can call a small whitelist of pure functions in the form `${name(args)}`. Useful for stamping the server's wall clock time and for generating unique IDs in derived entities (e.g. append-only `ActivityLog` records).
+
+| Function | Returns | Example |
+|---|---|---|
+| `${now()}` / `${now('iso')}` | ISO 8601 timestamp (ms precision, UTC) | `"2026-05-02T01:23:45.678Z"` |
+| `${now('unix')}` | UNIX timestamp in seconds | `"1746148225"` |
+| `${now('unix-ms')}` | UNIX timestamp in milliseconds | `"1746148225678"` |
+| `${uuid()}` | RFC 4122 v4 UUID | `"6f1c43b8-7c5e-4f12-9a2b-2d3a4f5c6e7d"` |
+
+**Notes**
+
+- Functions are evaluated **per rule fire** — every event creates a fresh value (so `${uuid()}` is genuinely unique per derived entity, and `${now()}` reflects the moment of evaluation, not rule registration).
+- The arg parser only handles simple comma-separated literal strings (`'iso'`, `"unix"`). Nested expressions, numeric arithmetic, and references such as `${now(entity.id)}` are not supported — compute those in a CEL `celExpression` condition instead and surface the result as an entity attribute.
+- Unknown function names and unsupported argument values leave the placeholder text in place (e.g. `${notAFunction()}` stays literal). A warning is logged so the rule author can fix the typo.
+- Path resolution and function calls coexist: `https://example.com/log?id=${uuid()}&entity=${entity.id}` works as expected.
+
+#### Append-only ActivityLog example
+
+```json
+{
+  "type": "createEntity",
+  "entityId": "urn:ngsi-ld:ActivityLog:${uuid()}",
+  "entityType": "ActivityLog",
+  "attributes": {
+    "target": "${entity.id}",
+    "action": "create",
+    "createdAt": "${now()}"
+  }
+}
+```
+
+Every entity create event produces a fresh `ActivityLog` instance — no entityId collisions, no cooldown conflicts.
+
+---
+
+## Rules API
+
+### List Rules
+
+```http
+GET /rules
+Authorization: Bearer <accessToken>
+```
+
+**Authorization**: XACML policy-based (requires the `tenant_admin` role; `super_admin` cannot access `/rules*` endpoints when `AUTH_ENABLED=true`)
+
+**Query Parameters**
+
+| Parameter | Description |
+|-----------|------|
+| `limit` | Number of results to retrieve (default: 20, max: 100) |
+| `offset` | Offset (default: 0) |
+| `servicePath` | Filter by service path |
+| `isActive` | Filter by enabled/disabled (`true` / `false`) |
+
+**Response**: `200 OK`
+
+```json
+[
+  {
+    "ruleId": "high-temperature-alert",
+    "name": "High Temperature Warning",
+    "description": "Add a warning attribute when temperature exceeds 30 degrees",
+    "tenantId": "smartcity",
+    "servicePath": "/sensors",
+    "conditions": [...],
+    "actions": [...],
+    "isActive": true,
+    "priority": 10,
+    "createdAt": "2026-02-10T00:00:00.000Z",
+    "updatedAt": "2026-02-10T00:00:00.000Z"
+  }
+]
+```
+
+**Response Headers**
+
+- `X-Total-Count`: Total number of results
+- `Link`: Pagination links
+
+### Create Rule
+
+```http
+POST /rules
+Authorization: Bearer <accessToken>
+Content-Type: application/json
+```
+
+**Request Body**
+
+```json
+{
+  "ruleId": "high-temperature-alert",
+  "name": "High Temperature Warning",
+  "description": "Add a warning attribute when temperature exceeds 30 degrees",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alert",
+      "value": "HIGH_TEMPERATURE"
+    }
+  ],
+  "priority": 10
+}
+```
+
+**Response**: `201 Created`
+
+### Get Rule
+
+```http
+GET /rules/:ruleId
+Authorization: Bearer <accessToken>
+```
+
+**Response**: `200 OK` / `404 Not Found`
+
+### Update Rule
+
+```http
+PATCH /rules/:ruleId
+Authorization: Bearer <accessToken>
+Content-Type: application/json
+```
+
+**Request Body**
+
+```json
+{
+  "name": "Updated rule name",
+  "description": "Updated description",
+  "conditions": [...],
+  "actions": [...],
+  "priority": 5
+}
+```
+
+**Response**: `204 No Content` / `404 Not Found`
+
+### Delete Rule
+
+```http
+DELETE /rules/:ruleId
+Authorization: Bearer <accessToken>
+```
+
+**Response**: `204 No Content` / `404 Not Found`
+
+### Enable/Disable Rule
+
+```http
+POST /rules/:ruleId/activate
+POST /rules/:ruleId/deactivate
+Authorization: Bearer <accessToken>
+```
+
+**Response**: `200 OK` / `404 Not Found`
+
+---
+
+## Examples
+
+### Example 1: High Temperature Alert
+
+Automatically adds a warning attribute when the temperature exceeds 30 degrees.
+
+```json
+{
+  "ruleId": "high-temperature-alert",
+  "name": "High Temperature Alert",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alert",
+      "value": "HIGH_TEMPERATURE"
+    },
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alertTimestamp",
+      "value": "${attribute.temperature.metadata.timestamp.value}"
+    }
+  ],
+  "priority": 10
+}
+```
+
+### Example 2: Automatic Status Update Outside Business Hours
+
+Automatically sets the status to "closed" outside business hours (18:00 to 09:00).
+
+```json
+{
+  "ruleId": "after-hours-status",
+  "name": "After-Hours Status",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["Store"]
+    },
+    {
+      "type": "or",
+      "conditions": [
+        {
+          "type": "time",
+          "startTime": "18:00",
+          "endTime": "23:59",
+          "timezone": "Asia/Tokyo"
+        },
+        {
+          "type": "time",
+          "startTime": "00:00",
+          "endTime": "09:00",
+          "timezone": "Asia/Tokyo"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "status",
+      "value": "closed"
+    }
+  ],
+  "priority": 5
+}
+```
+
+### Example 3: Automatic Generation of Derived Entities
+
+Automatically generates a daily summary entity from sensor data.
+
+```json
+{
+  "ruleId": "daily-summary",
+  "name": "Daily Summary Generation",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "change",
+      "attributeName": "temperature"
+    }
+  ],
+  "actions": [
+    {
+      "type": "createEntity",
+      "entityId": "summary-${entity.id}",
+      "entityType": "DailySummary",
+      "attributes": {
+        "sensorId": "${entity.id}",
+        "sensorType": "${entity.type}",
+        "currentTemperature": "${attribute.temperature.value}",
+        "unit": "${attribute.temperature.metadata.unit.value}",
+        "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+      }
+    }
+  ],
+  "priority": 20
+}
+```
+
+### Example 4: Webhook Notification to an External API
+
+Notifies an external monitoring system of temperature changes.
+
+```json
+{
+  "ruleId": "external-monitoring",
+  "name": "External Monitoring Notification",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "change",
+      "attributeName": "temperature"
+    }
+  ],
+  "actions": [
+    {
+      "type": "webhook",
+      "url": "https://monitoring.example.com/api/sensors/${entity.id}/events",
+      "method": "POST",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_TOKEN",
+        "X-Sensor-Type": "${entity.type}"
+      },
+      "body": {
+        "event": "temperature_change",
+        "sensorId": "${entity.id}",
+        "temperature": "${attribute.temperature.value}",
+        "unit": "celsius",
+        "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+      }
+    }
+  ],
+  "priority": 15
+}
+```
+
+### Example 5: Complex Conditions (AND + OR)
+
+Issues a warning when the temperature is 30 degrees or above, AND either humidity is 80% or above, OR the time is between 12:00 and 15:00.
+
+```json
+{
+  "ruleId": "complex-alert",
+  "name": "Complex Condition Alert",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["WeatherStation"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">=",
+      "value": 30
+    },
+    {
+      "type": "or",
+      "conditions": [
+        {
+          "type": "value",
+          "attributeName": "humidity",
+          "operator": ">=",
+          "value": 80
+        },
+        {
+          "type": "time",
+          "startTime": "12:00",
+          "endTime": "15:00",
+          "timezone": "Asia/Tokyo"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "heatIndexAlert",
+      "value": "EXTREME"
+    }
+  ],
+  "priority": 5
+}
+```
+
+### Example 6: Heat Stroke Alert Notification via Discomfort Index (CEL Expression + Notification)
+
+A practical example that evaluates the **Discomfort Index** in real time from temperature and humidity and sends a notification via subscription when the threshold is exceeded.
+
+**Discomfort Index formula:**
+
+```text
+DI = 0.81 × T + 0.01 × H × (0.99 × T − 14.3) + 46.3
+```
+
+- T: Temperature (°C)
+- H: Relative humidity (%)
+
+**Discomfort Index reference levels:**
+
+| Discomfort Index | Perceived sensation |
+|---------|------|
+| ~55 | Cold |
+| 55~60 | Chilly |
+| 60~65 | No particular sensation |
+| 65~70 | Comfortable |
+| 70~75 | Not hot |
+| **75~80** | **Somewhat hot** ← Alert threshold |
+| 80~85 | Hot with perspiration |
+| 85~ | Unbearably hot |
+
+#### Step 1: Create a notification subscription
+
+First, create a subscription to receive alert notifications.
+
+```bash
+# Create an NGSIv2 subscription
+curl -X POST "http://localhost:3000/v2/subscriptions" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -H "Authorization: Bearer <accessToken>" \
+  -d '{
+    "description": "Discomfort index alert notification",
+    "subject": {
+      "entities": [
+        { "idPattern": ".*", "type": "WeatherStation" }
+      ],
+      "condition": {
+        "attrs": ["temperature", "humidity"]
+      }
+    },
+    "notification": {
+      "http": {
+        "url": "https://alerts.example.com/discomfort-index"
+      },
+      "attrs": ["temperature", "humidity", "discomfortLevel"]
+    }
+  }'
+```
+
+Retrieve the subscription ID from the `Location` header of the response (e.g., `urn:ngsi-ld:Subscription:abc123`).
+
+#### Step 2: Create the discomfort index alert rule
+
+Create a rule that uses a CEL expression to calculate the discomfort index and executes actions when it exceeds 75.
+
+```bash
+curl -X POST "http://localhost:3000/rules" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -H "Authorization: Bearer <accessToken>" \
+  -d '{
+    "ruleId": "discomfort-index-alert",
+    "name": "Discomfort Index Alert",
+    "description": "Set a warning level and send a notification when the discomfort index exceeds 75",
+    "conditions": [
+      {
+        "type": "entityType",
+        "entityTypes": ["WeatherStation"]
+      },
+      {
+        "type": "or",
+        "conditions": [
+          { "type": "change", "attributeName": "temperature" },
+          { "type": "change", "attributeName": "humidity" }
+        ]
+      },
+      {
+        "type": "celExpression",
+        "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 75"
+      }
+    ],
+    "actions": [
+      {
+        "type": "updateAttribute",
+        "entityId": "${entity.id}",
+        "attributeName": "discomfortLevel",
+        "value": "WARNING"
+      },
+      {
+        "type": "sendNotification",
+        "subscriptionId": "urn:ngsi-ld:Subscription:abc123",
+        "message": "Discomfort index has exceeded the threshold",
+        "notificationData": {
+          "alertType": "DISCOMFORT_INDEX",
+          "stationId": "${entity.id}",
+          "temperature": "${attribute.temperature.value}",
+          "humidity": "${attribute.humidity.value}",
+          "level": "WARNING"
+        }
+      }
+    ],
+    "priority": 10,
+    "cooldownSeconds": 600
+  }'
+```
+
+**Key points of this rule:**
+
+- **Condition 1 (entityType)**: Only targets entities of type `WeatherStation`
+- **Condition 2 (or + change)**: Evaluates only when `temperature` or `humidity` changes (avoids unnecessary re-evaluation)
+- **Condition 3 (celExpression)**: The discomfort index formula is written directly in CEL and checks whether it exceeds 75
+- **Action 1 (updateAttribute)**: Adds the `discomfortLevel` attribute to the entity
+- **Action 2 (sendNotification)**: Sends an alert notification via the subscription
+- **cooldownSeconds: 600**: A 10-minute cooldown prevents excessive notification delivery
+
+#### Step 3: Add a danger-level (DI > 80) Webhook notification rule
+
+Create an additional rule that sends an emergency notification via Webhook when the discomfort index is even higher.
+
+```json
+{
+  "ruleId": "discomfort-index-danger",
+  "name": "Discomfort Index Danger Alert",
+  "description": "Send an emergency notification when the discomfort index exceeds 80",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["WeatherStation"]
+    },
+    {
+      "type": "celExpression",
+      "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 80"
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "discomfortLevel",
+      "value": "DANGER"
+    },
+    {
+      "type": "webhook",
+      "url": "https://api.example.com/emergency/heatstroke-alert",
+      "method": "POST",
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer YOUR_API_TOKEN"
+      },
+      "body": {
+        "severity": "DANGER",
+        "stationId": "${entity.id}",
+        "stationType": "${entity.type}",
+        "temperature": "${attribute.temperature.value}",
+        "humidity": "${attribute.humidity.value}",
+        "message": "Heat stroke danger level: Temperature ${attribute.temperature.value}°C, Humidity ${attribute.humidity.value}%"
+      }
+    }
+  ],
+  "priority": 5,
+  "cooldownSeconds": 300
+}
+```
+
+**Note:** This rule has `priority: 5`, which is higher priority than the `priority: 10` in Example 6. Therefore, when DI > 80, `DANGER` is set first, and care must be taken to avoid it being overwritten by the subsequent `WARNING` update. When both rules match for the same entity, they are executed in ascending order of priority, so the order would be `DANGER` → `WARNING`. To avoid this, add an upper bound condition to the CEL expression in the WARNING rule:
+
+```json
+{
+  "type": "celExpression",
+  "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 75 && 0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 <= 80"
+}
+```
+
+#### Step 4: Verify behavior
+
+```bash
+# Temperature 27°C, Humidity 75% → Discomfort index ≈ 77.5 (WARNING)
+curl -X POST "http://localhost:3000/v2/entities" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "id": "urn:ngsi-ld:WeatherStation:shibuya-001",
+    "type": "WeatherStation",
+    "temperature": { "value": 27, "type": "Number" },
+    "humidity": { "value": 75, "type": "Number" },
+    "location": { "value": "35.6595,139.7004", "type": "Text" }
+  }'
+
+# Verify that discomfortLevel was automatically added
+curl -s "http://localhost:3000/v2/entities/urn:ngsi-ld:WeatherStation:shibuya-001" \
+  -H "Fiware-Service: smartcity" | jq '.discomfortLevel'
+# → { "type": "Text", "value": "WARNING", "metadata": {} }
+
+# Update temperature to 33°C → Discomfort index ≈ 86.8 (DANGER)
+curl -X PATCH "http://localhost:3000/v2/entities/urn:ngsi-ld:WeatherStation:shibuya-001/attrs" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "temperature": { "value": 33, "type": "Number" }
+  }'
+
+# Verify that discomfortLevel was updated to DANGER
+curl -s "http://localhost:3000/v2/entities/urn:ngsi-ld:WeatherStation:shibuya-001" \
+  -H "Fiware-Service: smartcity" | jq '.discomfortLevel'
+# → { "type": "Text", "value": "DANGER", "metadata": {} }
+```
+
+---
+
+## Infinite Loop Prevention
+
+ReactiveCore Rules implements multiple protection mechanisms to prevent rules from falling into infinite loops.
+
+### 1. Action Entity Type Exclusion (Self-Trigger Prevention)
+
+**Restriction**: The entity types created by a rule's actions are **automatically excluded** from the trigger targets of that same rule.
+
+**Behavior**:
+- Extracts the entity types created by a rule's actions (`createEntity`)
+- If the entity type in a change event matches a type specified in an action, execution of that rule is blocked
+
+**Example**:
+```json
+{
+  "ruleId": "sensor-alert-rule",
+  "name": "Temperature Sensor Warning",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "createEntity",
+      "entityId": "Alert:${entity.id}",
+      "entityType": "Alert",  // ← Creates an Alert entity
+      "attributes": {
+        "severity": "high"
+      }
+    }
+  ]
+}
+```
+
+This rule:
+- ✅ Executes on changes to `TemperatureSensor` entities
+- ❌ Does not execute on changes to `Alert` entities (self-trigger prevention)
+
+**Benefits**:
+- Prevents a rule from being re-triggered by the entity it created
+- Automatically prevents unintended chain reactions
+- Avoids loops without explicit condition configuration
+
+### 2. Execution Counter (Per Entity, Per Time Window)
+
+**Restriction**: For a single entity, a single rule can execute at most **10 times per minute**.
+
+```typescript
+// Default configuration (src/config/defaults.ts)
+RULE_ENGINE.MAX_EXECUTIONS_PER_WINDOW = 10;  // Maximum executions
+RULE_ENGINE.EXECUTION_WINDOW_SECONDS = 60;   // Time window (seconds)
+```
+
+**Behavior**:
+- Tracks execution count per entity per rule
+- Blocks further executions if the maximum is reached within the time window
+- The counter is automatically reset when the time window expires
+
+### 3. Loop Detection (Circular Rule Chains)
+
+**Restriction**: The depth of a rule execution chain is limited to a maximum of **5 levels**.
+
+```typescript
+// Default configuration (src/config/defaults.ts)
+RULE_ENGINE.MAX_CHAIN_DEPTH = 5;
+```
+
+**Behavior**:
+- Tracks chains such as Rule A → entity update → Rule B → entity update → Rule C
+- If the same rule appears twice within an execution chain (circular), execution is blocked
+- If the chain depth exceeds the maximum, execution is blocked
+
+**Example**:
+```text
+Rule A (temperature sensor) → creates Alert entity
+  → Rule B (Alert) → creates notification entity
+    → Rule C (notification) → creates log entity
+      → Rule D (log) → ... (OK: up to depth 5)
+        → Rule E (Alert) → triggers Rule B (NG: circular detected)
+```
+
+### 4. Cooldown Period
+
+A **minimum execution interval** can be configured for each rule.
+
+```json
+{
+  "ruleId": "temperature-alert",
+  "name": "Temperature Alert",
+  "conditions": [ ... ],
+  "actions": [ ... ],
+  "cooldownSeconds": 300  // 5-minute cooldown
+}
+```
+
+**Default value**: If `cooldownSeconds` is not specified, a default cooldown of **60 seconds** is applied.
+
+```typescript
+// Default configuration (src/config/defaults.ts)
+RULE_ENGINE.DEFAULT_COOLDOWN_SECONDS = 60;
+```
+
+**Behavior**:
+- Tracks the last execution time per entity per rule
+- Blocks execution if within the cooldown period
+- Execution becomes possible again once the cooldown period has elapsed
+
+**Use Cases**:
+- Controlling alert notifications for frequently changing sensor data
+- Preventing excessive Webhook invocations
+- Reducing load on external systems
+
+### Best Practices for Loop Prevention
+
+1. **Clearly distinguish entity types**: The action entity type exclusion feature is applied automatically
+   ```json
+   // Rule 1: Sensor → creates Alert entity
+   {
+     "conditions": [{"type": "entityType", "entityTypes": ["Sensor"]}],
+     "actions": [{"type": "createEntity", "entityType": "Alert", ...}]
+   }
+   // Changes to Alert entities will not trigger this rule (automatically excluded)
+   ```
+
+2. **Use Change conditions**: Trigger only when an attribute actually changes
+   ```json
+   {
+     "type": "change",
+     "attributeName": "temperature"
+   }
+   ```
+
+3. **Set cooldownSeconds**: Set an appropriate cooldown when high-frequency execution is expected
+   ```json
+   {
+     "cooldownSeconds": 300  // 5 minutes
+   }
+   ```
+
+4. **Set rule priorities appropriately**: Control execution order to prevent unintended chaining
+
+---
+
+## Limitations
+
+### Current Limitations
+
+1. **No transactions**: If an error occurs during execution of multiple actions, no rollback is performed
+2. **Condition evaluation performance**: With a large number of rules, evaluation may take longer
+3. **No type checking for template variables**: Runtime errors may occur
+
+### Performance Considerations
+
+- With many rules, the processing time per entity change increases
+- Disable unnecessary rules (`isActive: false`)
+- Set priorities appropriately to optimize execution order
+- Exercise caution when configuring rules for entities that change at high frequency
+- **Loop prevention**: Infinite loops are automatically prevented by the action entity type exclusion, execution counter, loop detection, and cooldown period mechanisms
+
+---
+
+## Troubleshooting
+
+### Rules Not Executing
+
+**Checklist**:
+
+1. Is `RULES_ENABLED=true` set?
+2. Is the rule enabled (`isActive: true`)?
+3. Are the conditions correctly matched (especially entity type)?
+4. Does the servicePath match?
+5. Is the Change Stream Handler running?
+
+**Debugging**:
+
+Check the logs.
+
+```bash
+# Search for RuleEngineService logs
+grep "RuleEngineService" /var/log/lambda.log
+```
+
+### Template Variables Not Being Expanded
+
+**Checklist**:
+
+1. Is the variable path correct (e.g., `${entity.id}`, `${attribute.temperature.value}`)?
+2. Does the referenced attribute exist?
+3. Watch out for differences in uppercase and lowercase
+
+**Examples**:
+
+- ❌ `${Entity.ID}` → ✅ `${entity.id}`
+- ❌ `${temperature.value}` → ✅ `${attribute.temperature.value}`
+
+### Webhook Failures
+
+**Checklist**:
+
+1. Is the URL correct?
+2. Is the external API reachable (network, firewall)?
+3. Is the Authorization header correct?
+4. Is the Content-Type correct?
+5. Is the request body format correct?
+
+**Debugging**:
+
+Check the logs for error messages.
+
+```bash
+# Search for Webhook errors
+grep "Webhook execution failed" /var/log/lambda.log
+```
+
+### Infinite Loops
+
+A rule's actions may match the conditions of another rule, potentially causing an infinite loop.
+
+**Countermeasures**:
+
+1. Design rule conditions carefully
+2. Use `change` conditions to trigger only on specific attribute changes
+3. Separate entity types (e.g., use a different type for derived entities)
+
+### Action Execution Errors
+
+**Checklist**:
+
+1. Does the entity ID exist (for updateAttribute, deleteAttribute)?
+2. Is the attribute name correct?
+3. Is the value type correct (e.g., not setting a string value on a numeric attribute)?
+4. Is the tenant and servicePath correct?
+
+---
+
+## Technical Specification (GeonicDB Rule Specification v1.0)
+
+**Status**: Draft
+**Version**: 1.0.0
+**Last Updated**: 2026-02-10
+**Authors**: GeonicDB Development Team
+
+### Abstract
+
+This document specifies the GeonicDB Rule Engine format for processing entity changes in NGSI-based context brokers. The specification defines a JSON-based rule format following the Event-Condition-Action (ECA) pattern, optimized for IoT and smart city applications.
+
+### 1. Introduction
+
+#### 1.1 Purpose
+
+The GeonicDB Rule Engine enables automatic processing of entity changes in FIWARE-compatible context brokers. Rules define conditions that trigger actions when entities are created, updated, or deleted.
+
+#### 1.2 Design Principles
+
+- **JSON Format**: All rules are defined using standard JSON
+- **ECA Pattern**: Event-Condition-Action architecture for reactive processing
+- **NGSI-Aware**: Native support for NGSI entity attributes and metadata
+- **Composable**: Conditions support logical operators (AND, OR, NOT) with arbitrary nesting
+- **Type-Safe**: Discriminated union types for conditions and actions
+- **Template-Driven**: Dynamic value substitution using `${...}` syntax
+
+#### 1.3 Terminology
+
+- **Rule**: A complete definition consisting of conditions and actions
+- **Condition**: A predicate that evaluates to true or false against an entity
+- **Action**: An operation executed when all rule conditions are satisfied
+- **Entity Change Event**: A notification of entity creation, update, or deletion
+- **Template Variable**: A placeholder that resolves to runtime entity values
+
+### 2. Conformance
+
+#### 2.1 Conformance Levels
+
+An implementation is **conformant** if it implements all features marked as REQUIRED.
+
+Features marked as OPTIONAL MAY be implemented at the discretion of the implementer.
+
+#### 2.2 Required Features
+
+A conformant implementation MUST:
+
+1. Support all condition types defined in Section 4
+2. Support all action types defined in Section 5
+3. Support template variable substitution as defined in Section 6
+4. Implement loop prevention mechanisms as defined in Section 7
+5. Evaluate conditions recursively for nested logical operators
+6. Execute actions sequentially in the order specified
+7. Validate rules against the JSON Schema in Section 8
+
+#### 2.3 Optional Features
+
+A conformant implementation MAY:
+
+1. Support additional custom condition types
+2. Support additional custom action types
+3. Provide extended template variable paths
+4. Implement custom loop prevention strategies
+
+### 3. JSON Schema
+
+The complete JSON Schema for GeonicDB Rule Specification v1.0 is available in the specification document. All rules MUST validate against this schema.
+
+Key validation rules:
+- `ruleId`, `name`, `tenantId`, `servicePath`, `conditions`, `actions`, `isActive`, and `priority` are REQUIRED fields
+- `conditions` array MUST contain at least one condition
+- `actions` array MUST contain at least one action
+- `cooldownSeconds` MUST be a positive integer if specified
+- `servicePath` MUST start with `/`
+
+For the complete JSON Schema definition, refer to Section 8 of the formal specification document.
+
+### 4. Versioning
+
+#### 4.1 Version Format
+
+This specification follows Semantic Versioning 2.0.0 (https://semver.org/):
+
+- **MAJOR**: Incompatible changes (e.g., removing condition/action types)
+- **MINOR**: Backward-compatible additions (e.g., new condition/action types)
+- **PATCH**: Backward-compatible fixes (e.g., clarifications, typo fixes)
+
+Current version: **1.0.0**
+
+#### 4.2 Compatibility
+
+Rules MAY declare the specification version they conform to using the `specVersion` field:
+
+```json
+{
+  "specVersion": "1.0.0",
+  "ruleId": "...",
+  ...
+}
+```
+
+#### 4.3 Deprecation Policy
+
+When features are deprecated:
+1. Feature is marked as DEPRECATED in documentation
+2. Feature remains functional for at least one MAJOR version
+3. Deprecation warnings SHOULD be logged
+4. Migration guide MUST be provided
+
+### References
+
+- **FIWARE NGSI-v2 Specification**: https://fiware.github.io/specifications/ngsiv2/stable/
+- **FIWARE NGSI-LD Specification**: https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/
+- **JSON Schema Draft 7**: http://json-schema.org/draft-07/schema#
+- **Semantic Versioning 2.0.0**: https://semver.org/
+- **IANA Time Zone Database**: https://www.iana.org/time-zones
+- **ECMAScript Regular Expressions**: https://tc39.es/ecma262/#sec-regexp-regular-expression-objects
+
+### Acknowledgments
+
+This specification was developed by the GeonicDB team at Geolonia Inc. with inspiration from:
+- FIWARE Complex Event Processing (Proton CEP)
+- json-rules-engine (CacheControl)
+- AWS EventBridge Rules
+- Common Expression Language (CEL)
+
+**License**: GNU Affero General Public License v3.0 (AGPL-3.0)
+**Copyright**: © 2026 Geolonia Inc.
+
+---
+
+## Related Documentation
+
+- [API Common Specification](../api-reference/endpoints.md) - General API specification
+- [Authentication & Authorization](../reference/auth.md) - Details on admin API and authentication requirements
+- [API Specification](../api-reference/endpoints.md) - List of all endpoints
+- Development Guide - Details on HTTP status codes

--- a/docs/en/features/subscriptions.md
+++ b/docs/en/features/subscriptions.md
@@ -49,12 +49,7 @@ EventBridge ─┬─> SubscriptionMatcher -> SQS -> HTTP/MQTT  [existing]
 
 ### Enabling
 
-Set the `EventStreamingEnabled` parameter to `true` in the SAM template and deploy.
-
-```bash
-sam deploy -t infrastructure/template.yaml \
-  --parameter-overrides EventStreamingEnabled=true
-```
+Event streaming is enabled by default in GeonicDB SaaS. No additional configuration is required.
 
 ### Environment Variables
 
@@ -150,7 +145,7 @@ When `AUTH_ENABLED=true`, an authentication token is required to establish a Web
 
 Required when connecting with a DPoP-bound token (JWT containing `cnf.jkt`). Must be sent within 5 seconds of connection. The server verifies the proof's JWK Thumbprint matches the token's `cnf.jkt` claim and responds with `{"type": "dpop_verified"}`. Until verified, all other messages are rejected with `{"type": "error", "message": "DPoP proof required"}`.
 
-See AUTH.md — DPoP Token Binding for details.
+See [AUTH.md — DPoP Token Binding](../reference/auth.md#dpop-token-binding-rfc-9449) for details.
 
 #### ping (keep-alive)
 
@@ -212,7 +207,7 @@ When the broadcaster authorizes a delivery, it injects these per-entity resource
 | `entityId` | event's entity ID |
 | `entityOwner` | event entity's `createdBy` (the user who originally `POST`ed the entity) |
 
-This lets you write **per-user delivery filters** like "each user only receives events for entities they created" using a single XACML policy with `${subject.userId}` template expansion against `entityOwner`. See `docs/AUTH.md` — Per-entity attributes at broadcast time for a complete policy example.
+This lets you write **per-user delivery filters** like "each user only receives events for entities they created" using a single XACML policy with `${subject.userId}` template expansion against `entityOwner`. See [`docs/AUTH.md` — Per-entity attributes at broadcast time](../reference/auth.md#per-entity-attributes-at-broadcast-time-1107) for a complete policy example.
 
 > Entities written without authentication (or via legacy / batch paths that don't set `createdBy`) emit events with no `owner` attribute — owner-based rules will not match those events, so design your policies with that fallback in mind.
 
@@ -836,5 +831,5 @@ class DebugWebSocket {
 
 - JavaScript SDK - SDK API reference (recommended for browser applications)
 - [API Common Specification](../api-reference/endpoints.md) - REST API documentation
-- Authentication and Authorization - Authentication configuration
+- [Authentication and Authorization](../reference/auth.md) - Authentication configuration
 - Development Guide - Local development and deployment

--- a/docs/en/reference/auth.md
+++ b/docs/en/reference/auth.md
@@ -3,9 +3,1782 @@ title: "Authentication Guide"
 description: "GeonicDB authentication and authorization guide"
 outline: deep
 ---
+# Authentication & Authorization Guide
 
-# Authentication Guide
+This document describes the overall picture, setup, and administration of GeonicDB's authentication and authorization features.
 
-::: info Coming Soon
-This page is being synced from the GeonicDB upstream documentation. Full content will be available after the next documentation sync.
-:::
+## Table of Contents
+
+- [Overview](#overview)
+- [Authentication Architecture](#authentication-architecture)
+- [Initial Setup](#initial-setup)
+- [User & Tenant Management](#user--tenant-management)
+- [API Key Authentication](#api-key-authentication)
+  - [API Key Token Exchange (Browser SDK)](#api-key-token-exchange-browser-sdk)
+  - [DPoP Token Binding (RFC 9449)](#dpop-token-binding-rfc-9449)
+- [OAuth 2.0 M2M Authentication](#oauth-20-m2m-authentication)
+- [OIDC External IdP Authentication](#oidc-external-idp-authentication)
+- [XACML Policy-Based Authorization](#xacml-policy-based-authorization)
+- [Authentication Scenario Reference](#authentication-scenario-reference)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+GeonicDB provides JWT-based authentication and authorization features.
+
+### Role Configuration
+
+| Role | Description | Permissions |
+|--------|------|------|
+| `super_admin` | Platform administrator | `/admin/*`, `/auth/*`, `/me/*`, monitoring endpoints (`/statistics`, `/metrics`, `/cache/statistics`) only. **Cannot** access data APIs (`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`) — returns 403 |
+| `tenant_admin` | Tenant administrator | Full access within the assigned tenant (admin + data APIs) |
+| `user` | General user | Read-only by default (GET only). Custom XACML policies can grant write access |
+| `anonymous` | Unauthenticated user | Denied by default. Explicit XACML Permit policy required. No feature flag needed (#748) |
+
+> **Note**: `super_admin` is restricted to platform management operations for SaaS security.
+> Customer data isolation is enforced — Geolonia staff with `super_admin` credentials cannot access tenant entity data.
+> See [#674](https://github.com/geolonia/geonicdb/issues/674) for details.
+
+### Authentication Flow
+
+```text
+┌─────────┐     POST /auth/login      ┌─────────┐
+│  Client │ ─────────────────────────▶│  Server │
+└─────────┘                           └─────────┘
+     │                                      │
+     │◀──── accessToken + refreshToken ─────│
+     │                                      │
+     │   Authorization: Bearer <token>      │
+     │ ────────────────────────────────────▶│
+     │                                      │
+     │◀─────────── API Response ────────────│
+     │                                      │
+     │     POST /auth/logout               │
+     │ ────────────────────────────────────▶│
+     │        (invalidate all tokens)        │
+     │◀──────────── 204 ───────────────────│
+```
+
+---
+
+## Authentication Architecture
+
+GeonicDB's authentication and authorization is composed of the following layers.
+
+```text
+Request
+  ↓
+[1. Token Extraction] Retrieve token from Authorization: DPoP/Bearer <token> or X-Api-Key header
+  ↓
+[2. Authentication (AuthN)] Token verification (attempted in the following order)
+  │               2a. Authorization: Bearer <token> → Internal JWT / OIDC verification
+  │               2b. X-Api-Key header → API Key verification (SHA-256 hash lookup)
+  │                   → Origin check
+  │               2c. Internal JWT (HS256) verification → authentication completes immediately on success
+  │               2d. OIDC external IdP verification (only when OIDC_ENABLED=true)
+  │                   → Signature verification via OIDC Discovery + JWKS (RS256/ES256)
+  │                   → Search GeonicDB DB user by email address
+  ↓                → requireAuth() / requireAdminAuth() / requireSuperAdminAuth()
+[3. IP Restriction]  Admin endpoints only: restriction via ADMIN_ALLOWED_IPS
+  ↓
+[4. Tenant Isolation] Match Fiware-Service header against user's tenantId
+  ↓                → checkTenantAccess()
+[5. Authorization (AuthZ)] XACML policy-based authorization (when AUTH_ENABLED=true)
+  ↓                → XacmlService.evaluate()
+[6. Endpoint Processing]
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|-------|----------|------|
+| `AUTH_ENABLED` | `false` | Enable JWT authentication |
+| `JWT_SECRET` | `development-secret-key-change-in-production` | Secret for JWT signing |
+| `JWT_EXPIRES_IN` | `1h` | Access token expiration |
+| `JWT_REFRESH_EXPIRES_IN` | `7d` | Refresh token expiration |
+| `SUPER_ADMIN_EMAIL` | - | Super Admin email address via environment variable |
+| `SUPER_ADMIN_PASSWORD` | - | Super Admin password via environment variable |
+| `ADMIN_ALLOWED_IPS` | - | Allowed IPs for Admin API access (CIDR) |
+| `OAUTH_ENABLED` | ~~`false`~~ | **Deprecated**: OAuth 2.0 is always enabled when `AUTH_ENABLED=true`. This variable is ignored. |
+| `OIDC_ENABLED` | `false` | Enable OIDC external IdP authentication |
+| `OIDC_ISSUER` | - | OIDC Issuer URL |
+| `OIDC_AUDIENCE` | - | OIDC Audience (aud claim) |
+| `TOKEN_INVALIDATION_TABLE_NAME` | - | DynamoDB table name for token invalidation (in-memory when not set) |
+
+---
+
+## Initial Setup
+
+### 1. Configure Environment Variables
+
+> **SaaS users**: GeonicDB SaaS manages authentication automatically. No environment variable configuration is required.
+
+Set the following environment variables to enable authentication.
+
+```bash
+# Required settings
+export AUTH_ENABLED=true
+export JWT_SECRET=your-very-secure-secret-key-at-least-32-characters
+
+# Super Admin settings (required for initial setup)
+export SUPER_ADMIN_EMAIL=admin@example.com
+export SUPER_ADMIN_PASSWORD=YourSecurePassword123!
+
+# Optional settings
+export JWT_EXPIRES_IN=1h              # Access token expiration (default: 1h)
+export JWT_REFRESH_EXPIRES_IN=7d      # Refresh token expiration (default: 7d)
+export ADMIN_ALLOWED_IPS=10.0.0.0/8,192.168.1.0/24  # Admin API access restriction
+```
+
+### 2. Starting the Local Development Environment
+
+```bash
+# Start the server with environment variables set
+AUTH_ENABLED=true \
+JWT_SECRET=development-secret-key-32chars \
+SUPER_ADMIN_EMAIL=admin@localhost \
+SUPER_ADMIN_PASSWORD=adminpass123 \
+npm start
+```
+
+### 3. Deploying to AWS Lambda
+
+Set the following parameters in the SAM template:
+
+```yaml
+Parameters:
+  AuthEnabled:
+    Type: String
+    Default: "true"
+  JwtSecret:
+    Type: String
+    NoEcho: true  # Hide secret value
+  SuperAdminEmail:
+    Type: String
+  SuperAdminPassword:
+    Type: String
+    NoEcho: true
+```
+
+### Registering a Super Admin
+
+There are two ways to register a Super Admin.
+
+#### Method 1: Configuration via Environment Variables (Recommended)
+
+Set the first Super Admin using environment variables.
+
+```bash
+export SUPER_ADMIN_EMAIL=admin@example.com
+export SUPER_ADMIN_PASSWORD=YourSecurePassword123!
+```
+
+**Characteristics:**
+- Not stored in the database (in-memory only)
+- Available with the same credentials after server restart
+- Changing the password requires updating the environment variable and restarting the server
+
+#### Method 2: Additional Registration via Admin API
+
+After logging in as an existing Super Admin, you can create new Super Admins using the Admin API.
+
+```bash
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "admin@example.com",
+    "password": "YourSecurePassword123!"
+  }'
+```
+
+---
+
+## User & Tenant Management
+
+For details, refer to the Admin API documentation.
+
+### CADDE Configuration Management (super_admin only)
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/admin/cadde` | GET | Get CADDE configuration |
+| `/admin/cadde` | PUT | Update CADDE configuration (upsert) |
+| `/admin/cadde` | DELETE | Delete CADDE configuration (disable) |
+
+### Tenant Management
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/admin/tenants` | GET | Get tenant list |
+| `/admin/tenants` | POST | Create tenant |
+| `/admin/tenants/{tenantId}` | GET | Get tenant |
+| `/admin/tenants/{tenantId}` | PATCH | Update tenant |
+| `/admin/tenants/{tenantId}` | DELETE | Delete tenant (`?shred=true` for Crypto-Shredding) |
+| `/admin/tenants/{tenantId}/deletion-report` | GET | Get deletion report (Crypto-Shredding) |
+| `/admin/tenants/{tenantId}/activate` | POST | Activate tenant |
+| `/admin/tenants/{tenantId}/deactivate` | POST | Deactivate tenant |
+| `/admin/tenants/{tenantId}/ip-restrictions` | GET | Get tenant IP restrictions |
+| `/admin/tenants/{tenantId}/ip-restrictions` | PUT | Update tenant IP restrictions |
+| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | Delete tenant IP restrictions |
+
+### User Management
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/admin/users` | GET | Get user list |
+| `/admin/users` | POST | Create user |
+| `/admin/users/{userId}` | GET | Get user |
+| `/admin/users/{userId}` | PATCH | Update user |
+| `/admin/users/{userId}` | DELETE | Delete user |
+| `/admin/users/{userId}/activate` | POST | Activate user |
+| `/admin/users/{userId}/deactivate` | POST | Deactivate user |
+| `/admin/users/{userId}/unlock` | POST | Clear login lock |
+
+#### Tenant Existence Validation
+
+When creating or updating a user with a `tenantId`, the system validates that the specified tenant exists. If the tenant does not exist, a `400 Bad Request` error is returned.
+
+- **POST /admin/users**: `tenantId` must reference an existing tenant (except for `super_admin` users, which have no tenant)
+- **PATCH /admin/users/{userId}**: When changing `tenantId`, the target tenant must exist. Setting `tenantId` to `null` is allowed without validation.
+
+### Tenant Membership Management
+
+Conforming to the FIWARE Keyrock Organization model, a single user can belong to multiple tenants. Membership is automatically created when a user is created.
+
+| Endpoint | Method | Description | Authorization |
+|---------------|---------|------|------|
+| `/admin/tenants/{tenantId}/users` | GET | List tenant members | `tenant_admin` (own tenant) / `super_admin` |
+| `/admin/tenants/{tenantId}/users/{userId}` | PUT | Add user to tenant | `tenant_admin` (own tenant) / `super_admin` |
+| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | Remove user from tenant | `tenant_admin` (own tenant) / `super_admin` |
+| `/admin/users/{userId}/tenants` | GET | List tenants a user belongs to | Self / `super_admin` |
+
+#### Tenant-Scoped Login
+
+By specifying `tenantId` at login time, you can obtain a JWT token scoped to that tenant. The tenant can be specified via the request body or HTTP headers.
+
+```bash
+# Login with tenantId in request body
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "user@example.com",
+    "password": "password12345",
+    "tenantId": "target-tenant-id"
+  }'
+
+# Login with NGSILD-Tenant header (resolved by tenant name)
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -H "NGSILD-Tenant: my_tenant" \
+  -d '{
+    "email": "user@example.com",
+    "password": "password12345"
+  }'
+```
+
+**Tenant resolution priority:**
+1. `body.tenantId` — direct tenant ID specification (highest priority)
+2. `NGSILD-Tenant` / `Fiware-Service` header — resolved by tenant name
+3. Primary tenant (`user.tenantId`) — fallback when neither is specified
+
+**Behavior:**
+- With `tenantId` specified: Issues a token scoped to that tenant after confirming membership
+- With `NGSILD-Tenant` / `Fiware-Service` header: Resolves the tenant by name. Returns `400 Bad Request` if the tenant name is not found or has an invalid format (must match `^[a-z0-9_]+$`)
+- Without any tenant specification: Issues a token for the primary tenant (`user.tenantId`). If the user belongs to multiple tenants, the response includes an `availableTenants` list
+- Specifying a tenant the user does not belong to: `403 Forbidden`
+
+#### Membership Lifecycle
+
+- **On user creation**: Membership is automatically created via `POST /admin/users`
+- **Additional registration**: Add to another tenant via `PUT /admin/tenants/{tenantId}/users/{userId}`
+- **On tenant deletion**: All tenant-related data is cascade deleted (entities, subscriptions, registrations, temporalEntities, snapshots, rules, policies, OAuth clients, data models, users, memberships, etc. — all 16 collections)
+- **On user deletion**: All memberships associated with the user are automatically deleted
+
+### Per-Tenant CORS Allowed Origins (#1069)
+
+GeonicDB validates the request `Origin` header against a tenant-level whitelist. This is layered on top of API-Key `allowedOrigins` and applies to anonymous, JWT, and API-Key requests alike. Because GeonicDB is a multi-tenant Context Broker, allowed origins **cannot** be pinned via environment variables — they must be configured per tenant at runtime through the admin API.
+
+#### Endpoint
+
+Use the standard tenant settings endpoint:
+
+```http
+PATCH /admin/tenants/{tenantId}
+Content-Type: application/json
+Authorization: Bearer <super_admin token>
+
+{
+  "settings": {
+    "allowedOrigins": ["https://app.example.com", "https://admin.example.com"]
+  }
+}
+```
+
+#### `allowedOrigins` Semantics
+
+| Value | Behavior |
+|-------|----------|
+| Field absent | All origins allowed (backward compat — existing tenants unaffected). |
+| `[]` (explicit empty array) | All origins denied. |
+| `["*"]` | All origins allowed. Requests without `Origin` header (curl / S2S / CLI) also pass. |
+| `["https://app.example.com", ...]` | Exact match only (max 50 entries; protocol + host + port). Requests without `Origin` header are denied. |
+
+#### Enforcement
+
+- **Preflight (OPTIONS)** is not origin-validated (CORS spec: tenant header is not on preflight). It always echoes back the request `Origin` and returns 204.
+- **Actual request** passes through `optionalAuth(event, tenantService)` (data API) or `requireAuth(event)` (admin / `/auth/logout`). On origin mismatch, the request is rejected with `403 Forbidden` and body `Origin not allowed for this tenant`.
+- The 403 response still includes `Access-Control-Allow-Origin` echo back + `Vary: Origin` so the browser surfaces the actual error to the client (otherwise developers see a generic Network error).
+- `super_admin` users (`tenantId: null`) skip origin validation — they operate above tenant scope.
+
+#### Layering with API Key `allowedOrigins`
+
+Both checks apply when an API Key is used:
+
+1. **Tenant-level**: must satisfy `tenant.settings.allowedOrigins`.
+2. **API-Key level**: must satisfy `apiKey.allowedOrigins` (existing behavior, unchanged).
+
+Most restrictive wins.
+
+### Per-Tenant IP Restrictions
+
+You can configure unique IP address restrictions per tenant. In addition to the global setting (`ADMIN_ALLOWED_IPS`), fine-grained access control at the tenant level is possible.
+
+#### Endpoints
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/admin/tenants/{tenantId}/ip-restrictions` | GET | Get IP restriction settings |
+| `/admin/tenants/{tenantId}/ip-restrictions` | PUT | Update IP restriction settings |
+| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | Delete IP restriction settings (reset to default) |
+
+#### Scope
+
+| Scope | Description |
+|---------|------|
+| `admin` | Restrict access to the Admin API (`/admin/*`) only |
+| `all` | Restrict access to all API endpoints |
+
+#### Fallback Behavior
+
+When no IP restrictions are configured for a tenant, the global setting (`ADMIN_ALLOWED_IPS` environment variable) is applied. If a tenant-level setting exists, it takes priority.
+
+#### Request Examples
+
+**Get IP restriction settings:**
+
+```bash
+curl -X GET http://localhost:3000/admin/tenants/{tenantId}/ip-restrictions \
+  -H "Authorization: Bearer <accessToken>"
+```
+
+**Response example:**
+
+```json
+{
+  "tenantId": "abc123",
+  "tenantName": "my-tenant",
+  "ipRestrictions": {
+    "enabled": false,
+    "allowedIps": [],
+    "scope": "admin"
+  },
+  "globalFallback": null
+}
+```
+
+**Update IP restriction settings:**
+
+```bash
+curl -X PUT http://localhost:3000/admin/tenants/{tenantId}/ip-restrictions \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "allowedIps": ["192.168.1.0/24", "10.0.0.1"],
+    "scope": "admin"
+  }'
+```
+
+**Delete IP restriction settings:**
+
+```bash
+curl -X DELETE http://localhost:3000/admin/tenants/{tenantId}/ip-restrictions \
+  -H "Authorization: Bearer <accessToken>"
+```
+
+---
+
+## API Key Authentication
+
+GeonicDB supports API Key-based authentication as a lightweight alternative to JWT/OAuth tokens. API keys are ideal for public-facing integrations, browser-based applications, and scenarios where full OAuth credentials are unnecessary.
+
+### Overview
+
+API keys provide a simpler authentication mechanism with built-in restrictions for origin and rate limiting, and optional XACML policy binding via `policyId`.
+
+### Authentication Header
+
+```http
+X-Api-Key: <UUID or gdb_-prefixed key>
+```
+
+**Priority**: When both `Authorization: Bearer` and `X-Api-Key` headers are present, the Bearer token takes priority. The API key is used as a fallback only when no Bearer token is provided.
+
+### Key Format
+
+- **New keys**: Plain UUID (`randomUUID()`) — e.g., `550e8400-e29b-41d4-a716-446655440000`
+- **Legacy keys**: Existing keys with `gdb_` prefix continue to work (backward compatible)
+- **Storage**: Only the SHA-256 hash of the key is stored in the database. The plaintext key is returned only at creation and refresh time.
+- **Masking**: List and get responses return `"key": "******"` instead of the actual key
+
+### Restrictions
+
+| Field | Description |
+|-------|-------------|
+| **Origin** | `allowedOrigins` — list of permitted URL origins (or `*` for any). At least 1 required. Max 20 entries. Enforced at runtime. |
+| **Policy Binding** | `policyId` — optional. Binds the key to an existing XACML policy. The bound policy's target is bypassed during evaluation (only rules are evaluated). Without `policyId`, the key falls back to tenant policies + role default (api_key = All Deny). |
+| **Rate Limit** | `rateLimit.perMinute` — requests per minute (1–1000, default: 60). |
+
+### API Key Management (Admin)
+
+Administrators can manage API keys for any user.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/admin/api-keys` | POST | Create API key (returns raw key in response) |
+| `/admin/api-keys` | GET | List API keys (paginated, `X-Total-Count` header) |
+| `/admin/api-keys/{keyId}` | GET | Get API key details |
+| `/admin/api-keys/{keyId}` | PATCH | Update API key |
+| `/admin/api-keys/{keyId}` | DELETE | Delete API key |
+| `/admin/api-keys/{keyId}/refresh` | POST | Refresh (regenerate) API key — returns new plaintext key |
+
+### Self-Service API Key Management
+
+Users can create and manage their own API keys without admin privileges.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/me/api-keys` | POST | Create own API key |
+| `/me/api-keys` | GET | List own API keys |
+| `/me/api-keys/{keyId}` | PATCH | Update own API key (partial) |
+| `/me/api-keys/{keyId}` | DELETE | Delete own API key |
+| `/me/api-keys/{keyId}/refresh` | POST | Refresh (regenerate) own API key — returns new plaintext key |
+
+**Restrictions:**
+- Maximum **5 keys** per user
+- `allowedOrigins` is required at creation (non-empty array; use `["*"]` to allow all origins)
+- `policyId` is optional — when specified, the referenced policy must already exist and must have been created by the same user
+- `tenantId` is required for `super_admin` (400 if missing); `tenant_admin` may omit it (auto-derived from session)
+
+**PATCH updatable fields** (`PATCH /me/api-keys/{keyId}`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Key name |
+| `allowedOrigins` | string[] | Allowed origins (min 1 entry) |
+| `policyId` | string \| null | Policy binding (must be created by you, or `null` to unbind) |
+| `rateLimit` | object | Rate limit override |
+| `dpopRequired` | boolean | Require DPoP proof |
+| `isActive` | boolean | Activate / deactivate the key |
+
+### Request Examples
+
+#### Create an API Key
+
+```bash
+curl -X POST http://localhost:3000/admin/api-keys \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Public Dashboard",
+    "allowedOrigins": ["https://dashboard.example.com"],
+    "rateLimit": { "perMinute": 120 }
+  }'
+```
+
+> **Note:** `keyId` is auto-generated (UUID). `tenantId` is required for `super_admin`; `tenant_admin` may omit it (auto-derived from session). `policyId` is optional — when omitted, authorization falls back to tenant policies + role defaults. IDs (`keyId`, `policyId`) are unique per tenant.
+
+**Response** (`201 Created`, `Location: /admin/api-keys/{keyId}`):
+
+```json
+{
+  "keyId": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Public Dashboard",
+  "key": "550e8400-e29b-41d4-a716-446655440000 (plaintext key, shown only at creation and refresh)",
+  "allowedOrigins": ["https://dashboard.example.com"],
+  "policyId": "dashboard-readonly",
+  "rateLimit": { "perMinute": 120 },
+  "isActive": true,
+  "tenantId": "my-tenant-id",
+  "createdBy": "user-uuid",
+  "lastUsedAt": null,
+  "createdAt": "2026-03-07T00:00:00.000Z",
+  "updatedAt": "2026-03-07T00:00:00.000Z"
+}
+```
+
+> **Note:** The `keyPrefix` field has been removed. The `key` field is returned as plaintext only at creation and refresh; list/get responses return `"key": "******"`.
+>
+> **Backward compatibility:** Existing keys with `gdb_` prefix remain valid and continue to work. Only newly created keys use the UUID format.
+
+#### Refresh an API Key
+
+```bash
+curl -X POST http://localhost:3000/me/api-keys/{keyId}/refresh \
+  -H "Authorization: Bearer <accessToken>"
+```
+
+Regenerates the key value. The old key is immediately invalidated. The response includes the new plaintext key (same format as creation response).
+
+#### Use an API Key
+
+```bash
+curl -X GET http://localhost:3000/v2/entities?type=TemperatureSensor \
+  -H "X-Api-Key: 550e8400-e29b-41d4-a716-446655440000" \
+  -H "Fiware-Service: mytenant"
+```
+
+### Defaults and Limits
+
+| Parameter | Value |
+|-----------|-------|
+| Max keys per user | 5 |
+| Max allowed origins | 20 |
+| Default rate limit | 60 requests/minute |
+| Max rate limit | 1000 requests/minute |
+| Key length | 32 bytes (64 hex characters) |
+
+### Policy Binding (`policyId`
+
+)
+
+By default, API keys have a `Deny` policy (`__default_api_key`, priority -2). To grant permissions, create an XACML policy first, then bind it to the API key via the `policyId` field.
+
+#### Workflow
+
+```bash
+# 1. Create a policy (policyId is auto-generated when omitted)
+curl -X POST http://localhost:3000/admin/policies \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rules": [{ "ruleId": "permit", "effect": "Permit" }]
+  }'
+# Response: { "policyId": "550e8400-...", ... }
+
+# 2. Create API key with policyId binding
+curl -X POST http://localhost:3000/admin/api-keys \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Sensor key",
+    "allowedOrigins": ["*"],
+    "policyId": "<policyId from step 1>"
+  }'
+```
+
+> **Note:** `policyId` and `ruleId` are auto-generated (UUID) when omitted. IDs are unique per tenant — different tenants can use the same ID independently.
+
+When `policyId` is specified, the bound policy's `target` is bypassed during evaluation — only the policy's `rules` are evaluated. This allows a single policy to be shared across multiple credentials without target conflicts.
+
+#### Behavior
+
+| `policyId` | Behavior |
+|-----------|----------|
+| Specified (valid) | Bound policy rules are evaluated (target bypassed) |
+| Specified (not found) | 400 error at creation/update |
+| `null` or omitted | Tenant policies + role default (api_key = All Deny) |
+
+#### Updating policy binding
+
+Use `PATCH /admin/api-keys/{keyId}` to change or remove the policy binding (admin):
+
+```bash
+# Change the bound policy
+curl -X PATCH http://localhost:3000/admin/api-keys/{keyId} \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"policyId": "new-policy"}'
+
+# Remove policy binding (revert to default Deny)
+curl -X PATCH http://localhost:3000/admin/api-keys/{keyId} \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"policyId": null}'
+```
+
+For self-service keys, use `PATCH /me/api-keys/{keyId}` — the `policyId` must refer to a policy created by the authenticated user:
+
+```bash
+curl -X PATCH http://localhost:3000/me/api-keys/{keyId} \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"policyId": "my-readonly-policy"}'
+```
+
+### API Key Token Exchange (Browser SDK)
+
+For browser-based applications, API keys cannot be used directly in `X-Api-Key` headers due to the risk of key exposure. Instead, GeonicDB provides a token exchange flow that converts an API key into a short-lived session JWT via Nonce + Proof of Work.
+
+#### Flow
+
+```text
+Browser                              GeonicDB
+  │                                      │
+  │  POST /auth/nonce                    │
+  │  Headers: Origin: <origin>           │
+  │  Body: { api_key }                   │
+  │ ──────────────────────────────────►  │
+  │  { nonce, challenge, difficulty }    │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  [Solve PoW: SHA256(challenge+n)]    │
+  │                                      │
+  │  POST /oauth/token                   │
+  │  Headers: Origin: <origin>           │
+  │  Body: { grant_type: "api_key",      │
+  │          api_key, nonce, proof }     │
+  │ ──────────────────────────────────►  │
+  │  { access_token, token_type,         │
+  │    expires_in, scope }               │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  GET /v2/entities                    │
+  │  Authorization: Bearer <JWT>         │
+  │ ──────────────────────────────────►  │
+```
+
+#### Security Layers
+
+1. **Origin validation**: Nonce is bound to the request Origin via HMAC; mismatched Origin causes rejection
+2. **HMAC Nonce**: Stateless, signed with server secret, includes timestamp + Origin + keyId; TTL 60 seconds
+3. **Proof of Work**: SHA-256 based, difficulty=4 (4 leading zero bits); prevents automated abuse without external dependencies
+4. **Short-lived JWT**: `api_key_session` type, expires in 1 hour, embeds policyId
+
+#### JavaScript SDK
+
+GeonicDB provides a JavaScript SDK as an npm package (`@geolonia/geonicdb-sdk`) that handles the entire token exchange flow automatically:
+
+```javascript
+import GeonicDB from '@geolonia/geonicdb-sdk';
+
+const db = new GeonicDB({
+  apiKey: 'gdb_your_api_key_here',
+  tenant: 'your-tenant',
+  baseUrl: 'https://your-geonicdb-instance'
+});
+
+db.getEntities({ type: 'TemperatureSensor' }).then(function(entities) {
+  console.log(entities);
+});
+```
+
+The SDK handles nonce retrieval, PoW solving, and token refresh transparently.
+
+#### External Token Injection
+
+When using Bearer JWT login externally (e.g., application-level login flow), inject the token into the SDK via `setCredentials()` and register a callback for token refresh synchronization with `on('tokenRefresh', cb)`:
+
+```javascript
+var db = new GeonicDB({ tenant: 'my-tenant', baseUrl: 'https://...' });
+
+// Inject tokens obtained from an external login flow
+db.setCredentials({
+  token: loginResponse.accessToken,
+  tokenType: 'Bearer',
+  expiresIn: loginResponse.expiresIn,
+  refreshToken: loginResponse.refreshToken
+});
+
+// Sync refreshed tokens to application state (e.g., localStorage)
+db.on('tokenRefresh', function(creds) {
+  saveToStorage({ accessToken: creds.token, refreshToken: creds.refreshToken });
+});
+```
+
+> **Note**: When `setCredentials()` is called with `tokenType: 'Bearer'` and a `refreshToken`, all subsequent API calls and `connect()` bypass DPoP/PoW entirely. Token renewal uses `/auth/refresh`, so no PoW recomputation is needed.
+
+See the SDK documentation for full details.
+
+### DPoP Token Binding (RFC 9449)
+
+GeonicDB supports DPoP (Demonstration of Proof-of-Possession) per [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) to bind tokens to client-held cryptographic keys. This eliminates token theft and replay risks — even if a JWT is intercepted, it cannot be used without the corresponding private key.
+
+#### How It Works
+
+1. **Key pair generation**: Client generates an ECDSA P-256 key pair (the SDK uses `crypto.subtle.generateKey` with `extractable: false`)
+2. **Token exchange with DPoP proof**: Client sends a `DPoP` header containing a proof JWT during `POST /oauth/token`
+3. **Token binding**: Server verifies the proof and embeds the JWK Thumbprint ([RFC 7638](https://datatracker.ietf.org/doc/html/rfc7638)) as `cnf.jkt` in the issued JWT
+4. **Per-request proof**: Each API request includes a new DPoP proof; server verifies the proof's `jkt` matches the token's `cnf.jkt`
+
+#### DPoP Flow
+
+```text
+Browser                              GeonicDB
+  │                                      │
+  │  [Generate ECDSA P-256 key pair]     │
+  │                                      │
+  │  POST /oauth/token                   │
+  │  Headers: Origin: <origin>           │
+  │           DPoP: <proof JWT>          │
+  │  Body: { grant_type: "api_key",      │
+  │          api_key, nonce, proof }      │
+  │ ──────────────────────────────────►  │
+  │  { access_token (cnf.jkt bound),    │
+  │    token_type: "DPoP", ... }         │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  GET /v2/entities                    │
+  │  Authorization: DPoP <JWT>           │
+  │  DPoP: <new proof JWT>              │
+  │ ──────────────────────────────────►  │
+  │  [Verify proof jkt == token cnf.jkt] │
+```
+
+#### DPoP-Nonce (RFC 9449 Section 8)
+
+GeonicDB implements server-provided nonces per RFC 9449 Section 8 to prevent precomputed DPoP proofs. The nonce handshake occurs transparently:
+
+1. Client sends DPoP proof without `nonce` claim
+2. Server returns `400` with `error: "use_dpop_nonce"` and a `DPoP-Nonce` response header
+3. Client creates a new DPoP proof including the server nonce in the `nonce` claim
+4. Server verifies the nonce and issues the token; response includes a fresh `DPoP-Nonce` for subsequent requests
+
+```text
+Browser                              GeonicDB
+  │                                      │
+  │  POST /oauth/token                   │
+  │  DPoP: <proof (no nonce)>            │
+  │ ──────────────────────────────────►  │
+  │  400 { error: "use_dpop_nonce" }     │
+  │  DPoP-Nonce: <server-nonce>          │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  POST /oauth/token                   │
+  │  DPoP: <proof (nonce: server-nonce)> │
+  │ ──────────────────────────────────►  │
+  │  200 { access_token, token_type }    │
+  │  DPoP-Nonce: <next-nonce>            │
+  │ ◄──────────────────────────────────  │
+```
+
+The nonce is stateless (HMAC-based) with a TTL of 300 seconds. No database storage is required.
+
+API requests with DPoP-bound tokens also require nonces. The server returns a `DPoP-Nonce` header on every successful response and on `401` errors with `use_dpop_nonce` message.
+
+#### DPoP Proof JWT Structure
+
+```json
+// Header
+{
+  "typ": "dpop+jwt",
+  "alg": "ES256",
+  "jwk": { "kty": "EC", "crv": "P-256", "x": "...", "y": "..." }
+}
+
+// Payload
+{
+  "jti": "<unique identifier>",
+  "htm": "POST",
+  "htu": "https://api.example.com/oauth/token",
+  "iat": 1710000000,
+  "nonce": "<server-issued DPoP-Nonce>",
+  "ath": "<SHA-256 hash of access token>"  // Only for API requests, not token exchange
+}
+```
+
+| Claim | Description |
+|-------|-------------|
+| `jti` | Unique proof identifier (replay prevention) |
+| `htm` | HTTP method of the request |
+| `htu` | HTTP URI of the request (scheme + host + path) |
+| `iat` | Issued-at timestamp (max age: 120 seconds) |
+| `nonce` | Server-issued DPoP-Nonce (required when server enforces nonce) |
+| `ath` | Access token hash (required when using with a bound token) |
+
+#### `dpopRequired` Flag
+
+API keys can enforce DPoP by setting `dpopRequired: true` at creation time:
+
+```bash
+curl -X POST https://api.example.com/admin/api-keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "secure-key", "allowedOrigins": ["https://app.example.com"], "dpopRequired": true}'
+```
+
+When `dpopRequired` is `true`, token exchange without a valid `DPoP` header returns `400 invalid_dpop_proof`.
+
+#### Bearer Fallback
+
+When no `DPoP` header is sent during token exchange (and `dpopRequired` is `false`), the server issues a standard `Bearer` token without binding. This maintains backward compatibility with clients that do not support DPoP.
+
+| DPoP Header | `dpopRequired` | Result |
+|-------------|----------------|--------|
+| Present, valid | `false` | `token_type: "DPoP"` with `cnf.jkt` binding |
+| Present, valid | `true` | `token_type: "DPoP"` with `cnf.jkt` binding |
+| Absent | `false` | `token_type: "Bearer"` (no binding) |
+| Absent | `true` | `400 invalid_dpop_proof` (rejected) |
+
+> **Note**: All DPoP-bound requests (token exchange and API calls) participate in the nonce handshake. The JavaScript SDK handles this transparently.
+
+#### SDK DPoP Support
+
+The JavaScript SDK (`@geolonia/geonicdb-sdk`) automatically enables DPoP when `crypto.subtle` is available:
+
+- Generates a non-extractable ECDSA P-256 key pair on initialization
+- Attaches DPoP proofs to token exchange and API requests
+- Falls back to Bearer mode in environments without `crypto.subtle`
+- Handles `use_dpop_nonce` retry automatically for both token exchange and API requests
+- WebSocket connections use post-connect `dpop_bind` message for proof verification
+
+See the full SDK API reference for all available methods.
+
+#### DPoP & HTTP Cache Interaction (#1052)
+
+DPoP touches three points in the HTTP-cache flow:
+
+1. **DPoP proof JWT in `Vary`?** — No. The proof contains a per-request `jti` and `iat`, so adding it to `Vary` would make every request a cache miss. The bound access token in `Authorization` is the cache-key dimension that matters; the proof is verified separately and does not influence body content.
+2. **`DPoP-Nonce` on `304 Not Modified`** — Yes, passed through. The cache-control middleware whitelists `DPoP-Nonce` in the 304 response headers (`evaluateConditionalRequest`). When the server rotates the nonce, a `304` still delivers the freshest nonce so the client does not fall behind. Without this passthrough, a client receiving `304` would retry with a stale nonce and hit `401 + use_dpop_nonce` on the next request.
+3. **DPoP authentication failure** — Stale or missing DPoP proofs are rejected at `requireAuth` before `evaluateConditionalRequest` runs (see [Policy Propagation Delay](#policy-propagation-delay--http-cache-integrity-1050) for the handler order). A stale `If-None-Match` cannot resurface a `304` from a previous valid session — the response is `401`, never `304`.
+
+See SECURITY.md — DPoP & Cache Integrity for the security model.
+
+---
+
+## OAuth 2.0 M2M Authentication
+
+GeonicDB supports machine-to-machine (M2M) authentication via the OAuth 2.0 Client Credentials flow.
+
+### Overview
+
+The OAuth 2.0 Client Credentials flow is an authentication method optimized for machine-to-machine (M2M) scenarios such as server-to-server communication and background jobs.
+
+### When to Use OAuth 2.0
+
+- **Machine-to-machine communication**: API-to-API calls
+- **Background jobs**: Batch processing without user interaction
+- **Service-to-service integration**: Authentication between microservices
+- **CI/CD pipelines**: API access in automated deployment and testing
+- **Fine-grained access control**: When scope-based permission management is required
+
+### Differences Between OAuth 2.0 and JWT Authentication
+
+| Item | OAuth 2.0 Client Credentials | JWT Authentication |
+|------|----------------------------|---------|
+| **Authentication subject** | Client application (machine) | User (human) |
+| **Token acquisition** | `POST /oauth/token` | `POST /auth/login` |
+| **Credentials** | Client ID + Client Secret (Basic auth) | Email + Password |
+| **Access control** | Scope-based | Role-based |
+| **Token expiration** | Short-lived (default: 1 hour; unlimited with `permanent` scope) | Access token: 1 hour, Refresh token: 7 days |
+| **Refresh token** | None (re-request when expired) | Available (can be refreshed via `POST /auth/refresh`) |
+
+### OAuth Client Management
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/admin/oauth-clients` | GET | Get OAuth client list |
+| `/admin/oauth-clients` | POST | Create OAuth client |
+| `/admin/oauth-clients/{clientId}` | GET | Get OAuth client |
+| `/admin/oauth-clients/{clientId}` | PATCH | Update OAuth client |
+| `/admin/oauth-clients/{clientId}` | DELETE | Delete OAuth client |
+| `/admin/oauth-clients/{clientId}/regenerate-secret` | POST | Regenerate Client Secret |
+
+### Self-Service OAuth Client Management
+
+Users can create and manage their own OAuth clients without admin privileges. Clients created via self-service are scoped to the user and subject to role-based restrictions.
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/me/oauth-clients` | POST | Create own OAuth client |
+| `/me/oauth-clients` | GET | List own OAuth clients |
+| `/me/oauth-clients/{clientId}` | PATCH | Update own OAuth client (partial) |
+| `/me/oauth-clients/{clientId}` | DELETE | Delete own OAuth client |
+| `/me/oauth-clients/{clientId}/regenerate-secret` | POST | Regenerate own client secret |
+
+**Restrictions:**
+- Maximum **5 clients** per user
+- `policyId` is optional — when specified, the referenced policy must already exist and must have been created by the same user. When omitted, authorization falls back to tenant policies + role defaults (`user` default is GET-only Permit)
+- The `clientSecret` is returned only at creation and regeneration — store it securely
+
+**PATCH updatable fields** (`PATCH /me/oauth-clients/{clientId}`):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Client name |
+| `description` | string | Client description |
+| `policyId` | string \| null | Policy binding (must be created by you, or `null` to unbind) |
+| `isActive` | boolean | Activate / deactivate the client |
+
+### Token Request
+
+```bash
+curl -X POST https://api.example.com/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&scope=read:entities write:entities"
+```
+
+**Response example:**
+
+```json
+{
+  "access_token": "eyJhbGc...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read:entities write:entities"
+}
+```
+
+### Rate Limiting (#1075)
+
+`POST /oauth/token` is rate-limited per **client IP** and per **`client_id`**
+to prevent offline-less brute force of `client_id+client_secret` pairs.
+
+| Bucket | Per minute | Per hour | Per day | Burst |
+|--------|-----------:|---------:|--------:|------:|
+| Per IP | 20 | 100 | 500 | 5 |
+| Per `client_id` | 10 | 60 | 200 | 2 |
+
+Both buckets must permit the request. Exceeding either returns `429 Too Many
+Requests` with a `Retry-After` header. The same per-IP scheme also protects
+`/auth/refresh` and `/auth/nonce` (the `auth` category in `PUBLIC_RATE_LIMIT`).
+See [QUOTAS.md — Public (Unauthenticated) Endpoint Rate Limit](../saas/quotas.md#public-unauthenticated-endpoint-rate-limit-1075)
+for the full configuration.
+
+### Scope System
+
+| Scope | Description | `user` | `tenant_admin` | `super_admin` |
+|-------|-------------|:------:|:---------------:|:--------------:|
+| `read:entities` | Read entities | ✅ | ✅ | ✅ |
+| `write:entities` | Write entities (create/update/delete only) | ✅ | ✅ | ✅ |
+| `read:subscriptions` | Read subscriptions | ✅ | ✅ | ✅ |
+| `write:subscriptions` | Write subscriptions (create/update/delete only) | ✅ | ✅ | ✅ |
+| `read:registrations` | Read registrations | ✅ | ✅ | ✅ |
+| `write:registrations` | Write registrations (create/update/delete only) | ✅ | ✅ | ✅ |
+| `read:rules` | Read rules | ✅ | ✅ | ✅ |
+| `write:rules` | Write rules (create/update/delete only) | ✅ | ✅ | ✅ |
+| `read:custom-data-models` | Read custom data models | ✅ | ✅ | ✅ |
+| `write:custom-data-models` | Write custom data models (create/update/delete only) | ✅ | ✅ | ✅ |
+| `admin:users` | Access to user management API (`/admin/users`) | ❌ | ✅ | ✅ |
+| `admin:policies` | Access to policy management API (`/admin/policies`, `/admin/policy-sets`) | ❌ | ✅ | ✅ |
+| `admin:oauth-clients` | Access to OAuth client management API (`/admin/oauth-clients`) | ❌ | ✅ | ✅ |
+| `admin:metrics` | Access to metrics API (`/admin/metrics`) | ❌ | ✅ | ✅ |
+| `admin:tenants` | Access to tenant management API (`/admin/tenants`) | ❌ | ❌ | ✅ |
+| `permanent` | Set token to never expire (no expiration) | — | — | — |
+| `jwt` | JWT format token | — | — | — |
+
+> **Scope hierarchy**: `write:X` does **not** imply `read:X` — scopes are independent. This enables write-only use cases such as public contact forms. `admin:X` implies both `read:X` and `write:X`. OAuth tokens with `admin:*` scopes can access the Admin API, bypassing normal JWT role-based authentication. Normal JWT tokens (without a `scope` field) skip scope checks for backward compatibility.
+>
+> **Role restrictions for self-service (`/me/oauth-clients`)**: Users can only request scopes allowed for their role. `user` can request resource scopes only. `tenant_admin` can additionally request `admin:*` scopes except `admin:tenants`. `super_admin` can request all scopes.
+
+---
+
+## OIDC External IdP Authentication
+
+GeonicDB supports authentication by external IdPs compliant with OIDC (OpenID Connect).
+
+### Enabling
+
+```bash
+export AUTH_ENABLED=true
+export OIDC_ENABLED=true
+export OIDC_ISSUER=https://accounts.google.com
+export OIDC_AUDIENCE=your-client-id.apps.googleusercontent.com
+```
+
+### Behavior
+
+1. The client obtains an ID token from the external IdP
+2. Include `Authorization: Bearer <id_token>` in the GeonicDB API request
+3. GeonicDB verifies the signature via OIDC Discovery + JWKS
+4. Search for the user in the GeonicDB DB by email address (`email` claim)
+5. Authentication succeeds if the user exists
+
+### Supported IdPs
+
+- Google
+- Microsoft Entra ID (Azure AD)
+- Auth0
+- Other OIDC-compliant IdPs
+
+---
+
+## XACML Policy-Based Authorization
+
+GeonicDB supports XACML 3.0-compliant policy-based access control.
+
+### Policy Management
+
+| Endpoint | Method | Description |
+|---------------|---------|------|
+| `/admin/policies` | GET | Get policy list |
+| `/admin/policies` | POST | Create policy |
+| `/admin/policies/{policyId}` | GET | Get policy |
+| `/admin/policies/{policyId}` | PATCH | Update policy (partial) |
+| `/admin/policies/{policyId}` | PUT | Replace policy |
+| `/admin/policies/{policyId}` | DELETE | Delete policy |
+| `/admin/policies/{policyId}/activate` | POST | Activate policy |
+| `/admin/policies/{policyId}/deactivate` | POST | Deactivate policy |
+
+### Target Matching Semantics
+
+Within `subjects`, `resources`, and `actions` arrays:
+- **Same `attributeId`**: OR (any match satisfies) — e.g., `[{method: POST}, {method: PATCH}]` matches POST **or** PATCH
+- **Different `attributeId`s**: AND (all must match) — e.g., `[{role: user}, {userId: u1}]` requires both
+- **Across categories** (`subjects` + `resources` + `actions`): AND
+
+### Match Functions (including GeonicDB extensions)
+
+`matchFunction` values available in AttributeMatch within a policy's Target:
+
+| matchFunction | Description | XACML 3.0 |
+|---------------|------|-----------|
+| `string-equal` | Exact match (default) | Standard |
+| `string-regexp` | Regular expression match | Standard (`string-regexp-match`) |
+| `glob` | Glob pattern match (`*`, `**` supported) | **GeonicDB extension** |
+
+**Automatic glob detection (GeonicDB extension)**: When `matchFunction` is omitted, if `matchValue` contains `*`, it is automatically processed as `glob`. Otherwise, `string-equal` is applied.
+
+**XACML XML export**: Since `glob` does not exist in the XACML 3.0 specification, it is converted to a regular expression and output as `string-regexp-match` on export.
+
+### Implicit Policy Hierarchy
+
+GeonicDB applies the following implicit policies (skipping DB lookup):
+
+| Priority | Role | Behavior |
+|--------|--------|------|
+| Custom policies (0+) | any | Custom XACML policies always override defaults |
+| 0 | `super_admin` | Management APIs always Permit. Data APIs Deny (403) |
+| 0 | `tenant_admin` | Always Permit (all APIs within own tenant) |
+| -1 | `user` | GET → Permit, all other methods → Deny (readonly) |
+| -2 | `api_key` | All Deny (explicit Permit policy required) |
+| -3 | `anonymous` | All Deny (explicit Permit policy required) |
+
+> **Important**: Custom XACML policies (priority 0 or higher) always override role defaults. To grant write access to `user`, create a Permit policy with priority ≥ 0.
+>
+> **Tie-breaking**: When priorities are equal, policies are evaluated by `policyId` in lexicographic order for deterministic results. Tenant custom policies (stored in DB) are combined with role defaults and sorted together.
+
+### Resource Attributes
+
+The following attributes are available in `resources` within a policy Target:
+
+| attributeId | Description | Source |
+|-------------|-------------|--------|
+| `path` | HTTP request path (e.g. `/v2/entities/Room1`) | Request |
+| `tenantService` | Tenant service name (`Fiware-Service` header) | Request |
+| `servicePath` | Service path (`Fiware-ServicePath` header, e.g. `/devices`, `/opendata`) | Request |
+| `scope` | NGSI-LD entity scope (comma-separated, e.g. `/Madrid/parks,/Madrid/gardens`) | Entity context |
+| `entityId` | Target entity ID (e.g. `Room1`) | Entity context / Subscription `entities[].id` |
+| `entityType` | Target entity type (e.g. `Room`) | Request (auto-extracted) / Entity context / Subscription `entities[].type` |
+| `entityOwner` | Entity creator's userId (`createdBy` field) | Entity context |
+| `entityIdPattern` | Subscription target id pattern (e.g. `urn:ngsi-ld:Sensor:.*`) | Subscription `entities[].idPattern` |
+| `notificationEndpoint` | Subscription notification endpoint URI (e.g. `https://hooks.example.com/x`) | Subscription `notification.endpoint.uri` |
+
+> **Note**: `entityId`, `entityOwner`, and `scope` are only available for entity-level authorization checks (via `requireEntityAuthz`). `entityType` is automatically extracted from the HTTP request at the path level — from the `?type=` query parameter or the request body's `type` / `@type` field — making entity-type-based access control possible without entity-level checks. `servicePath` is automatically extracted from the `Fiware-ServicePath` header and available at both path-level and entity-level checks — supports glob patterns (e.g. `/opendata/**`) for hierarchical path matching. `scope` is the NGSI-LD equivalent of NGSIv2's `servicePath` at the entity level — when an entity has multiple scope values (e.g. `["/Madrid/parks", "/Madrid/gardens"]`), they are joined as a comma-separated string for matching with `string-regexp` or `glob`. **NGSI-LD Subscription create (`POST /ngsi-ld/v1/subscriptions`)**: the literal `body.type === "Subscription"` is **not** injected into `entityType` — instead, the PIP extracts the **subscription target** from `entities[]` and the **notification destination** from `notification.endpoint.uri`. When `entities[]` contains multiple elements, one AuthzRequest is built per element and **all of them must Permit** (all-Permit semantics) for the request to succeed. This lets you write type-based policies ("anonymous can only subscribe to `ActivityLog`") and URI-based policies ("subscriptions may only post notifications to `https://*.example.com/**`", a defence against SSRF / data exfiltration). See [Subscription PIP attributes](#subscription-pip-attributes) below.
+
+### Path-Level vs Entity-Level Authorization
+
+GeonicDB uses a two-stage authorization model. Each stage uses XACML evaluation, but the **default decision for `NotApplicable` differs by design**.
+
+| Stage | Middleware | Triggered when | NotApplicable behavior |
+|-------|-----------|----------------|------------------------|
+| Path-level | `requireAuthz()` | Every authenticated request | **Deny (fail-closed)** |
+| Entity-level | `requireEntityAuthz()` | Entity CRUD with concrete entity (after path-level passes) | **Permit (fail-open)** |
+
+#### Why path-level is fail-closed
+
+Without an applicable policy, the request must be rejected. Otherwise, an unprivileged user could call any path that no policy explicitly Permits. The default role policies (`__default_user`, `__default_api_key`, etc.) ensure that the path stage always has at least one applicable rule.
+
+#### Why entity-level is fail-open (by design)
+
+By the time `requireEntityAuthz()` runs, the path stage has **already produced a Permit**. Entity-level evaluation is meant to apply **additional** constraints (e.g., owner-only, scope-based), not to re-authorize the request from scratch.
+
+If entity-level were fail-closed, it would Deny any request whose tenant has no entity-targeted policy — even though the path was already permitted. That would force every tenant to write a default-Permit entity policy just to keep CRUD working, which is both error-prone and contrary to the layering intent.
+
+**Consequence**: attribute-based fine-grained control (e.g., "users can only modify entities they created") requires an **explicit Deny rule** at the entity level. A missing rule does **not** Deny — only Permits with non-matching targets, or explicit Denies, take effect.
+
+#### Example: owner-only update enforcement
+
+To restrict `PATCH /v2/entities/{id}/attrs` to entity owners, write an explicit Deny:
+
+```json
+{
+  "description": "Users can only modify entities they own",
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "ruleId": "deny-non-owner",
+      "effect": "Deny",
+      "target": {
+        "subjects": [{ "attributeId": "role", "matchValue": "user" }],
+        "actions": [{ "attributeId": "method", "matchValue": "PATCH" }],
+        "resources": [
+          { "attributeId": "path", "matchValue": "/v2/entities/**", "matchFunction": "glob" }
+        ]
+      },
+      "condition": {
+        "function": "string-not-equal",
+        "args": ["${subject.userId}", "${resource.entityOwner}"]
+      }
+    }
+  ]
+}
+```
+
+Without such an explicit rule, entity-level evaluation returns `NotApplicable` and the request is permitted (because the path stage already permitted it).
+
+### WebSocket Authorization (WS ⊂ GET)
+
+WebSocket subscriptions and broadcasts are evaluated as a **read-only stream** that is a subset of `GET`. The `authorizeWs()` PIP (`src/core/auth/policy/policy.pip.ts`) evaluates each WebSocket request **twice** — once with `action.method = 'WS'` and once with `action.method = 'GET'` — and grants access only if **both** evaluations return `Permit`.
+
+This invariant has two practical consequences for policy authors:
+
+1. **Policies that Deny `GET` automatically Deny `WS`.** No need to repeat `WS` in the rule; the second evaluation will pick up the same Deny.
+2. **Policies that target `WS` alone are typically a configuration mistake.** Because the second evaluation falls back to `GET`, denying `WS` only does not protect the underlying data — clients can still read it via `GET /v2/entities/...`. Conversely, permitting `WS` only is meaningless if `GET` is not also permitted.
+
+#### Authoring guidance
+
+When you want to restrict streaming for a specific role/tenant, write the rule against `GET` (or omit `actions` entirely so the rule applies to all methods). Mention `WS` only when the rule must apply to *both*:
+
+```json
+{
+  "actions": [
+    { "attributeId": "method", "matchValue": "WS" },
+    { "attributeId": "method", "matchValue": "GET" }
+  ]
+}
+```
+
+#### Detection
+
+`PolicyService.validateWsGetSymmetry()` (#1085) emits a `WARN` log when a rule's `actions` contain `method = 'WS'` (`string-equal`) but no matching `'GET'` entry. This runs on every write path: `createPolicy`, `updatePolicy`, `updatePolicySystem`, and `updatePolicyForUser` (including self-service `/me/policies` updates). The policy is still accepted to preserve backward compatibility — the warning is the signal to revisit the rule.
+
+```text
+[WARN] PolicyService — Policy rule 'ws-only-deny' targets method='WS' without an explicit 'GET'
+counterpart. WebSocket authorization evaluates both WS and GET, so WS-only rules typically do not
+restrict the data path that GET serves.
+```
+
+#### Per-entity attributes at broadcast time (#1107)
+
+When the WebSocket broadcaster (`src/handlers/websocket/broadcaster.ts`, `src/core/streaming/local-ws-server.ts`) decides whether to deliver a change event to a connection, it injects the following per-entity attributes into the AuthzRequest:
+
+| attributeId | Source | Use case |
+|-------------|--------|----------|
+| `entityType` | `EntityChangeEvent.entity.type` | "Only forward `ActivityLog` events to clients" |
+| `entityId` | `EntityChangeEvent.entity.id` | "Forward only `urn:ngsi-ld:Room:42` events" |
+| `entityOwner` | `EntityChangeEvent.entity.owner` (the entity's `createdBy`) | "Forward only events for entities the recipient owns" |
+
+The `entityOwner` attribute, combined with `${subject.userId}` template expansion, lets you express **per-user "self-only" delivery filters** in a single XACML policy:
+
+```jsonc
+// Each user receives only updates to entities they created
+{
+  "policyId": "ws-self-only-feed",
+  "target": {
+    "subjects": [{ "attributeId": "role", "matchValue": "user" }],
+    "resources": [
+      { "attributeId": "path", "matchValue": "/v2/**", "matchFunction": "glob" },
+      { "attributeId": "entityType", "matchValue": "GeoJSON" }
+    ]
+  },
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    // Allow the user to create their own entity (no owner exists at POST time)
+    { "ruleId": "permit-write", "effect": "Permit",
+      "target": { "actions": [
+        { "attributeId": "method", "matchValue": "POST" },
+        { "attributeId": "method", "matchValue": "PATCH" },
+        { "attributeId": "method", "matchValue": "PUT" }
+      ] }
+    },
+    // For WS / GET, only forward entities the subject owns
+    { "ruleId": "permit-self-read", "effect": "Permit",
+      "target": { "resources": [
+        { "attributeId": "entityOwner", "matchValue": "${subject.userId}" }
+      ] }
+    },
+    { "ruleId": "default-deny", "effect": "Deny" }
+  ]
+}
+```
+
+> **Caching note**: The broadcaster caches authorization decisions per `(role, policyId, userId)` within a single broadcast — `userId` must be in the key because owner-based policies yield per-user decisions even at fixed entityType/entityOwner. Multi-device users with the same userId still share the cached decision within one event.
+>
+> **Source of `entity.owner`**: populated transparently by `EntityService` when publishing change events. It comes from the entity's `createdBy` field (set on `POST` by the authenticated user) — entities without `createdBy` (legacy / batch / unauthenticated writes) emit events without `owner`, in which case owner-based rules will not match and the next rule applies.
+
+### Subscription PIP attributes
+
+For `POST /ngsi-ld/v1/subscriptions` (NGSI-LD subscription create), the PIP injects three additional resource attributes drawn from the subscription body, **and the literal `body.type === "Subscription"` is intentionally not exposed as `entityType`**:
+
+| attributeId | Source field | Use case |
+|-------------|--------------|----------|
+| `entityType` | `entities[].type` | "Anonymous can only subscribe to `ActivityLog`" |
+| `entityId` | `entities[].id` | "Allow subscribing only to `urn:ngsi-ld:Room:1`" |
+| `entityIdPattern` | `entities[].idPattern` | "Allow subscribing only when the pattern matches `urn:ngsi-ld:Sensor:.*`" |
+| `notificationEndpoint` | `notification.endpoint.uri` | "Notifications may only be sent to `https://*.example.com/**`" — defence against SSRF / data exfiltration |
+
+#### Multi-entity all-Permit semantics
+
+If `entities[]` contains more than one element, the PEP evaluates **one AuthzRequest per element** and the request is permitted only when **every** AuthzRequest returns `Permit`. A single `Deny` / `NotApplicable` / `Indeterminate` short-circuits the entire request to `403 Forbidden`. This prevents a "first element looks fine, sneak the rest in" bypass:
+
+```jsonc
+// All elements must satisfy the policy. With a policy that permits only ActivityLog,
+// this body is rejected because { type: "Building" } is not permitted.
+{
+  "type": "Subscription",
+  "entities": [{ "type": "ActivityLog" }, { "type": "Building" }],
+  "notification": { "endpoint": { "uri": "http://localhost:1028/notify" } }
+}
+```
+
+#### Example: type-based + URI-based control combined
+
+```json
+{
+  "policyId": "anon-subscribe-activity-only",
+  "target": {
+    "subjects": [{ "attributeId": "role", "matchValue": "anonymous" }],
+    "resources": [{ "attributeId": "path", "matchValue": "/ngsi-ld/v1/subscriptions" }],
+    "actions": [{ "attributeId": "method", "matchValue": "POST" }]
+  },
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "ruleId": "allow-activitylog-to-internal-hooks",
+      "effect": "Permit",
+      "target": {
+        "resources": [
+          { "attributeId": "entityType", "matchValue": "ActivityLog" },
+          { "attributeId": "notificationEndpoint", "matchValue": "https://*.example.com/**", "matchFunction": "glob" }
+        ]
+      }
+    },
+    { "ruleId": "deny-rest", "effect": "Deny" }
+  ]
+}
+```
+
+This policy permits only when *both* the subscription target type is `ActivityLog` *and* the notification endpoint is on `*.example.com`. Different `attributeId`s within `resources` are AND-combined (see [Target Matching Semantics](#target-matching-semantics)).
+
+> **Out of scope (#1104)**: `PATCH /ngsi-ld/v1/subscriptions/{id}` does **not** yet apply this same rewriting — the legacy single-AuthzRequest path is still used. Subscription updates are therefore evaluated only against the path / role, not the new target / notification endpoint. Track this as a follow-up if your threat model requires it.
+
+### Template Variables (GeonicDB Extension)
+
+`matchValue` supports `${subject.<attributeId>}` template variables that are resolved to the request subject's attribute values at evaluation time. This enables dynamic policies like "owner-only" access without hardcoding user IDs.
+
+| Template | Resolves to |
+|----------|-------------|
+| `${subject.userId}` | Requesting user's ID |
+| `${subject.email}` | Requesting user's email |
+| `${subject.role}` | Requesting user's role |
+
+#### Example: Entity Owner-Only Policy
+
+```json
+{
+  "description": "Users can only operate on entities they created",
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "effect": "Permit",
+      "target": {
+        "resources": [
+          { "attributeId": "entityOwner", "matchValue": "${subject.userId}" }
+        ]
+      }
+    },
+    {
+      "effect": "Deny"
+    }
+  ]
+}
+```
+
+> `policyId` and `ruleId` are auto-generated when omitted.
+
+This policy permits access only when `entityOwner` (the entity's `createdBy` value) matches the requesting user's `userId`. All other requests are denied.
+
+#### Example: Service Path-Based Access Control
+
+```json
+{
+  "description": "Allow anonymous read access to /opendata/ service path",
+  "target": {
+    "subjects": [{ "attributeId": "role", "matchValue": "anonymous" }],
+    "resources": [{ "attributeId": "servicePath", "matchValue": "/opendata/**" }],
+    "actions": [{ "attributeId": "method", "matchValue": "GET" }]
+  },
+  "rules": [{ "ruleId": "permit-read", "effect": "Permit" }],
+  "priority": 100
+}
+```
+
+This policy allows anonymous users to read entities under the `/opendata/` service path (including nested paths like `/opendata/sensors`). The glob pattern `/**` matches zero or more path segments.
+
+#### Example: NGSI-LD Scope-Based Access Control
+
+```json
+{
+  "description": "Allow read access only to entities scoped under /Madrid",
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "ruleId": "allow-madrid-read",
+      "effect": "Permit",
+      "target": {
+        "resources": [
+          { "attributeId": "scope", "matchValue": "(^|,)/Madrid(/[^,]*)?(,|$)", "matchFunction": "string-regexp" }
+        ],
+        "actions": [{ "attributeId": "method", "matchValue": "GET" }]
+      }
+    },
+    { "ruleId": "deny-all", "effect": "Deny" }
+  ],
+  "priority": 50
+}
+```
+
+This policy permits read access to entities whose `scope` is `/Madrid` itself or a child path under it (e.g. `["/Madrid/parks"]`). Since entity scopes are stored as arrays and serialized to comma-separated strings (e.g. `"/Madrid/parks,/Madrid/gardens"`), prefer boundary-aware `string-regexp` patterns (using `(^|,)` and `(,|$)` anchors) to avoid unintended partial matches. For single-value exact matching, `string-equal` works directly (e.g. `matchValue: "/Madrid"`).
+
+### Default Policies
+
+GeonicDB has the following default policies configured:
+
+- **Admin API**: Accessible by `super_admin` only
+- **Rules API**: Accessible by `super_admin` or `tenant_admin`
+- **NGSI API**: Explicit policy required (`user` role)
+
+### Anonymous Access Policy (GeonicDB Extension)
+
+GeonicDB supports anonymous (unauthenticated) access to data APIs when configured by tenant administrators. This is useful for publishing public data (e.g., weather observations, open datasets) without requiring authentication.
+
+#### Prerequisites
+
+1. **Create an explicit Permit policy**: Target `role=anonymous` with the desired access level (no feature flag needed since #748)
+
+#### Setup
+
+```bash
+# Create a policy allowing anonymous read access
+curl -X POST http://localhost:3000/admin/policies \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Allow anonymous read access to WeatherObserved entities",
+    "target": {
+      "subjects": [{"attributeId": "role", "matchValue": "anonymous"}],
+      "resources": [
+        {"attributeId": "path", "matchValue": "/v2/**", "matchFunction": "glob"},
+        {"attributeId": "entityType", "matchValue": "WeatherObserved"}
+      ]
+    },
+    "ruleCombiningAlgorithm": "first-applicable",
+    "rules": [
+      {"effect": "Permit", "target": {"actions": [{"attributeId": "method", "matchValue": "GET"}]}},
+      {"effect": "Deny"}
+    ]
+  }'
+
+# 3. Anonymous access (no Authorization header)
+curl http://localhost:3000/v2/entities?type=WeatherObserved \
+  -H "Fiware-Service: mytenant"
+```
+
+For browser / Node apps, the SDK supports the same flow via the `anonymous: true` option (no token acquisition, no `Authorization` header). See `docs/SDK.md`.
+
+```javascript
+const db = new GeonicDB({
+  baseUrl: 'http://localhost:3000',
+  tenant: 'mytenant',
+  anonymous: true,
+});
+const entities = await db.getEntities({ type: 'WeatherObserved' });
+```
+
+#### Security Model
+
+- **Fail-closed**: Without explicit Permit policies, all anonymous requests are denied (403).
+- **No policies = Deny**: Anonymous access always requires explicit XACML Permit policies.
+- **Admin APIs are never accessible**: Anonymous users cannot access `/admin/*`, `/auth/*`, or `/me/*` endpoints regardless of policies.
+- **Tenant isolation**: Anonymous requests must include a `Fiware-Service` header. The anonymous user is bound to the specified tenant and cannot access other tenants' data.
+- **Revocable**: Delete the XACML Permit policy to immediately block all anonymous access.
+
+---
+
+## Policy Propagation Delay & HTTP Cache Integrity (#1050)
+
+When XACML policies are added, modified, or deleted via `/admin/policies`, there is a small window during which Lambda instances may still serve cached evaluations.
+
+### Cache Layers
+
+1. **`PolicyService` instance cache (TTL: `AUTH.POLICY_CACHE_TTL_MS` = 60s)** — Per-Lambda-instance in-memory cache of `findActivePoliciesForTenant(tenantId)` results. Invalidated on policy create/update/delete operations within the same Lambda instance, but other Lambda instances rely on TTL expiry.
+2. **No HTTP / CDN cache for data endpoints** — All data endpoints return `Cache-Control: private, no-cache` (#1047). Shared caches MUST NOT store these responses, and even private caches MUST revalidate. So policy changes propagate as soon as the next request reaches a Lambda with a fresh PolicyService cache (≤ 60s).
+
+### Worst-Case Propagation Delay
+
+- **Single Lambda instance**: Immediate (cache invalidated on the same write).
+- **Multiple Lambda instances**: Up to `POLICY_CACHE_TTL_MS` (default 60s) before all instances pick up the change.
+
+This is acceptable for most authorization changes. For immediate revocation, restart Lambda instances or rotate the user's token to force re-authentication.
+
+### HTTP Cache Integrity After Policy Revocation
+
+The handler evaluates middleware in this fixed order, locked in by [the unit test in `tests/unit/handlers/api/index.test.ts`](../tests/unit/handlers/api/index.test.ts) under `#1050` regression tests:
+
+```text
+extractAuthContext → optionalAuth → checkTenantAccess → requireAuthz (XACML PEP)
+  → controller (200 + ETag)
+  → evaluateConditionalRequest (200 → 304 if If-None-Match matches)
+```
+
+When `requireAuthz` throws `ForbiddenError` (policy revoked), the response goes through the `catch` block which returns `4xx` directly — `evaluateConditionalRequest` is **not** called. So even if the client sends `If-None-Match` with a stale ETag from before revocation, the server returns `403`, never `304`. The old view cannot resurface.
+
+### Operational Recommendations
+
+- **Audit-critical revocations** should be paired with token invalidation (see [Token Invalidation](#token-invalidation)) to forcibly log out the user and prevent any in-flight cached responses from being trusted by the client.
+- **Policy hot-fixes** (≤ 60s propagation) are sufficient for most operational changes. Document the propagation expectation when communicating policy changes.
+
+---
+
+## Resource Scopes (Deprecated)
+
+> **Removed in #748**: Resource scopes (`resourceScopes` in JWT, `checkResourceScopes()`, `filterByResourceScopes()`) have been removed as part of the XACML authorization consolidation. Use XACML policies for fine-grained access control instead.
+
+---
+
+## Per-Tenant Feature Flags (Deprecated)
+
+> **Removed in #748**: Tenant feature flags (`apiKeysEnabled`, `oauthClientsEnabled`, `anonymousAccessEnabled`) have been removed. Authorization is now handled entirely by XACML policies with role-based defaults:
+> - API keys: Default Deny, requires explicit XACML Permit policy
+> - OAuth clients: Always available (no feature flag gate)
+> - Anonymous access: Default Deny, requires explicit XACML Permit policy (no feature flag needed)
+
+---
+
+## Authentication Scenario Reference
+
+### Access Permission Summary by Role
+
+| API Category | anonymous | user | tenant_admin | super_admin |
+|-------------|-----------|------|--------------|-------------|
+| Public endpoints | ✅ | ✅ | ✅ | ✅ |
+| `/statistics`, `/cache/statistics`, `/metrics` | ❌ (401) | ✅ (auth required) | ✅ (auth required) | ✅ (auth required) |
+| `/auth/*` | ❌ (401) | ✅ | ✅ | ✅ |
+| `/me/*` | ❌ (401) | ✅ | ✅ | ✅ |
+| `/v2/*` | ⚠️ Policy-dependent | 📖 Read-only (own tenant) | ✅ (own tenant) | ❌ Denied (403) |
+| `/ngsi-ld/*` | ⚠️ Policy-dependent | 📖 Read-only (own tenant) | ✅ (own tenant) | ❌ Denied (403) |
+| `/catalog/*` | ⚠️ Policy-dependent | 📖 Read-only (own tenant) | ✅ (own tenant) | ❌ Denied (403) |
+| `/admin/users` | ❌ (403) | ❌ | ✅ (`user` role within own tenant only) | ✅ (all users) |
+| `/admin/policies`, `/admin/policy-sets` | ❌ (403) | ❌ | ✅ (own tenant) | ✅ (all tenants) |
+| `/admin/cadde` | ❌ (403) | ❌ | ❌ | ✅ |
+| `/custom-data-models` | ❌ (403) | 📖 Read-only (own tenant) | ✅ (own tenant) | ✅ (all tenants) |
+| `/admin/*` (others) | ❌ (403) | ❌ (OAuth: accessible with `admin:*` scope) | ❌ | ✅ |
+| `/rules` | ⚠️ Policy-dependent | 📖 Read-only (own tenant) | ✅ (own tenant) | ❌ Denied (403) |
+| WebSocket | ❌ (403) | ✅ (own tenant) | ✅ (own tenant) | ❌ Denied (403) |
+
+> **⚠️ Policy-dependent**: Requires an explicit XACML Permit policy targeting `role=anonymous`. Without it, returns 403.
+
+### Common Authentication Scenarios
+
+#### Scenario 1: Authentication Disabled (`AUTH_ENABLED=false`
+
+)
+
+All endpoints are accessible without authentication.
+
+#### Scenario 2: JWT Authentication
+
+```bash
+# Login
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "password12345"}'
+
+# API request
+curl -X GET http://localhost:3000/v2/entities \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### Scenario 3: OAuth 2.0 M2M Authentication
+
+```bash
+# Obtain token
+curl -X POST http://localhost:3000/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d "grant_type=client_credentials&scope=read:entities"
+
+# API request
+curl -X GET http://localhost:3000/v2/entities \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### Scenario 4: API Key Authentication
+
+```bash
+# Create an API key (via admin or self-service)
+curl -X POST http://localhost:3000/me/api-keys \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My App Key",
+    "allowedOrigins": ["*"]
+  }'
+
+# API request with API key
+curl -X GET http://localhost:3000/v2/entities \
+  -H "X-Api-Key: gdb_<key_from_creation_response>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### Scenario 5: OIDC External IdP Authentication
+
+```bash
+# Obtain ID token from external IdP (e.g., Google)
+# API request
+curl -X GET http://localhost:3000/v2/entities \
+  -H "Authorization: Bearer <id_token_from_google>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### Scenario 6: Anonymous Access (No Authentication)
+
+```bash
+# No Authorization header needed
+# Requires: XACML Permit policy for role=anonymous (no feature flag needed since #748)
+curl -X GET http://localhost:3000/v2/entities?type=WeatherObserved \
+  -H "Fiware-Service: mytenant"
+```
+
+---
+
+## Token Invalidation
+
+GeonicDB provides a per-user token invalidation mechanism.
+
+### How Invalidation Works
+
+A timestamp (`invalidatedBefore`) is maintained per user — "tokens issued before this time are invalid." If a token's `iat` (issued-at time) is earlier than this timestamp, the token is judged invalid.
+
+### When Invalidation Occurs
+
+| Action | Effect |
+|-----------|------|
+| `POST /auth/logout` | Immediately invalidates all access tokens and refresh tokens for that user |
+| `POST /me/password` (password change) | Invalidates all existing tokens after the password change (re-login required) |
+
+### Storage
+
+| Environment | Storage | Configuration |
+|------|----------|------|
+| AWS Lambda | DynamoDB table | Specified via `TOKEN_INVALIDATION_TABLE_NAME` environment variable |
+| Local development | In-memory Map | Used automatically when environment variable is not set |
+
+The DynamoDB table has a TTL configured (7 days), and records exceeding the refresh token's expiration are automatically deleted.
+
+### Notes
+
+- OAuth 2.0 Client Credentials tokens are not subject to token invalidation
+- Logging in again after logout issues a new token
+
+### WebSocket Token Re-validation
+
+For WebSocket connections, the JWT `exp` (expiration) is stored in DynamoDB when the connection is established. On subsequent message receipt, `exp` is re-validated, and `401` is returned if the token has expired (OWASP API2:2023 compliance).
+
+- On connection: The `connect` handler saves `tokenExp` in `ConnectionRecord`
+- On message: The `default` handler compares `tokenExp` with the current time
+
+---
+
+## Brute Force Protection
+
+GeonicDB includes a brute force attack prevention feature for the login endpoint (`POST /auth/login`) and the OAuth token endpoint (`POST /oauth/token`) (OWASP API2:2023 compliance).
+
+### Behavior Specification
+
+#### Login Endpoint (`POST /auth/login`
+
+)
+
+Tracks login failure counts by email address and responds with the following rules:
+
+| Failure count | Response | Wait time until next attempt |
+|---------|-----------|---------------------|
+| 1st | `401 Unauthorized` | None |
+| 2nd | `401 Unauthorized` | 2 seconds (progressive delay) |
+| 3rd | `401 Unauthorized` | 4 seconds (progressive delay) |
+| 4th | `401 Unauthorized` | 8 seconds (progressive delay) |
+| 5th and beyond (locked) | `429 Too Many Requests` | 60 seconds (lock) |
+| While locked (even correct PW) | `429 Too Many Requests` | Remaining seconds |
+| Successful login | Counter reset | — |
+
+> **Note**: Retrying within the wait time results in `429 Too Many Requests` (with a `Retry-After` header). The progressive delay is applied on the next request (`checkLoginAllowed`), and the failure response itself is `401`.
+
+#### OAuth Token Endpoint (`POST /oauth/token`
+
+)
+
+Tracks authentication failure counts by `client_id`. The behavior rules are the same as the login endpoint (progressive delay + account lock).
+
+- **Tracking key**: Shares `LoginProtectionService` in the format `oauth:<clientId>`
+- **On success**: Counter reset
+- **Inactive client**: Recorded as authentication failure
+
+### Design Principles
+
+- **Email-based**: Tracked per email address since IP addresses can be easily bypassed with VPNs/proxies
+- **Lambda-optimized**: Responds with `429 + Retry-After` header instead of `sleep()` delay (to avoid Lambda billing costs)
+- **Automatic cleanup**: Attempt records are automatically deleted after 1 hour via MongoDB TTL index
+- **Independent from activate/deactivate**: Brute force protection is an automated security mechanism, managed separately from manual enable/disable operations by administrators
+
+### Administrator Unlock
+
+When an account is locked, administrators can clear the lock at the following endpoint:
+
+```bash
+POST /admin/users/{userId}/unlock
+Authorization: Bearer <accessToken>
+```
+
+**Response example:**
+
+```json
+{
+  "userId": "abc123",
+  "email": "user@example.com",
+  "locked": false,
+  "failedCount": 0,
+  "message": "Account login lock has been cleared"
+}
+```
+
+### Configuration Values
+
+| Parameter | Default | Description |
+|-----------|------------|------|
+| `MAX_FAILED_ATTEMPTS` | 5 | Maximum number of failures before lock |
+| `LOCK_DURATION_SECONDS` | 60 | Lock duration (seconds) |
+| `ATTEMPT_WINDOW_SECONDS` | 900 | Attempt window (15 minutes) |
+| `PROGRESSIVE_DELAY_BASE_SECONDS` | 2 | Base value for progressive delay (seconds) — delay = base × 2^(n-2) |
+| `ATTEMPT_RECORD_TTL_SECONDS` | 3600 | Automatic deletion of attempt records (1 hour) |
+
+---
+
+## Ownership Verification (GeonicDB Extension)
+
+GeonicDB provides ownership verification for Subscriptions and Registrations as a countermeasure for OWASP API1:2023 (Broken Object Level Authorization).
+
+### Overview
+
+The NGSI specification performs access control through tenant isolation (the `Fiware-Service` header) alone, but in multi-user tenant environments there is a challenge: users within the same tenant can operate on other users' resources. GeonicDB introduces a `createdBy` field and verifies ownership on write operations.
+
+### Target Resources
+
+| Resource | Target Operations |
+|---------|---------|
+| Subscription (`/v2/subscriptions`, `/ngsi-ld/v1/subscriptions`) | UPDATE, DELETE |
+| Registration (`/v2/registrations`, `/ngsi-ld/v1/csourceRegistrations`) | UPDATE, DELETE |
+
+> **Note**: Read operations (GET/LIST) are not restricted. Only tenant isolation conforming to the NGSI specification applies.
+
+### Behavior by Role
+
+| Role | Own resource | Other's resource | createdBy not set |
+|--------|--------------|--------------|----------------|
+| `super_admin` | ✅ Operable | ✅ Operable (bypass) | ✅ Operable |
+| `tenant_admin` | ✅ Operable | ✅ Operable (bypass) | ✅ Operable |
+| `user` | ✅ Operable | ❌ 403 Forbidden | ✅ Operable (backward compatible) |
+
+### Behavior Specification
+
+1. **On creation**: The authenticated user's ID is automatically recorded in the `createdBy` field when a resource is created
+2. **On update/delete**: The requesting user's ID is matched against `createdBy`
+   - Match: Operation permitted
+   - Mismatch: Returns `403 Forbidden`
+   - `createdBy` not set (existing data): Operation permitted for backward compatibility
+3. **Admin bypass**: `super_admin`/`tenant_admin` skip the ownership check
+4. **When authentication is disabled**: Ownership check is skipped when `AUTH_ENABLED=false`
+
+### Error Response
+
+```json
+{
+  "error": "Forbidden",
+  "description": "You do not have permission to modify this resource"
+}
+```
+
+Status code: `403 Forbidden`
+
+---
+
+## Troubleshooting
+
+### Rate Limit Error (429 Too Many Requests)
+
+**Possible causes:**
+- Too many login failures (brute force protection)
+- Account is locked
+
+**Resolution:**
+- Wait the number of seconds indicated in the `Retry-After` header, then retry
+- If locked, ask an administrator to clear the lock via `POST /admin/users/{userId}/unlock`
+
+### Authentication Error (401 Unauthorized)
+
+**Possible causes:**
+- Token is invalid or expired
+- `JWT_SECRET` is not configured correctly
+- User or tenant is deactivated
+- Token after logout or password change (already invalidated)
+
+**Resolution:**
+```bash
+# Check token expiration
+jwt decode <access_token>
+
+# Re-login
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "password12345"}'
+```
+
+### Authorization Error (403 Forbidden)
+
+**Possible causes:**
+- Insufficient role
+- Tenant does not match
+- Denied by XACML policy
+
+**Resolution:**
+- Check the user's role
+- Verify that the `Fiware-Service` header matches the user's tenant
+- Check the policy configuration
+
+### Admin API Access Error
+
+**Possible causes:**
+- Not a `super_admin` role (when using JWT authentication)
+- OAuth token lacks the required `admin:*` scope
+- IP address is not included in `ADMIN_ALLOWED_IPS`
+
+**Resolution:**
+```bash
+# Re-login as Super Admin
+# Check IP restrictions
+echo $ADMIN_ALLOWED_IPS
+# For OAuth: check the client's policyId and bound policy
+```
+
+---
+
+## Related Documentation
+
+- [API Common Specification](../api-reference/endpoints.md) - General API specifications
+- Development Guide - API specifications (pagination, status codes) and deployment
+- [XACML 3.0 Specification](https://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-os-en.html) - Official XACML 3.0 specification

--- a/docs/en/reference/cli.md
+++ b/docs/en/reference/cli.md
@@ -603,7 +603,7 @@ Manage entity snapshots.
 
 ### `rules`
 
-Manage ReactiveCore Rules. See ReactiveCore Rules for details.
+Manage ReactiveCore Rules. See [ReactiveCore Rules](../features/reactivcore-rules.md) for details.
 
 | Command | Description |
 |---------|-------------|
@@ -646,7 +646,7 @@ Browse the DCAT-AP data catalog.
 
 ### `admin`
 
-Administrative operations. Requires `tenant_admin` or `super_admin` role. See Authentication & Authorization Guide for details.
+Administrative operations. Requires `tenant_admin` or `super_admin` role. See [Authentication & Authorization Guide](./auth.md) for details.
 
 #### `admin tenants`
 
@@ -675,7 +675,7 @@ Administrative operations. Requires `tenant_admin` or `super_admin` role. See Au
 
 #### `admin policies`
 
-XACML policy management. See XACML Policy-Based Authorization for details.
+XACML policy management. See [XACML Policy-Based Authorization](./auth.md#xacml-policy-based-authorization) for details.
 
 | Command | Description |
 |---------|-------------|
@@ -689,7 +689,7 @@ XACML policy management. See XACML Policy-Based Authorization for details.
 
 #### `admin oauth-clients`
 
-OAuth 2.0 client management. See OAuth 2.0 M2M Authentication for details.
+OAuth 2.0 client management. See [OAuth 2.0 M2M Authentication](./auth.md#oauth-20-m2m-authentication) for details.
 
 | Command | Description |
 |---------|-------------|
@@ -701,7 +701,7 @@ OAuth 2.0 client management. See OAuth 2.0 M2M Authentication for details.
 
 #### `admin api-keys`
 
-API key management. Requires `tenant_admin` or `super_admin` role. See API Key Authentication for details.
+API key management. Requires `tenant_admin` or `super_admin` role. See [API Key Authentication](./auth.md#api-key-authentication) for details.
 
 | Command | Description |
 |---------|-------------|

--- a/docs/en/saas/quotas.md
+++ b/docs/en/saas/quotas.md
@@ -3,9 +3,774 @@ title: "Quotas & Plans"
 description: "GeonicDB quota system and plans"
 outline: deep
 ---
+# GeonicDB Quota System
 
-# Quotas & Plans
+GeonicDB provides a comprehensive quota system for managing per-tenant rate limits and storage quotas.
 
-::: info Coming Soon
-This page is being synced from the GeonicDB upstream documentation. Full content will be available after the next documentation sync.
-:::
+## Overview
+
+The quota system consists of three main components:
+
+1. **Rate Limiting System** - API request limiting using a DynamoDB-based token bucket algorithm
+2. **Storage Quota System** - Count limits on entities/subscriptions/registrations/temporal data based on MongoDB
+3. **Monitoring & Management System** - Usage tracking, alert delivery, and management API
+
+## Quota Plans
+
+GeonicDB offers four standard plans and a custom plan:
+
+### FREE Plan (for evaluation and development)
+
+**Rate Limits:**
+- Per minute: 60 requests (1 req/sec)
+- Per hour: 1,000 requests
+- Per day: 10,000 requests
+- Burst allowance: 10 requests
+
+**Storage Quotas:**
+- Entities: 1,000
+- Subscriptions: 10
+- Registrations: 5
+- Temporal data points: 10,000
+
+**Limits:**
+- Maximum request body size: 512KB
+- Maximum response body size: 5MB
+- Maximum batch operation size: 50
+
+### STANDARD Plan (small-scale production)
+
+**Rate Limits:**
+- Per minute: 600 requests (10 req/sec)
+- Per hour: 10,000 requests
+- Per day: 100,000 requests
+- Burst allowance: 100 requests
+
+**Storage Quotas:**
+- Entities: 10,000
+- Subscriptions: 100
+- Registrations: 50
+- Temporal data points: 100,000
+
+**Limits:**
+- Maximum request body size: 1MB
+- Maximum response body size: 10MB
+- Maximum batch operation size: 100
+
+### PREMIUM Plan (medium-scale production)
+
+**Rate Limits:**
+- Per minute: 3,000 requests (50 req/sec)
+- Per hour: 50,000 requests
+- Per day: 500,000 requests
+- Burst allowance: 500 requests
+
+**Storage Quotas:**
+- Entities: 100,000
+- Subscriptions: 500
+- Registrations: 200
+- Temporal data points: 1,000,000
+
+**Limits:**
+- Maximum request body size: 5MB
+- Maximum response body size: 50MB
+- Maximum batch operation size: 500
+
+### ENTERPRISE Plan (large-scale production)
+
+**Rate Limits:**
+- Per minute: 12,000 requests (200 req/sec)
+- Per hour: 200,000 requests
+- Per day: 2,000,000 requests
+- Burst allowance: 2,000 requests
+
+**Storage Quotas:**
+- Entities: 1,000,000
+- Subscriptions: 2,000
+- Registrations: 1,000
+- Temporal data points: 10,000,000
+
+**Limits:**
+- Maximum request body size: 10MB
+- Maximum response body size: 100MB
+- Maximum batch operation size: 1,000
+
+### CUSTOM Plan
+
+A custom plan that allows any values to be configured. Set individually using the management API.
+
+## Rate Limiting
+
+### Token Bucket Algorithm
+
+GeonicDB uses a token bucket algorithm operating on three sliding windows (minute/hour/day):
+
+1. Tokens are consumed per request based on the endpoint weight
+2. A request is permitted only when all three windows have sufficient tokens
+3. Tokens are automatically refilled at the transition of each time window
+
+### Endpoint Weights
+
+Different endpoints are assigned different weights based on their processing cost:
+
+| Operation | Weight | Example |
+|------|------|-----|
+| GET | 1 | `GET /v2/entities` |
+| POST (single) | 3 | `POST /v2/entities` |
+| PATCH/PUT | 2 | `PATCH /v2/entities/{id}` |
+| DELETE | 2 | `DELETE /v2/entities/{id}` |
+| Batch operations | 5 × count | `POST /v2/op/update` with 10 entities = 50 |
+| Temporal operations | 2 | `POST /ngsi-ld/v1/temporal/entities` |
+
+### Burst Allowance
+
+Each plan has a burst allowance to handle sudden traffic spikes in short periods. This allows temporarily exceeding the limit.
+
+### Response Headers
+
+When rate limiting is enabled, responses from NGSIv2, NGSI-LD, and Catalog API endpoints include headers indicating the current rate limit status:
+
+```http
+X-RateLimit-Limit-Minute: 600
+X-RateLimit-Remaining-Minute: 450
+X-RateLimit-Reset-Minute: 1707648000
+
+X-RateLimit-Limit-Hour: 10000
+X-RateLimit-Remaining-Hour: 8500
+X-RateLimit-Reset-Hour: 1707651600
+
+X-RateLimit-Limit-Day: 100000
+X-RateLimit-Remaining-Day: 95000
+X-RateLimit-Reset-Day: 1707734400
+```
+
+### Behavior When Rate Limit Is Exceeded
+
+When the rate limit is exceeded:
+
+- **HTTP status code**: `429 Too Many Requests`
+- **Retry-After header**: Number of seconds until the next request is permitted
+- **Error message**: `{"error": "TooManyRequests", "description": "Rate limit exceeded"}`
+
+### Public (Unauthenticated) Endpoint Rate Limit (#1075)
+
+Public endpoints reachable without authentication are protected by a separate
+IP-based token bucket independent of per-tenant `QUOTAS.PLANS`. This blocks
+OAuth `client_id+secret` brute-force and DoS via heavy JSON generation
+(`/openapi.json` etc.).
+
+| Category | Endpoints | Per minute | Per hour | Per day | Burst |
+|----------|-----------|-----------:|---------:|--------:|------:|
+| `metadata` | `/openapi.json`, `/api.json`, `/tools.json`, `/llms.txt`, `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json`, `/.well-known/ngsi-ld` | 30 | 300 | 1,000 | 10 |
+| `oauth` (per IP) | `/oauth/token` | 20 | 100 | 500 | 5 |
+| `oauth` (per `client_id`) | `/oauth/token` | 10 | 60 | 200 | 2 |
+| `auth` | `/auth/refresh`, `/auth/nonce` | 30 | 200 | 1,000 | 5 |
+
+Notes:
+
+- `/auth/login` is **not** subject to this limit; it is protected by `LoginProtectionService` (email + IP based progressive lockout).
+- `/health`, `/health/live`, `/health/ready`, `/version` are **not** subject to this limit (intended for health-check polling).
+- When the bucket store (DynamoDB / MongoDB) is unavailable, the request is allowed through; we do not fail-close on infrastructure error to avoid taking the public surface offline.
+- Defaults are centralised in `PUBLIC_RATE_LIMIT` in `src/config/defaults.ts`.
+
+## Storage Quotas
+
+### Resource Types
+
+Quotas are configured for four types of resources:
+
+1. **Entities** - Total number of NGSIv2/NGSI-LD entities
+2. **Subscriptions** - Total number of active subscriptions
+3. **Registrations** - Total number of context source registrations
+4. **Temporal data points** - Total number of time-series data points
+
+### Pre-Check
+
+Storage quotas are checked **before** create operations:
+
+- For batch operations, execution proceeds only when all entities fit within the quota
+- If even one would exceed the quota, the entire operation is rejected (all-or-nothing)
+
+### Response Headers
+
+NGSIv2, NGSI-LD, and Catalog API endpoints include headers indicating the current storage usage:
+
+```http
+X-Storage-Quota-Entities-Used: 5000
+X-Storage-Quota-Entities-Limit: 10000
+X-Storage-Quota-Subscriptions-Used: 50
+X-Storage-Quota-Subscriptions-Limit: 100
+X-Storage-Quota-Registrations-Used: 25
+X-Storage-Quota-Registrations-Limit: 50
+X-Storage-Quota-TemporalDataPoints-Used: 50000
+X-Storage-Quota-TemporalDataPoints-Limit: 100000
+```
+
+**Target endpoints**: These headers are returned by all endpoints of the NGSIv2, NGSI-LD, and Catalog APIs. Using the management API (`/admin/tenants/{tenantId}/quotas`) allows you to retrieve more detailed quota information. See [Authentication & Authorization](../reference/auth.md#quota-management) for details.
+
+### Behavior When Storage Quota Is Exceeded
+
+When the storage quota is exceeded:
+
+- **HTTP status code**: `507 Insufficient Storage`
+- **Error message**: Includes the resource type and current usage
+- **Example**: `{"error": "InsufficientStorage", "description": "Entity quota exceeded (10000/10000)", "details": {"resourceType": "entities", "current": 10000, "limit": 10000}}`
+
+## Monitoring and Alerts
+
+### Usage Snapshots
+
+The system periodically records usage snapshots to DynamoDB:
+
+- Rate limit utilization (minute/hour/day)
+- Storage resource utilization
+- Timestamp and tenant information
+- Retained for 90 days (TTL)
+
+### Alert Thresholds
+
+Each tenant has two alert levels:
+
+- **Warning**: Default at 80% usage
+- **Critical**: Default at 95% usage
+
+### Alert Delivery
+
+When a configured threshold is exceeded:
+
+1. An alert message is recorded in the log
+2. If a Webhook URL is configured, an alert is sent via HTTP POST
+3. The same alert is not resent within 1 hour (debounce feature)
+
+### Webhook Payload
+
+```json
+{
+  "id": "rateLimit.perMinute.warning.tenant1#/",
+  "tenantService": "tenant1#/",
+  "alertType": "rateLimit",
+  "resourceType": "perMinute",
+  "severity": "warning",
+  "message": "Rate limit perMinute usage is high (85%)",
+  "currentValue": 510,
+  "limitValue": 600,
+  "utilizationPercent": 85,
+  "timestamp": 1707645123456
+}
+```
+
+## Management API
+
+### Get Quota Information
+
+```http
+GET /admin/tenants/{tenantId}/quotas
+```
+
+**Response:**
+```json
+{
+  "tenantId": "tenant-1",
+  "tenantName": "tenant1",
+  "quotaPlan": "STANDARD",
+  "customQuotas": null,
+  "alertThresholds": {
+    "rateLimitWarning": 80,
+    "rateLimitCritical": 95,
+    "storageWarning": 80,
+    "storageCritical": 95
+  },
+  "currentUsage": {
+    "rateLimit": {
+      "minute": { "limit": 600, "used": 150, "remaining": 450, "usagePercent": 25, "resetAt": 1707648000 },
+      "hour": { "limit": 10000, "used": 1500, "remaining": 8500, "usagePercent": 15, "resetAt": 1707651600 },
+      "day": { "limit": 100000, "used": 5000, "remaining": 95000, "usagePercent": 5, "resetAt": 1707734400 }
+    },
+    "storage": {
+      "entities": { "used": 5000, "limit": 10000, "usagePercent": 50 },
+      "subscriptions": { "used": 50, "limit": 100, "usagePercent": 50 },
+      "registrations": { "used": 25, "limit": 50, "usagePercent": 50 },
+      "temporalDataPoints": { "used": 50000, "limit": 100000, "usagePercent": 50 }
+    }
+  }
+}
+```
+
+### Update Quota Settings
+
+```http
+PUT /admin/tenants/{tenantId}/quotas
+```
+
+**Request body:**
+```json
+{
+  "quotaPlan": "PREMIUM",
+  "alertThresholds": {
+    "rateLimitWarning": 85,
+    "rateLimitCritical": 98,
+    "storageWarning": 85,
+    "storageCritical": 98
+  }
+}
+```
+
+### Configure Custom Quotas
+
+```http
+PUT /admin/tenants/{tenantId}/quotas
+```
+
+**Request body:**
+```json
+{
+  "quotaPlan": "CUSTOM",
+  "customQuotas": {
+    "rateLimit": {
+      "perMinute": 1200,
+      "perHour": 20000,
+      "perDay": 200000,
+      "burstAllowance": 200
+    },
+    "storage": {
+      "maxEntities": 50000,
+      "maxSubscriptions": 200,
+      "maxRegistrations": 100,
+      "maxTemporalDataPoints": 500000
+    },
+    "limits": {
+      "maxRequestBodyBytes": 2097152,
+      "maxResponseBodyBytes": 20971520,
+      "maxBatchSize": 200
+    }
+  }
+}
+```
+
+### Get Usage History
+
+```http
+GET /admin/tenants/{tenantId}/usage?startDate=2026-02-01&endDate=2026-02-10&limit=100
+```
+
+**Response:**
+```json
+{
+  "tenantId": "tenant-1",
+  "tenantName": "tenant1",
+  "startDate": "2026-02-01",
+  "endDate": "2026-02-10",
+  "snapshots": [
+    {
+      "tenantService": "tenant1#/",
+      "timestamp": 1707645123456,
+      "date": "2026-02-10",
+      "rateLimit": { ... },
+      "storage": { ... }
+    }
+  ]
+}
+```
+
+## Environment Variables
+
+### SAM Template
+
+```yaml
+Parameters:
+  RateLimitEnabled:
+    Type: String
+    Default: 'true'
+    Description: Enable rate limiting for API requests
+
+  QuotaAlertWebhookUrl:
+    Type: String
+    Default: ''
+    Description: Webhook URL for quota violation alerts
+```
+
+### Environment Variables
+
+- `RATE_LIMIT_ENABLED`: Enable/disable rate limiting (default: `true`)
+- `RATE_LIMIT_TABLE_NAME`: DynamoDB rate limit table name
+- `USAGE_STATS_TABLE_NAME`: DynamoDB usage statistics table name
+- `QUOTA_ALERT_WEBHOOK_URL`: Webhook URL for alert delivery (optional)
+
+## Access Control
+
+### Permission Levels
+
+- **super_admin**: Can view and modify quotas for all tenants
+- **tenant_admin**: Can view and modify quotas for their own tenant
+- **user**: No access to the quota management API
+
+### Authentication
+
+All quota management APIs require authentication:
+
+```http
+Authorization: Bearer <JWT_TOKEN>
+```
+
+## Best Practices
+
+### Choosing a Quota Plan
+
+1. **Development/Testing**: Start with the FREE plan
+2. **Small-scale production**: STANDARD plan
+3. **Medium-scale production**: PREMIUM plan
+4. **Large-scale production**: ENTERPRISE plan
+5. **Special requirements**: Configure individually with the CUSTOM plan
+
+### Alert Configuration
+
+- **Warning**: Threshold to consider expanding capacity (default 80%)
+- **Critical**: Threshold requiring immediate action (default 95%)
+- Configure a Webhook URL to receive real-time notifications
+
+### Monitoring
+
+- Check response headers regularly
+- Analyze trends with the usage history API
+- Monitor alert logs
+
+## Troubleshooting
+
+### 429 Too Many Requests
+
+**Cause**: Rate limit exceeded
+
+**Resolution**:
+1. Wait the number of seconds specified in the `Retry-After` header
+2. Reduce request frequency
+3. Leverage batch operations to reduce the number of requests
+4. Consider upgrading the plan
+
+### 507 Insufficient Storage
+
+**Cause**: Storage quota exceeded
+
+**Resolution**:
+1. Delete unnecessary entities/subscriptions/registrations
+2. Shorten the retention period for temporal data
+3. Consider upgrading the plan
+
+### Quota Headers Not Displayed
+
+**Cause**: Rate limiting may be disabled
+
+**Resolution**:
+1. Check the `RATE_LIMIT_ENABLED` environment variable
+2. Check the SAM template parameters
+3. Verify that the DynamoDB table is deployed correctly
+
+## Input Validation Limits
+
+GeonicDB enforces input length and count limits to prevent abuse and ensure system stability.
+
+### Authentication & Login Protection
+
+#### Per-Account Login Protection
+
+Existing per-account brute-force protection (see [AUTH.md](../reference/auth.md)):
+
+- Maximum failed login attempts per account: **5** within **15 minutes**
+- Account lock duration: **15 minutes** after threshold is reached
+- Progressive delay: Exponential backoff starting at **2 seconds** (2^(n-2))
+
+#### Per-IP Login Protection (#900)
+
+Prevents password spray attacks across multiple accounts from a single IP:
+
+| Parameter | Value |
+|-----------|-------|
+| Maximum failed attempts per IP | **20** within **5 minutes** |
+| IP lock duration | **15 minutes** |
+| Record TTL | **1 hour** (auto-deleted) |
+
+- **HTTP status**: `429 Too Many Requests` with `Retry-After: 900`
+- Successful logins do NOT reset the IP counter (prevents timing-based enumeration)
+- Error message: `"Too many failed login attempts from this IP. Please try again later."`
+
+### Tenant Resource Limits
+
+#### Users per Tenant (#901)
+
+| Parameter | Default |
+|-----------|---------|
+| Maximum users per tenant | **100** |
+
+- Checked on user creation only
+- Per-tenant override via `tenant.settings.maxUsers`
+- **HTTP status**: `400 Bad Request`
+- Error message: `"User limit reached for this tenant (current: N, limit: M)"`
+
+#### Policies per Tenant (#912)
+
+| Parameter | Default |
+|-----------|---------|
+| Maximum policies per tenant | **50** |
+
+- Per-tenant override via `tenant.settings.maxPolicies`
+- **HTTP status**: `400 Bad Request`
+- Error message: `"Policy limit reached for this tenant (current: N, limit: M)"`
+
+#### Admin User Operations Rate Limit (#905)
+
+Prevents create-delete cycle attacks on the Admin API:
+
+| Parameter | Value |
+|-----------|-------|
+| Window | **10 minutes** |
+| Maximum operations per window | **1,000** (create + delete combined) |
+
+- Applied per tenant on `createUser` and `deleteUser`
+- `super_admin` is exempt
+- **HTTP status**: `429 Too Many Requests`
+- Error message: `"Too many user management operations. Limit: 1000 per 10 minutes."`
+
+### XACML Policy Input Limits (#912)
+
+| Field | Max Length |
+|-------|-----------|
+| `policyId` / `policySetId` / `ruleId` | 256 characters |
+| `description` | 2,000 characters |
+| `attributeId` | 256 characters |
+| `matchValue` | 2,000 characters |
+| `expression` (condition) | 5,000 characters |
+| `timezone`, `startTime`, `endTime` | 50 characters |
+| IP/CIDR entry in `allowedIps` | 50 characters |
+
+| Collection | Max Count |
+|------------|-----------|
+| Rules per policy | 100 |
+| Conditions per rule | 50 |
+| Policies per policy set | 100 |
+
+### Email Address Validation (#903)
+
+- Maximum length: **254 characters** (RFC 5321 compliance)
+- Applied to: user creation, user update, login
+- **HTTP status**: `400 Bad Request`
+
+### Subscription Endpoint URI/URL (#913)
+
+- Maximum length: **2,048 characters**
+- Applied to: NGSI-LD `notification.endpoint.uri`, NGSIv2 `notification.http.url` / `notification.httpCustom.url` / `notification.mqtt.url`
+- **HTTP status**: `400 Bad Request`
+
+### Input Validation Limits (General)
+
+GeonicDB enforces comprehensive input validation across all API endpoints. Exceeding any limit returns `400 Bad Request`.
+
+#### String Length Limits
+
+| Category | Example Fields | Max Length |
+|----------|---------------|-----------|
+| Entity ID | `entityId`, `id` | 256 |
+| Entity Type | `type` | 256 |
+| Attribute Name | `attrName`, attribute keys | 256 |
+| Generic ID | `subscriptionId`, `registrationId`, `ruleId` | 256 |
+| Name fields | `name`, `subscriptionName` | 256 |
+| Description fields | `description` | 2,000 |
+| URL fields | `endpoint`, `provider.http.url` | 2,048 |
+| Query strings | `q`, `mq`, `scopeQ`, `csf` | 2,000 |
+| Regex patterns | `idPattern`, `typePattern` | 200 |
+| georel | `georel` | 100 |
+| geometry | `geometry` | 50 |
+| coords | `coords`, `coordinates` | 2,000 |
+| orderBy | `orderBy` | 500 |
+| options | `options` | 200 |
+| lang | `lang` | 50 |
+| scope | `scope` (string) | 500 |
+| unitCode | `unitCode` | 50 |
+
+#### Array Element Count Limits
+
+| Array Field | Max Elements |
+|------------|-------------|
+| `attrs`, `pick`, `omit`, `expandValues` | 50 |
+| `watchedAttributes` | 100 |
+| `notification.attrs` / `exceptAttrs` | 100 |
+| `subject.entities` / `entities` | 100 |
+| Batch operation `entities` | 100 (MAX_BATCH_SIZE) |
+| `propertyNames` / `relationshipNames` | 100 |
+| `receiverInfo` / `notifierInfo` | 50 |
+| `contextSourceInfo` | 50 |
+| `operationGroup` | 20 |
+| `scope` (array) | 20 |
+| `@context` (array) | 10 |
+
+#### Numeric Upper Bounds
+
+| Field | Max Value |
+|-------|-----------|
+| `throttling` | 86,400 (24 hours, in seconds) |
+| `timeout` | 30,000 (30 seconds, in ms) |
+| `lastN` | 1,000 |
+
+#### Header Validation
+
+| Header | Max Length |
+|--------|-----------|
+| Bearer / DPoP token | 8,192 |
+| Link (@context URL) | 2,048 |
+| Fiware-ServicePath (per element) | 256 |
+| Tenant name (Fiware-Service) | 64 |
+
+#### Path Parameter Validation
+
+Resource IDs in URL paths are also validated for length.
+
+| Parameter | Max Length | Applicable APIs |
+|-----------|-----------|-----------------|
+| `entityId` | 256 | NGSIv2, NGSI-LD |
+| `attrName` | 256 | NGSIv2, NGSI-LD |
+| `subscriptionId` | 256 | NGSIv2, NGSI-LD |
+| `registrationId` | 256 | NGSIv2, NGSI-LD |
+| `instanceId` | 256 | NGSI-LD Temporal |
+| `entityMapId` | 256 | NGSI-LD Entity Maps |
+| `contextId` | 256 | NGSI-LD JSON-LD Contexts |
+| `snapshotId` | 256 | NGSI-LD Snapshots |
+| `ruleId` | 256 | Rules API |
+| `typeName` | 256 | NGSIv2/NGSI-LD Types |
+| `datasetId` | 256 | Catalog API |
+
+#### AttributeValue Nesting Depth Limit
+
+- Maximum depth: **10**
+- Beyond the limit, only primitive types (string, number, boolean, null) are accepted
+- **HTTP status**: `400 Bad Request` when nesting exceeds the limit
+
+#### MQTT Notification Fields
+
+| Field | Max Length |
+|-------|-----------|
+| `topic` | 1,024 |
+| `user` / `passwd` | 256 |
+
+#### HTTP Custom Notification Fields
+
+| Field | Max Length |
+|-------|-----------|
+| Header key | 256 |
+| Header value | 4,096 |
+| Query string value | 2,048 |
+| `payload` | 51,200 (50KB) |
+
+#### Admin API Validation
+
+| Field | Max Length / Value |
+|-------|-------------------|
+| Tenant `name` | 64 |
+| Tenant `maxUsers` | 10,000 |
+| Tenant `description` | 2,000 |
+| Tenant `allowedServices` | 50 elements, each 256 chars |
+| User `password` | 128 (also minimum 12) |
+| Policy `priority` | 0–1,000 |
+| Policy `subjects` / `resources` / `actions` array | 50 elements each |
+| API key `policyId` / `tenantId` | 256 |
+| API key origin | 2,048 |
+| OAuth client `name` | 256 |
+| OAuth client `description` | 2,000 |
+| Path parameters (`tenantId`, `userId`, `policyId`, `keyId`, `clientId`) | 256 |
+
+#### Auth & OAuth API Validation
+
+| Field | Max Length |
+|-------|-----------|
+| Login `password` | 128 |
+| Login `tenantId` | 256 |
+| Refresh token | 8,192 |
+| Password reset `token` | 2,048 |
+| OAuth `scope` | 2,000 |
+| OAuth `client_secret` | 512 |
+| OAuth `nonce` / `proof` | 512 |
+
+#### Custom Quota Upper Bounds
+
+When configuring custom quotas via the Admin API, the following maximum values apply:
+
+| Field | Max Value |
+|-------|-----------|
+| `rateLimit.perMinute` | 1,000,000 |
+| `rateLimit.perHour` | 10,000,000 |
+| `rateLimit.perDay` | 100,000,000 |
+| `rateLimit.burstAllowance` | 100,000 |
+| `storage.maxEntities` | 100,000,000 |
+| `storage.maxSubscriptions` | 1,000,000 |
+| `storage.maxRegistrations` | 1,000,000 |
+| `storage.maxTemporalDataPoints` | 1,000,000,000 |
+| `limits.maxRequestBodyBytes` | 100MB (104,857,600) |
+| `limits.maxResponseBodyBytes` | 1GB (1,073,741,824) |
+| `limits.maxBatchSize` | 10,000 |
+
+#### Rules API Validation
+
+| Field | Max Length / Value |
+|-------|-------------------|
+| Rule `name` | 256 |
+| Rule `description` | 2,000 |
+| Rule `priority` | 0–1,000 |
+| Rule `cooldownSeconds` | 86,400 (24h) |
+| Condition `attributeName` | 256 |
+| Condition `pattern` | 200 |
+| Condition `timezone` / `startTime` / `endTime` | 50 |
+| Action `entityId` | 256 |
+| Action `entityType` | 256 |
+| Action `url` (webhook) | 2,048 |
+| Action `message` | 2,000 |
+| `conditions` / `actions` array | 50 elements each |
+| `entityTypes` array | 100 elements |
+
+#### Custom Data Models API Validation
+
+| Field | Max Length / Value |
+|-------|-------------------|
+| Model `type` | 256 |
+| Model `domain` | 256 |
+| Model `description` | 2,000 |
+| Property `valueType` | 256 |
+| Property `description` | 2,000 |
+| Validation `minLength` / `maxLength` | 10,000 |
+| Validation `enum` array | 100 elements |
+
+#### Catalog / CADDE / Vocabulary API Validation
+
+| Field | Max Length |
+|-------|-----------|
+| Catalog `q` (keyword) | 2,000 |
+| Catalog `id` (package/dataset) | 256 |
+| CADDE query params (`type`, `id`, `q`) | Same as NGSI limits |
+| Vocabulary `tenantId` | 64 |
+| Vocabulary `term` | 256 |
+
+#### MCP Admin Tools Validation
+
+MCP tools enforce the same limits as the HTTP Admin API at the tool input layer:
+
+| Field | Validation |
+|-------|-----------|
+| `email` | Valid email format, max 254 chars |
+| `password` | 12–128 chars |
+| `id` / `policyId` / `tenant` | Max 256 chars |
+| `description` | Max 2,000 chars |
+| `priority` | 0–1,000 |
+
+All limit violations return:
+- **HTTP status**: `400 Bad Request`
+- **Error format**: `{ "error": "BadRequest", "description": "field exceeds maximum length of N" }`
+
+### Storage Quota Fix: `/v2/op/update` (#902)
+
+The storage quota check for batch operations (`/v2/op/update`) now correctly identifies entity-creation operations:
+
+- **`append` / `appendStrict`**: Counted as entity creation — consumes storage quota
+- **`update` / `delete` / `replace`**: NOT counted as entity creation — no storage quota impact
+
+Previously, all `/v2/op/update` requests were incorrectly counted against the entity creation quota regardless of `actionType`.
+
+## Related Documentation
+
+- Development & Deployment Guide - Infrastructure setup
+- [Authentication & Authorization](../reference/auth.md) - Tenant/user management, access control

--- a/docs/ja/ai-integration/examples.md
+++ b/docs/ja/ai-integration/examples.md
@@ -152,7 +152,8 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`
+- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
 - **動作モード**: ステートレス (Lambda 互換)
 - **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
@@ -256,7 +257,8 @@ API キーで利用可能なスコープ:
 
 Claude Desktop 設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 ```json
 {
   "mcpServers": {

--- a/docs/ja/ai-integration/overview.md
+++ b/docs/ja/ai-integration/overview.md
@@ -152,7 +152,8 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`
+- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
 - **動作モード**: ステートレス(Lambda 互換)
 - **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます

--- a/docs/ja/ai-integration/tools-json.md
+++ b/docs/ja/ai-integration/tools-json.md
@@ -152,7 +152,8 @@ GeonicDB は [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) �
 
 ### 概要
 
-- **エンドポイント**: `POST /mcp`- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
+- **エンドポイント**: `POST /mcp`
+- **トランスポート**: Streamable HTTP (JSON レスポンスモード)
 - **プロトコルバージョン**: 2025-03-26
 - **動作モード**: ステートレス (Lambda 互換)
 - **認証**: `AUTH_ENABLED=true` の場合、JWT Bearer トークンによるアクセス制御とテナント分離が適用されます
@@ -256,7 +257,8 @@ API キーで利用可能なスコープ:
 
 Claude Desktop の設定ファイルを編集します:
 
-- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 ```json
 {
   "mcpServers": {

--- a/docs/ja/api-reference/endpoints.md
+++ b/docs/ja/api-reference/endpoints.md
@@ -5,38 +5,58 @@ outline: deep
 ---
 # GeonicDB Context Broker API ドキュメント
 
-これは AWS Lambda 上で動作する FIWARE Orion 互換 Context Broker の API ドキュメントです。NGSIv2 と NGSI-LD の両方の API をサポートしています。
+これは AWS Lambda 上で動作する FIWARE Orion 互換の Context Broker の API ドキュメントです。NGSIv2 と NGSI-LD API の両方をサポートしています。
 
 ## 目次
 
-- [概要](#概要)
-- [認証とマルチテナンシー](#認証とマルチテナンシー)
-- [ページネーション](#ページネーション)
-- [認証 API](#認証-api)
-- [メタエンドポイント](#メタエンドポイント)
-- [NGSIv2 API](#ngsiv2-api) (→ [API_NGSIV2.md](./ngsiv2.md))
-- [NGSI-LD API](#ngsi-ld-api) (→ [API_NGSILD.md](./ngsild.md))
-- [クエリ言語](#クエリ言語)
-- [ジオクエリ](#ジオクエリ)
-- [空間 ID 検索](#空間-id-検索)
-- [GeoJSON 出力](#geojson-出力)
-- [ベクタータイル](#ベクタータイル)
-- [座標参照系 (CRS)](#座標参照系-crs)
-- [データカタログ API](#データカタログ-api)
-- [CADDE 統合](#cadde-統合)
-- [イベントストリーミング](#イベントストリーミング)
-- [エラーレスポンス](#エラーレスポンス)
-- [実装状況](#実装状況)
 
----
+* [概要](#overview)
+  
+* [認証とマルチテナンシー](#認証とマルチテナンシー)
+  
+* [ページネーション](#ページネーション)
+  
+* [認証 API](#認証-api)
+  
+* [メタエンドポイント](#メタエンドポイント)
+  
+* [NGSIv2 API](#ngsiv2-api) (→ [API\_NGSIV2.md](./ngsiv2.md))
+  
+* [NGSI-LD API](#ngsi-ld-api) (→ [API\_NGSILD.md](./ngsild.md))
+  
+* [クエリ言語](#クエリ言語)
+  
+* [地理クエリ](#地理クエリ)
+  
+* [空間 ID 検索](#空間-id-検索)
+  
+* [GeoJSON 出力](#geojson-出力)
+  
+* [ベクタータイル](#vector-tiles)
+  
+* [座標参照系 (CRS)](#座標参照系-crs)
+  
+* [データカタログ API](#data-catalog-api)
+  
+* [CADDE 連携](#cadde-integration)
+  
+* [イベントストリーミング](#イベントストリーミング)
+  
+* [エラーレスポンス](#エラーレスポンス)
+  
+* [実装ステータス](#implementation-status)
+
+***
 
 ## 概要
 
 この Context Broker は、FIWARE NGSI (Next Generation Service Interface) 仕様に準拠した RESTful API を提供します。
 
 **関連ドキュメント:**
-- [NGSIv2 / NGSI-LD 互換性ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の互換性、型マッピング、ベストプラクティス
-- [WebSocket イベントストリーミング](../features/subscriptions.md) - リアルタイムイベントサブスクリプション、実装例、ベストプラクティス
+
+* [NGSIv2 / NGSI-LD 相互運用ガイド](../core-concepts/ngsiv2-vs-ngsild.md) - 両 API 間の相互運用性、型マッピング、およびベストプラクティス
+  
+* [WebSocket イベントストリーミング](../features/subscriptions.md) - リアルタイムイベントサブスクリプション、実装例、およびベストプラクティス
 
 ### ベース URL
 
@@ -46,18 +66,18 @@ https://{api-gateway-url}/{stage}
 
 ### サポートされている API
 
-| API バージョン | ベースパス | Content-Type |
-|-------------|-----------|--------------|
-| NGSIv2 | `/v2` | `application/json` |
-| NGSI-LD | `/ngsi-ld/v1` | `application/ld+json` |
+| API Version | Base Path     | Content-Type          |
+| ----------- | ------------- | --------------------- |
+| NGSIv2      | `/v2`         | `application/json`    |
+| NGSI-LD     | `/ngsi-ld/v1` | `application/ld+json` |
 
 ### OPTIONS メソッド
 
-`OPTIONS` メソッドはすべてのエンドポイントでサポートされています。CORS プリフライトリクエストに対して、許可されたメソッドとヘッダーに関する情報を返します。
+`OPTIONS` メソッドはすべてのエンドポイントでサポートされています。CORS プリフライトリクエストに応答して、許可されたメソッドとヘッダーに関する情報を返します。
 
 #### レスポンス形式
 
-OPTIONS リクエストは `204 No Content` を返し、以下のヘッダーが含まれます:
+OPTIONS リクエストは、以下のヘッダーと共に `204 No Content` を返します:
 
 ```http
 OPTIONS /v2/entities/urn:ngsi-ld:Room:Room1
@@ -84,35 +104,38 @@ Access-Control-Allow-Headers: Content-Type, NGSILD-Tenant, Fiware-Service, Link,
 Access-Control-Max-Age: 86400
 ```
 
-> **注意**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュ自動再検証や SDK の条件付きリクエストがプリフライト拒否なしにクロスオリジンで発行できます (#1065)。
+> **注**: `If-None-Match` / `If-Modified-Since` は `Access-Control-Allow-Headers` に明示的にリストされているため、ブラウザの HTTP キャッシュの自動再検証と SDK の条件付きリクエストが、プリフライトの拒否なしにクロスオリジンで発行できます (#1065)。
 
 ### エンティティ ID の一意性 (GeonicDB 拡張)
 
-> **GeonicDB 拡張**: この動作は、同じ ID で異なる型を持つエンティティの共存を許可する標準 NGSIv2 仕様とは異なります。
+> **GeonicDB 拡張**: この動作は、同じ ID だが異なる型を持つエンティティの共存を許可する標準 NGSIv2 仕様とは異なります。
 
-GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の一部では **ありません**。
+GeonicDB では、エンティティ ID は **テナント** (`Fiware-Service`) と **ServicePath** (`Fiware-ServicePath`) のスコープ内で一意です。エンティティの `type` は一意性制約の一部では**ありません**。
 
 **主な動作:**
 
-- 既存のエンティティと同じ ID でエンティティを作成すると (異なる `type` であっても)、`409 AlreadyExists` が返されます
-- バッチ upsert 操作は `entityId` のみでエンティティをマッチングします (型は上書き可能)
-- 同一 ID のエンティティ間で型を区別するための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
 
-この設計は NGSI-LD 仕様に準拠しており、エンティティ ID は URI であり、本質的に一意です。エンティティ ID は、テナント、servicePath、プロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
+* 既存のエンティティと同じ ID を持つエンティティを作成すると(異なる `type` であっても)、`409 AlreadyExists` が返されます
+  
+* バッチアップサート操作は `entityId` のみでエンティティをマッチングします(型は上書き可能)
+  
+* 同一 ID エンティティ間の型の曖昧性解消のための NGSIv2 `?type=` クエリパラメータは適用されなくなりました
 
----
+この設計は、エンティティ ID が URI であり本質的に一意である NGSI-LD 仕様と整合しています。エンティティ ID はテナント、servicePath、およびプロトコルごとに一意です。NGSIv2 と NGSI-LD のエンティティは完全に分離されており、同じエンティティ ID が各プロトコルで独立して存在できます。
+
+***
 
 ## 認証とマルチテナンシー
 
 ### 必須ヘッダー
 
-すべてのリクエストには、以下のヘッダーを含めることを推奨します:
+すべてのリクエストには以下のヘッダーを含めることを推奨します:
 
-| ヘッダー | 必須 | 説明 | デフォルト |
-|--------|------|------|---------|
-| `Fiware-Service` / `NGSILD-Tenant` | 推奨 | テナント名 (英数字とアンダースコアのみ) | `default` |
-| `Fiware-ServicePath` | NGSIv2 のみ | テナント内の階層パス (`/` で開始)。**NGSI-LD API では無視されます** — 代わりに `scope` プロパティと `scopeQ` パラメータを使用してください | `/` (クエリ時は `/#` と同等) |
-| `Fiware-Correlator` | オプション | リクエストトレーシング用の相関 ID | 自動生成 |
+| Header                             | Required    | Description                                                                                                                             | Default                              |
+| ---------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `Fiware-Service` / `NGSILD-Tenant` | Recommended | Tenant name (alphanumeric and underscores only)                                                                                         | `default`                            |
+| `Fiware-ServicePath`               | NGSIv2 only | Hierarchical path within the tenant (starts with `/`). **Ignored by NGSI-LD API** — use `scope` property and `scopeQ` parameter instead | `/` (equivalent to `/#` for queries) |
+| `Fiware-Correlator`                | Optional    | Correlation ID for request tracing                                                                                                      | Auto-generated                       |
 
 ### 使用例
 
@@ -122,21 +145,27 @@ curl -X GET "https://api.example.com/v2/entities" \
   -H "Fiware-ServicePath: /buildings/floor1"
 ```
 
-### テナントの分離
+### テナント分離
 
-- 異なる `Fiware-Service` 値のデータは完全に分離されます
-- 同じテナント内では、`Fiware-ServicePath` を使用してデータを階層的に整理できます
-- テナント名は自動的に小文字に変換されます
 
-### ServicePathの仕様
+* 異なる `Fiware-Service` 値のデータは完全に分離されます
+  
+* 同じテナント内では、`Fiware-ServicePath` を使用してデータを階層的に整理できます
+  
+* テナント名は自動的に小文字に変換されます
+
+### ServicePath仕様
 
 [FIWARE Orion 仕様](https://fiware-orion.readthedocs.io/en/1.3.0/user/service_path/index.html) に準拠しています。
 
 #### 基本形式
 
-- `/` で始まる絶対パスのみ許可されます
-- 英数字とアンダースコアのみ許可されます
-- 最大 10 階層、各レベル最大 50 文字
+
+* `/` で始まる絶対パスのみが許可されます
+  
+* 英数字とアンダースコアのみが許可されます
+  
+* 最大 10 レベル、各レベルは最大 50 文字まで
 
 ```bash
 # Retrieve entities at a specific path
@@ -145,10 +174,11 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /Madrid/Gardens"
 ```
 
-#### 階層検索 (`/#`
+#### 階層検索(`/#`
+
 )
 
-`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます (**クエリ操作のみ**)。
+`/#` サフィックスを使用すると、指定されたパスとそのすべての子パスを検索できます(**クエリ操作のみ**)。
 
 ```bash
 # Search /Madrid/Gardens and all its child paths
@@ -157,9 +187,9 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /Madrid/Gardens/#"
 ```
 
-#### 複数パス (カンマ区切り)
+#### 複数パス(カンマ区切り)
 
-カンマで区切ることで、複数のパスを同時に検索できます (最大 10 パス、**クエリ操作のみ**)。
+カンマで区切ることで、複数のパスを同時に検索できます(最大 10 パス、**クエリ操作のみ**)。
 
 ```bash
 # Search both /park1 and /park2
@@ -168,42 +198,42 @@ curl "http://localhost:3000/v2/entities" \
   -H "Fiware-ServicePath: /park1, /park2"
 ```
 
-#### デフォルト動作
+#### デフォルトの動作
 
-| 操作 | ヘッダー省略時 | 説明 |
-|------|--------------|------|
-| クエリ (GET) | `/` | ルートパスのみ検索 |
-| 書き込み (POST/PUT/PATCH/DELETE) | `/` | ルートパスで作成/更新 |
+| Operation                     | When Header is Omitted | Description                |
+| ----------------------------- | ---------------------- | -------------------------- |
+| Query (GET)                   | `/`                    | Search root path only      |
+| Write (POST/PUT/PATCH/DELETE) | `/`                    | Create/update in root path |
 
-**注意**: 書き込み操作では、単一の非階層パスのみ使用できます。`/#` や複数パスを指定するとエラーになります。
+**注意**: 書き込み操作では、単一の非階層パスのみ使用できます。`/#` または複数のパスを指定するとエラーになります。
 
----
+***
 
 ## ページネーション
 
-ページネーションは、すべてのリスト型 API エンドポイントでサポートされています。
+ページネーションはすべてのリスト型 API エンドポイントでサポートされています。
 
 ### パラメータ
 
-| パラメータ | 説明 | デフォルト | 最大値 |
-|-----------|-------------|---------|---------|
-| `limit` | 返される結果の最大数 | 20 | 1000 (Admin API: 100) |
-| `offset` | スキップする結果の数 | 0 | - |
+| Parameter | Description                         | Default | Maximum               |
+| --------- | ----------------------------------- | ------- | --------------------- |
+| `limit`   | Maximum number of results to return | 20      | 1000 (Admin API: 100) |
+| `offset`  | Number of results to skip           | 0       | -                     |
 
 ### レスポンスヘッダー
 
-各 API タイプごとに、合計数を示すヘッダーが返されます:
+各 API タイプに対して、合計カウントを示すヘッダーが返されます:
 
-| API | ヘッダー名 | 条件 |
-|-----|-------------|-----------|
-| NGSIv2 | `Fiware-Total-Count` | 常に返される (すべてのリストエンドポイント) |
-| NGSI-LD | `NGSILD-Results-Count` | 常に返される |
-| Admin API | `X-Total-Count` | 常に返される |
-| Catalog API | `X-Total-Count` | 常に返される |
+| API         | Header Name            | Condition                            |
+| ----------- | ---------------------- | ------------------------------------ |
+| NGSIv2      | `Fiware-Total-Count`   | Always returned (all list endpoints) |
+| NGSI-LD     | `NGSILD-Results-Count` | Always returned                      |
+| Admin API   | `X-Total-Count`        | Always returned                      |
+| Catalog API | `X-Total-Count`        | Always returned                      |
 
 ### Link ヘッダー
 
-すべてのリストエンドポイントは、[RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) に準拠した `Link` ヘッダーを返し、次のページ (`rel="next"`) と前のページ (`rel="prev"`) の URL を提供します。結果が 1 ページに収まる場合、`Link` ヘッダーは返されません。
+すべてのリストエンドポイントは、[RFC 8288](https://www.rfc-editor.org/rfc/rfc8288) に準拠した `Link` ヘッダーを返し、次のページ (`rel="next"`) と前のページ (`rel="prev"`) の URL を提供します。結果が単一ページに収まる場合、`Link` ヘッダーは返されません。
 
 ```http
 Link: <https://api.example.com/v2/entities?limit=10&offset=20>; rel="next", <https://api.example.com/v2/entities?limit=10&offset=0>; rel="prev"
@@ -213,13 +243,13 @@ Link: <https://api.example.com/v2/entities?limit=10&offset=20>; rel="next", <htt
 
 無効なページネーションパラメータは `400 Bad Request` を返します:
 
-| エラー条件 | エラーメッセージ |
-|-----------------|---------------|
-| 負の limit | `Invalid limit: must not be negative` |
-| 負の offset | `Invalid offset: must not be negative` |
-| limit=0 | `Invalid limit: must be greater than 0` |
-| 最大値を超過 | `Invalid limit: must not exceed 1000` |
-| 数値以外 | `Invalid limit: must be a valid integer` |
+| Error Condition | Error Message                            |
+| --------------- | ---------------------------------------- |
+| Negative limit  | `Invalid limit: must not be negative`    |
+| Negative offset | `Invalid offset: must not be negative`   |
+| limit=0         | `Invalid limit: must be greater than 0`  |
+| Exceeds maximum | `Invalid limit: must not exceed 1000`    |
+| Non-numeric     | `Invalid limit: must be a valid integer` |
 
 ### 使用例
 
@@ -235,53 +265,55 @@ curl "http://localhost:3000/v2/entities?limit=10&options=count" \
 
 ### 注意事項
 
-- `offset` が合計数を超える場合、空の配列が返されます (エラーではありません)
-- FIWARE Orion の仕様に準拠しています
 
----
+* `offset` が合計カウントを超えた場合、空の配列が返されます(エラーではありません)
+  
+* FIWARE Orion 仕様に準拠しています
 
-## HTTP キャッシュコントロール (ETag / 条件付きリクエスト)
+***
 
-GET エンドポイントはエンドポイントクラスに基づいてキャッシュ関連ヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップでき、[RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠しています。
+## HTTP キャッシュ制御 (ETag / 条件付きリクエスト)
+
+GET エンドポイントは、エンドポイントクラスに基づいてキャッシュ関連のヘッダーを返します。クライアントはこれらを使用して、変更されていないレスポンスボディの転送をスキップでき、[RFC 7232](https://datatracker.ietf.org/doc/html/rfc7232) および [RFC 7234](https://datatracker.ietf.org/doc/html/rfc7234) に準拠します。
 
 ### エンドポイントクラス
 
-| クラス | エンドポイント | バリデータ (ETag/Last-Modified) | 条件付きリクエスト | Cache-Control |
-|-------|-----------|-------------------------------|----------------------|---------------|
-| **Data** | `/v2/entities` (リスト、単一、attrs、attrs/{name}、attrs/{name}/value)、`/v2/subscriptions`、`/v2/registrations`、`/ngsi-ld/v1/entities` (リスト、単一、attrs、attrs/{name})、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions` | ✓ | ✓ (`If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache` |
-| **Temporal** | `/ngsi-ld/v1/temporal/entities` (リストと単一、集約を含む) | ✗ (ETag なし — 時系列集約には安価な単調バリデータがない) | ✗ | `private, no-cache` |
-| **Meta** | `/v2/types`、`/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes` (リストと単一) | ✗ (ETag なし、Last-Modified なし) | ✗ (`304` サポートなし) | `max-age=60, stale-while-revalidate=120` |
+| Class        | Endpoints                                                                                                                                                                                                                                                                         | Validator (ETag/Last-Modified)                                        | Conditional Requests                              | Cache-Control                            |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------- | ---------------------------------------- |
+| **Data**     | `/v2/entities` (list, single, attrs, attrs/{name}, attrs/{name}/value), `/v2/subscriptions`, `/v2/registrations`, `/ngsi-ld/v1/entities` (list, single, attrs, attrs/{name}), `/ngsi-ld/v1/subscriptions`, `/ngsi-ld/v1/csourceRegistrations`, `/ngsi-ld/v1/csourceSubscriptions` | ✓                                                                     | ✓ (`If-None-Match` / `If-Modified-Since` → `304`) | `private, no-cache`                      |
+| **Temporal** | `/ngsi-ld/v1/temporal/entities` (list, single, including aggregation)                                                                                                                                                                                                             | ✗ (no ETag — time-series aggregation lacks cheap monotonic validator) | ✗                                                 | `private, no-cache`                      |
+| **Meta**     | `/v2/types`, `/ngsi-ld/v1/types`, `/ngsi-ld/v1/attributes` (list and single)                                                                                                                                                                                                      | ✗ (no ETag, no Last-Modified)                                         | ✗ (no `304` support)                              | `max-age=60, stale-while-revalidate=120` |
 
-すべてのキャッシュ制御されたレスポンスは同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーション分離、CloudFront のような共有キャッシュに必要)。
+すべてのキャッシュ制御されたレスポンスは、同じ `Vary` ヘッダーを共有します: `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` (テナント + 認証 + コンテンツネゴシエーションの分離、CloudFront のような共有キャッシュに必要)。
 
-### レスポンスヘッダー (Data エンドポイント)
+### レスポンスヘッダー (データエンドポイント)
 
-| ヘッダー | 説明 |
-|--------|-------------|
-| `ETag` | 弱いエンティティタグ (`W/"..."`、RFC 7232 §2.3.2 弱いバリデータ)。生成は常に **リソーススコープ** (`path + Accept + tenant + Fiware-ServicePath`) をシードに混ぜ込むため、異なるエンドポイント、Accept フォーマット、**テナント**、または **ServicePath** は、基礎となる状態が同一であっても異なる ETag を生成します。`tenant` スロットは最初に `NGSILD-Tenant` を読み取り、`Fiware-Service` にフォールバックし、`extractTenantContext` の優先順位と一致します。テナント / ServicePathシードは、中間キャッシュが `Vary` を誤って処理した場合でも、テナント間の ETag 衝突を防ぎます。<br>• **リスト**: 各要素の `id + modifiedAt` のストリーミングダイジェスト、合計カウントとリソーススコープと組み合わせ。<br>• **単一リソース**: `modifiedAt` のハッシュとリソーススコープの組み合わせ。|
-| `Last-Modified` | 結果セット内の最新の `modifiedAt` の RFC 1123 HTTP 日付。|
-| `Cache-Control` | `private, no-cache` — `private` は共有 / 中間キャッシュ (CloudFront、ISP プロキシ、企業プロキシ) への保存を禁止します。`no-cache` はプライベートキャッシュからの再利用前に再検証を強制します。|
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`。|
+| Header          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETag`          | Weak entity tag (`W/"..."`, RFC 7232 §2.3.2 weak validator). Generation always mixes a **resource scope** (`path + Accept + tenant + Fiware-ServicePath`) into the seed so that different endpoints, Accept formats, **tenants**, or **service paths** produce distinct ETags even when the underlying state is identical. The `tenant` slot reads `NGSILD-Tenant` first and falls back to `Fiware-Service`, matching `extractTenantContext` precedence. The tenant / servicePath seed defends against cross-tenant ETag collision even if `Vary` is mishandled by an intermediate cache. <br>• **Lists**: streaming digest of each element's `id + modifiedAt`, combined with the total count and the resource scope. <br>• **Single resources**: hash of `modifiedAt` combined with the resource scope. |
+| `Last-Modified` | RFC 1123 HTTP-date of the latest `modifiedAt` in the result set.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `Cache-Control` | `private, no-cache` — `private` forbids storage in shared / intermediate caches (CloudFront, ISP proxies, corporate proxies). `no-cache` forces revalidation before reuse from a private cache.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
-### レスポンスヘッダー (Meta エンドポイント)
+### レスポンスヘッダー (メタエンドポイント)
 
-| ヘッダー | 説明 |
-|--------|-------------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — バックグラウンド再検証による短期キャッシング。|
-| `Vary` | Data エンドポイントと同じ。|
+| Header          | Description                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------- |
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120` — short-term caching with background revalidation. |
+| `Vary`          | Same as data endpoints.                                                                     |
 
-Meta エンドポイントは意図的に `ETag` / `Last-Modified` を省略します。これは、そのコンテンツが安価な単調バリデータを持たない集約クエリから派生しているためです。クライアントは条件付きリクエストではなく `max-age` に依存する必要があります。
+メタエンドポイントは、意図的に `ETag` / `Last-Modified` を省略しています。これは、それらのコンテンツが集約クエリから導出されており、安価な単調バリデータを持たないためです。クライアントは、条件付きリクエストの代わりに `max-age` に依存する必要があります。
 
-### 条件付きリクエスト (Data エンドポイントのみ)
+### 条件付きリクエスト (データエンドポイントのみ)
 
-クライアントは条件付きリクエストヘッダーを送信して、結果が変更されていない場合に `304 Not Modified` (空のボディ) を受け取ることができます:
+クライアントは、条件付きリクエストヘッダーを送信して、結果が変更されていない場合に `304 Not Modified` (空のボディ) を受信できます:
 
-| リクエストヘッダー | 動作 |
-|----------------|----------|
-| `If-None-Match: <ETag>` | サーバーは現在の `ETag` と比較します。一致する場合、`304` を返します。ワイルドカード `*` は常に一致します。|
-| `If-Modified-Since: <HTTP-date>` | サーバーは現在の `Last-Modified` と比較します。変更されていない場合、`304` を返します。|
+| Request Header                   | Behavior                                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------------------------- |
+| `If-None-Match: <ETag>`          | Server compares with current `ETag`. If matched, returns `304`. Wildcard `*` always matches. |
+| `If-Modified-Since: <HTTP-date>` | Server compares with current `Last-Modified`. If unchanged, returns `304`.                   |
 
-両方のヘッダーが存在する場合、RFC 7232 §6 に従い `If-None-Match` が優先されます。
+両方のヘッダーが存在する場合、RFC 7232 §6 に従って `If-None-Match` が優先されます。
 
 ### 例
 
@@ -302,26 +334,38 @@ curl -i "http://localhost:3000/v2/entities" \
 # Last-Modified: Sun, 26 Apr 2026 00:00:00 GMT
 ```
 
-### 注記
+### 注意事項
 
-- ETag は弱い (`W/`) です — これらはバイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータを持つが属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
-- ETag 生成はリソースパスと `Accept` ヘッダーをシードに含めます。異なるエンドポイントと異なるコンテンツネゴシエーションは、基礎となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
-- `304` レスポンスは `ETag`、`Last-Modified`、`Cache-Control`、`Vary`、および CORS ヘッダーを保持します。
-- 条件評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
-- キャッシュコントロールは以下に適用されます:
-  - **NGSIv2**: `/v2/entities` (リスト / 単一 / attrs / attrs+name / attrs+name+value)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`  - **NGSI-LD Data**: `/ngsi-ld/v1/entities` (リスト / 単一 / attrs / attrs+name)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`  - **NGSI-LD Meta**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`  - **NGSI-LD Temporal**: `/ngsi-ld/v1/temporal/entities` (リストと単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
 
-### クライアント主導のキャッシュコントロール
+* ETag は弱い (`W/`) です — バイト単位の同一性ではなく、意味的な等価性を伝えます。同じデータでも属性の順序が異なる 2 つのレスポンスは、同じ ETag を共有します。
+  
+* ETag 生成には、シード内にリソースパスと `Accept` ヘッダーが含まれます。異なるエンドポイントと異なるコンテンツネゴシエーションは、基礎となる状態 (例: 空のリスト) が同一であっても、常に異なる ETag を生成し、エンドポイント間または Accept 間のキャッシュポイズニングを防ぎます。
+  
+* `304` レスポンスは、`ETag`、`Last-Modified`、`Cache-Control`、`Vary`、および CORS ヘッダーを保持します。
+  
+* 条件付き評価は、ステータス `200` の `GET` および `HEAD` リクエストに適用されます。`HEAD` は、空のボディで `GET` と同じヘッダーを返し (RFC 7231 §4.3.2)、`200` でもボディを転送せずに軽量な再検証を可能にします。
+  
+* キャッシュ制御は以下に適用されます:
+  
+  * **NGSIv2**: `/v2/entities` (リスト / 単一 / 属性 / 属性+名前 / 属性+名前+値)、`/v2/subscriptions`、`/v2/registrations`、`/v2/types`
+    
+  * **NGSI-LD Data**: `/ngsi-ld/v1/entities` (リスト / 単一 / 属性 / 属性+名前)、`/ngsi-ld/v1/subscriptions`、`/ngsi-ld/v1/csourceRegistrations`、`/ngsi-ld/v1/csourceSubscriptions`
+    
+  * **NGSI-LD Meta**: `/ngsi-ld/v1/types`、`/ngsi-ld/v1/attributes`
+    
+  * **NGSI-LD Temporal**: `/ngsi-ld/v1/temporal/entities` (リストと単一、`Cache-Control` のみ — `ETag` / `Last-Modified` なし)
 
-クライアントは `Cache-Control` リクエストヘッダーを送信して、キャッシング動作に影響を与えることができます:
+### クライアント駆動のキャッシュ制御
 
-| リクエストヘッダー | サーバーの動作 |
-|----------------|-----------------|
-| `Cache-Control: no-store` | サーバーはレスポンス `Cache-Control` を `no-store` にオーバーライドします (CDN / 中間キャッシュ抑制ヒント)。|
-| `Cache-Control: no-cache` | サーバーは特別なオーバーライドを行いません; エンドポイントのデフォルトポリシーが引き続き適用されます (data → 再検証; meta → `max-age=60` など)。|
-| `Cache-Control: max-age=N` | エッジキャッシュレイヤー用に予約済み (Phase 3 / CloudFront)。Lambda サーバー自体はステートレスであり、このディレクティブを解釈しません。|
+クライアントは、`Cache-Control` リクエストヘッダーを送信して、キャッシュ動作に影響を与えることができます:
 
----
+| Request Header             | Server Behavior                                                                                                                    |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `Cache-Control: no-store`  | Server overrides response `Cache-Control` to `no-store` (CDN/intermediary cache suppression hint).                                 |
+| `Cache-Control: no-cache`  | Server makes no special override; the endpoint's default policy still applies (data → revalidation; meta → `max-age=60` etc).      |
+| `Cache-Control: max-age=N` | Reserved for edge-cache layer (Phase 3 / CloudFront). The Lambda server itself is stateless and does not interpret this directive. |
+
+***
 
 ## 認証 API
 
@@ -329,29 +373,29 @@ curl -i "http://localhost:3000/v2/entities" \
 
 ### 有効化
 
-認証はデフォルトで無効になっています。以下の環境変数で有効化できます。
+認証はデフォルトで無効になっています。以下の環境変数で有効にすることができます。
 
-**注意**: `AUTH_ENABLED=false` の場合、認証関連のエンドポイント (`/auth/*`、`/me`、`/me/*`、`/admin/*`) は 404 を返します。
+**注意**: `AUTH_ENABLED=false` の場合、認証関連のエンドポイント(`/auth/*`、`/me`、`/me/*`、`/admin/*`)は 404 を返します。
 
-**重要**: `AUTH_ENABLED=true` の場合、NGSI API エンドポイント (`/v2/*`、`/ngsi-ld/*`、`/catalog/*`) へのアクセスには認証が必要です。認証なしでアクセスすると `401 Unauthorized` エラーが返されます。
+**重要**: `AUTH_ENABLED=true` の場合、NGSI API エンドポイント(`/v2/*`、`/ngsi-ld/*`、`/catalog/*`)へのアクセスには認証が必要です。認証なしでアクセスすると `401 Unauthorized` エラーが返されます。
 
-| 環境変数 | デフォルト | 説明 |
-|---------|-----------|------|
-| `AUTH_ENABLED` | `false` | 認証を有効化 |
-| `JWT_SECRET` | - | JWT トークン署名用のシークレット (32 文字以上推奨) |
-| `JWT_EXPIRES_IN` | `1h` | アクセストークンの有効期限 |
-| `JWT_REFRESH_EXPIRES_IN` | `7d` | リフレッシュトークンの有効期限 |
-| `SUPER_ADMIN_EMAIL` | - | 環境変数で設定されるスーパー管理者のメールアドレス |
-| `SUPER_ADMIN_PASSWORD` | - | 環境変数で設定されるスーパー管理者のパスワード |
-| `ADMIN_ALLOWED_IPS` | - | Admin API へのアクセスを許可する IP/CIDR (カンマ区切り) |
+| Environment Variable     | Default | Description                                                 |
+| ------------------------ | ------- | ----------------------------------------------------------- |
+| `AUTH_ENABLED`           | `false` | Enable authentication                                       |
+| `JWT_SECRET`             | -       | Secret for JWT token signing (32+ characters recommended)   |
+| `JWT_EXPIRES_IN`         | `1h`    | Access token expiration                                     |
+| `JWT_REFRESH_EXPIRES_IN` | `7d`    | Refresh token expiration                                    |
+| `SUPER_ADMIN_EMAIL`      | -       | Super admin email address set via environment variable      |
+| `SUPER_ADMIN_PASSWORD`   | -       | Super admin password set via environment variable           |
+| `ADMIN_ALLOWED_IPS`      | -       | IPs/CIDRs allowed to access the Admin API (comma-separated) |
 
-### ロールと権限
+### ロールとパーミッション
 
-| ロール | 説明 | 権限 |
-|-------|------|------|
-| `super_admin` | スーパー管理者 | `/admin/*`、`/auth/*`、`/me/*`、監視エンドポイントのみ。データ API (`/v2/*`、`/ngsi-ld/*`、`/catalog*`、`/rules*`) にはアクセス**できません** — 403 を返します |
-| `tenant_admin` | テナント管理者 | 自分のテナント内のユーザーを管理 |
-| `user` | 一般ユーザー | 自分のプロフィール表示とパスワード変更のみ |
+| Role           | Description          | Permissions                                                                                                                                          |
+| -------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `super_admin`  | Super administrator  | `/admin/*`, `/auth/*`, `/me/*`, monitoring endpoints only. **Cannot** access data APIs (`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`) — returns 403 |
+| `tenant_admin` | Tenant administrator | Manage users within their own tenant                                                                                                                 |
+| `user`         | General user         | View own profile and change password only                                                                                                            |
 
 ### ログイン
 
@@ -374,14 +418,14 @@ Content-Type: application/json
 }
 ```
 
-| パラメータ | 型 | 必須 | 説明 |
-|-----------|------|------|------|
-| `email` | string | はい | メールアドレス |
-| `password` | string | はい | パスワード |
-| `tenantId` | string | いいえ | 指定された場合、そのテナントにスコープされた JWT を発行します。省略時はプライマリテナントがデフォルト |
-| `resourceScopes` | ResourceScope[] | いいえ | エンティティレベルのアクセス制御スコープ。省略時は完全アクセス。詳細は AUTH.md を参照 |
+| Parameter        | Type             | Required | Description                                                                                                                                   |
+| ---------------- | ---------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `email`          | string           | Yes      | Email address                                                                                                                                 |
+| `password`       | string           | Yes      | Password                                                                                                                                      |
+| `tenantId`       | string           | No       | If specified, issues a JWT scoped to that tenant. Defaults to primary tenant if omitted                                                       |
+| `resourceScopes` | ResourceScope\[] | No       | Entity-level access control scopes. Full access if omitted. See [AUTH.md](../reference/auth.md#resource-scopesgeonicdb-extension) for details |
 
-**テナントヘッダーのサポート**: ボディ内の `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダー経由でテナントを指定できます (テナント名で解決)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダー値は `^[a-z0-9_]+$` と一致する必要があります。
+**テナントヘッダーのサポート**: ボディの `tenantId` の代わりに、`NGSILD-Tenant` または `Fiware-Service` ヘッダーでテナントを指定できます(テナント名で解決されます)。優先順位: `body.tenantId` > ヘッダー > プライマリテナント。ヘッダーの値は `^[a-z0-9_]+$` に一致する必要があります。
 
 **レスポンス例**
 
@@ -400,7 +444,7 @@ Content-Type: application/json
 }
 ```
 
-### トークンリフレッシュ
+### トークンのリフレッシュ
 
 ```http
 POST /auth/refresh
@@ -417,7 +461,7 @@ Content-Type: application/json
 
 **レスポンス**: ログインと同じ形式
 
-### 現在のユーザー情報取得
+### 現在のユーザー情報を取得
 
 ```http
 GET /me
@@ -436,7 +480,7 @@ Authorization: Bearer <accessToken>
 }
 ```
 
-### パスワード変更
+### パスワードの変更
 
 ```http
 POST /me/password
@@ -453,7 +497,9 @@ Content-Type: application/json
 }
 ```
 
-**レスポンス**: `204 No Content`**注意**: パスワード変更後、既存のすべてのアクセストークンとリフレッシュトークンが無効化されます。新しいトークンを取得するため、再度ログインしてください。
+**レスポンス**: `204 No Content`
+
+**注意**: パスワード変更後、既存のアクセストークンとリフレッシュトークンはすべて無効化されます。新しいトークンを取得するには、再度ログインしてください。
 
 ### ログアウト
 
@@ -462,12 +508,13 @@ POST /auth/logout
 Authorization: Bearer <accessToken>
 ```
 
-すべてのセッションを無効化します。このユーザーに対して発行されたすべてのアクセストークンとリフレッシュトークンが即座に無効化されます。
+すべてのセッションを無効化します。このユーザーに発行されたすべてのアクセストークンとリフレッシュトークンは直ちに無効化されます。
 
 **レスポンス**: `204 No Content`
-### API キー トークン交換
 
-#### Nonce の取得
+### API Key トークン交換
+
+#### Nonce を取得
 
 ```http
 POST /auth/nonce
@@ -487,7 +534,7 @@ Origin: https://example.com
 }
 ```
 
-#### トークンの交換
+#### トークンを交換
 
 ```http
 POST /oauth/token
@@ -513,11 +560,11 @@ Origin: https://example.com
 }
 ```
 
-**DPoP トークン バインディング**(オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明キーにバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を必要とします — 最初のリクエストは `DPoP-Nonce` ヘッダーと共に `400 use_dpop_nonce` を返します。証明の `nonce` クレームに nonce を含めて再試行してください。詳細は AUTH.md を参照してください。
+**DPoP トークンバインディング**(オプション): [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に従って、ECDSA P-256 証明 JWT を含む `DPoP` ヘッダーを含めます。これが存在する場合、レスポンスの `token_type` は `"DPoP"` になり、JWT には証明鍵にバインドする `cnf.jkt` クレームが含まれます。サーバーは DPoP-Nonce (RFC 9449 §8) を必要とします。最初のリクエストは `DPoP-Nonce` ヘッダー付きの `400 use_dpop_nonce` を返すので、証明の `nonce` クレームに nonce を含めて再試行してください。詳細については [AUTH.md](../reference/auth.md#dpop-token-binding-rfc-9449) を参照してください。
 
-### 管理 API
+### Admin API
 
-管理 API は `super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセス可能です。
+Admin API は、`super_admin` または `tenant_admin` ロールを持つユーザーのみがアクセスできます。
 
 #### ユーザー一覧
 
@@ -528,12 +575,12 @@ Authorization: Bearer <accessToken>
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `tenantId` | テナント ID でフィルター (super_admin のみ) |
-| `role` | ロールでフィルター |
-| `limit` | 取得する結果の数 |
-| `offset` | オフセット |
+| Parameter  | Description                             |
+| ---------- | --------------------------------------- |
+| `tenantId` | Filter by tenant ID (super\_admin only) |
+| `role`     | Filter by role                          |
+| `limit`    | Number of results to retrieve           |
+| `offset`   | Offset                                  |
 
 #### ユーザー作成
 
@@ -593,7 +640,7 @@ POST /admin/users/{userId}/deactivate
 Authorization: Bearer <accessToken>
 ```
 
-#### ログインのロック解除
+#### ログインロックの解除
 
 ブルートフォース保護によってロックされたアカウントのロックを解除します。
 
@@ -614,7 +661,7 @@ Authorization: Bearer <accessToken>
 }
 ```
 
-### テナント管理 (super_admin のみ)
+### テナント管理 (super\_admin のみ)
 
 #### テナント一覧
 
@@ -643,7 +690,7 @@ Content-Type: application/json
 }
 ```
 
-> **注意**: テナント名には小文字の英数字とアンダースコアのみを含める必要があります (`^[a-z0-9_]+$`)。
+> **注意**: テナント名は小文字の英数字とアンダースコアのみを含む必要があります (`^[a-z0-9_]+$`)。
 
 #### テナント取得
 
@@ -667,7 +714,7 @@ DELETE /admin/tenants/{tenantId}
 Authorization: Bearer <accessToken>
 ```
 
-**カスケード削除**: テナントが削除されると、関連するすべてのデータ (エンティティ、サブスクリプション、登録、ルール、ポリシー、ユーザー、メンバーシップ、および全 16 コレクション) が自動的にカスケード削除されます。削除が開始される前に、テナントは自動的に無効化され、新しい API リクエストがブロックされます。
+**カスケード削除**: テナントが削除されると、関連するすべてのデータ (エンティティ、サブスクリプション、レジストレーション、ルール、ポリシー、ユーザー、メンバーシップ、およびすべての 16 コレクション) が自動的にカスケード削除されます。削除が開始される前に、テナントは新しい API リクエストをブロックするために自動的に無効化されます。
 
 #### テナントの有効化/無効化
 
@@ -679,11 +726,13 @@ Authorization: Bearer <accessToken>
 
 ### カスタムデータモデル管理
 
-> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については [カスタムデータモデル API](#カスタムデータモデル-api) セクションを参照してください。
+> **注意**: カスタムデータモデル API は `/custom-data-models` に移動しました。詳細については、[Custom Data Models API](#custom-data-models-api) セクションを参照してください。
 
 ### IP 制限
 
-`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます。
+**SaaS 利用者の方へ**: これは tenant 設定 API 経由で設定されます。詳細は Geolonia サポートにお問い合わせください。
+
+`ADMIN_ALLOWED_IPS` 環境変数を設定することで、Admin API (`/admin/*`) へのアクセスを特定の IP アドレスに制限できます:
 
 ```bash
 # Single IP
@@ -696,11 +745,11 @@ ADMIN_ALLOWED_IPS=192.168.1.100,10.0.0.50
 ADMIN_ALLOWED_IPS=192.168.1.0/24,10.0.0.0/8
 ```
 
-許可されていない IP からのアクセスは `403 Forbidden` エラーとなります。
+未承認の IP からのアクセスは `403 Forbidden` エラーになります。
 
-#### テナント毎の IP 制限
+#### テナント単位の IP 制限
 
-テナント毎に個別の IP 制限を設定できます。テナントレベルの設定が存在する場合は、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
+個別の IP 制限は、テナントごとに設定できます。テナントレベルの設定が存在する場合、グローバル設定 (`ADMIN_ALLOWED_IPS`) よりも優先されます。
 
 ```http
 GET /admin/tenants/{tenantId}/ip-restrictions
@@ -709,15 +758,16 @@ DELETE /admin/tenants/{tenantId}/ip-restrictions
 Authorization: Bearer <accessToken>
 ```
 
-スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかを指定できます。詳細は AUTH.md を参照してください。
+スコープは `admin` (Admin API のみ) または `all` (すべての API) のいずれかになります。詳細については、[AUTH.md](../reference/auth.md#per-tenant-ip-restrictions) を参照してください。
 
-### ルールエンジン管理（tenant_admin）
+### ルールエンジン管理 (tenant\_admin)
 
 エンティティの変更を自動的に処理するルールを管理します。`tenant_admin` ロールが必要です。`AUTH_ENABLED=true` の場合、`super_admin` は `/rules*` エンドポイントにアクセスできません。
 
-- **REACTIVCORE_RULES.md** - ユーザーガイド(使用例、管理 API など)
 
-#### ルール一覧の取得
+* **[REACTIVCORE\_RULES.md](../features/reactivcore-rules.md)** - ユーザーガイド (使用例、Admin API など)
+
+#### ルール一覧
 
 ```http
 GET /rules
@@ -726,14 +776,14 @@ Authorization: Bearer <accessToken>
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 結果の件数(デフォルト: 20、最大: 100) |
-| `offset` | オフセット(デフォルト: 0) |
-| `servicePath` | ServicePathでフィルタ |
-| `isActive` | アクティブ/非アクティブでフィルタ(`true` / `false`) |
+| Parameter     | Description                                  |
+| ------------- | -------------------------------------------- |
+| `limit`       | Number of results (default: 20, max: 100)    |
+| `offset`      | Offset (default: 0)                          |
+| `servicePath` | Filter by service path                       |
+| `isActive`    | Filter by active/inactive (`true` / `false`) |
 
-#### ルールの作成
+#### ルール作成
 
 ```http
 POST /rules
@@ -772,14 +822,14 @@ Content-Type: application/json
 }
 ```
 
-#### ルールの取得
+#### ルール取得
 
 ```http
 GET /rules/{ruleId}
 Authorization: Bearer <accessToken>
 ```
 
-#### ルールの更新
+#### ルール更新
 
 ```http
 PATCH /rules/{ruleId}
@@ -787,7 +837,9 @@ Authorization: Bearer <accessToken>
 Content-Type: application/json
 ```
 
-レスポンス: `204 No Content`#### ルールの削除
+レスポンス: `204 No Content`
+
+#### ルール削除
 
 ```http
 DELETE /rules/{ruleId}
@@ -804,102 +856,115 @@ Authorization: Bearer <accessToken>
 
 #### クロスプロトコルアクション
 
-ルールアクション(`createEntity`、`updateAttribute`、`deleteAttribute`)は、プロトコル境界を越えて動作するためのオプションフィールド `protocol` をサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
+ルールアクション (`createEntity`、`updateAttribute`、`deleteAttribute`) は、プロトコル境界を越えて動作するためのオプションの `protocol` フィールドをサポートしています。`createEntity` アクションは、階層制御のための `servicePath` および `scope` フィールドもサポートしています。
 
-| フィールド | アクション | 型 | 説明 |
-|---|---|---|---|
-| `protocol` | createEntity、updateAttribute、deleteAttribute | `'ngsiv2' \| 'ngsild'` | ターゲットプロトコル(デフォルト: トリガーから継承) |
-| `servicePath` | createEntity | `string` | NGSIv2 のターゲット servicePath (テンプレート変数をサポート) |
-| `scope` | createEntity | `string[]` | NGSI-LD のターゲットスコープ(テンプレート変数をサポート) |
+| Field         | Actions                                        | Type                         | Description                                                 |
+| ------------- | ---------------------------------------------- | ---------------------------- | ----------------------------------------------------------- |
+| `protocol`    | createEntity, updateAttribute, deleteAttribute | `'ngsiv2' \| 'ngsild'` | Target protocol (default: inherit from trigger)             |
+| `servicePath` | createEntity                                   | `string`                     | Target servicePath for NGSIv2 (supports template variables) |
+| `scope`       | createEntity                                   | `string[]`                   | Target scope for NGSI-LD (supports template variables)      |
 
-プロトコルを越える場合、servicePath ↔ scope は自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` は、トリガーエンティティのコンテキストを参照します。
+プロトコルをまたぐ場合、servicePath ↔ scope は自動的にマッピングされます。テンプレート変数 `${trigger.protocol}`、`${trigger.servicePath}`、`${trigger.scope}`、`${trigger.service}` はトリガーエンティティのコンテキストを参照します。
 
-詳細な例とマッピングルールについては、**REACTIVCORE_RULES.md** を参照してください。
+詳細な例とマッピングルールについては、**[REACTIVCORE\_RULES.md](../features/reactivcore-rules.md)** を参照してください。
 
----
+***
 
 ## OAuth 2.0 API (M2M 認証)
 
 OAuth 2.0 Client Credentials Grant フローを使用した Machine-to-Machine (M2M) 認証がサポートされています。
 
 **主要なエンドポイント:**
-- `POST /oauth/token` - トークン取得 (Basic 認証)
-- `POST /admin/oauth-clients` - クライアント作成 (管理者)
-- `GET /admin/oauth-clients` - クライアント一覧 (管理者)
-- `POST /admin/oauth-clients/{clientId}/regenerate-secret` - シークレット再生成 (管理者)
-- `POST /me/oauth-clients` - 自分のクライアント作成 (セルフサービス)
-- `GET /me/oauth-clients` - 自分のクライアント一覧 (セルフサービス)
-- `DELETE /me/oauth-clients/{clientId}` - 自分のクライアント削除 (セルフサービス)
-- `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自分のシークレット再生成 (セルフサービス)
 
-**有効化:** `AUTH_ENABLED=true` の場合、OAuth 2.0 は常に有効になります。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
+* `POST /oauth/token` - トークン取得 (Basic 認証)
+  
+* `POST /admin/oauth-clients` - クライアント作成 (管理者)
+  
+* `GET /admin/oauth-clients` - クライアント一覧 (管理者)
+  
+* `POST /admin/oauth-clients/{clientId}/regenerate-secret` - シークレット再生成 (管理者)
+  
+* `POST /me/oauth-clients` - 自分のクライアントを作成 (セルフサービス)
+  
+* `GET /me/oauth-clients` - 自分のクライアント一覧 (セルフサービス)
+  
+* `DELETE /me/oauth-clients/{clientId}` - 自分のクライアントを削除 (セルフサービス)
+  
+* `POST /me/oauth-clients/{clientId}/regenerate-secret` - 自分のシークレットを再生成 (セルフサービス)
+
+**有効化:** OAuth 2.0 は `AUTH_ENABLED=true` の場合、常に有効です。`OAUTH_ENABLED` 環境変数は非推奨であり、無視されます。
 
 **利用可能なスコープ:**
 
-| スコープ | 説明 | `user` | `tenant_admin` | `super_admin` |
-|-------|-------------|:------:|:---------------:|:--------------:|
-| `read:entities` | エンティティの読み取り | ✅ | ✅ | ✅ |
-| `write:entities` | エンティティの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:subscriptions` | サブスクリプションの読み取り | ✅ | ✅ | ✅ |
-| `write:subscriptions` | サブスクリプションの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:registrations` | 登録の読み取り | ✅ | ✅ | ✅ |
-| `write:registrations` | 登録の書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:rules` | ルールの読み取り | ✅ | ✅ | ✅ |
-| `write:rules` | ルールの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `read:custom-data-models` | カスタムデータモデルの読み取り | ✅ | ✅ | ✅ |
-| `write:custom-data-models` | カスタムデータモデルの書き込み (作成/更新/削除のみ) | ✅ | ✅ | ✅ |
-| `admin:users` | ユーザー管理 API | ❌ | ✅ | ✅ |
-| `admin:policies` | ポリシー管理 API | ❌ | ✅ | ✅ |
-| `admin:oauth-clients` | OAuth クライアント管理 API | ❌ | ✅ | ✅ |
-| `admin:metrics` | メトリクス API | ❌ | ✅ | ✅ |
-| `admin:tenants` | テナント管理 API | ❌ | ❌ | ✅ |
-| `permanent` | トークンが期限切れにならない | — | — | — |
-| `jwt` | JWT 形式のトークン | — | — | — |
+| Scope                      | Description                                          | `user` | `tenant_admin` | `super_admin` |
+| -------------------------- | ---------------------------------------------------- | :----: | :------------: | :-----------: |
+| `read:entities`            | Read entities                                        |    ✅   |        ✅       |       ✅       |
+| `write:entities`           | Write entities (create/update/delete only)           |    ✅   |        ✅       |       ✅       |
+| `read:subscriptions`       | Read subscriptions                                   |    ✅   |        ✅       |       ✅       |
+| `write:subscriptions`      | Write subscriptions (create/update/delete only)      |    ✅   |        ✅       |       ✅       |
+| `read:registrations`       | Read registrations                                   |    ✅   |        ✅       |       ✅       |
+| `write:registrations`      | Write registrations (create/update/delete only)      |    ✅   |        ✅       |       ✅       |
+| `read:rules`               | Read rules                                           |    ✅   |        ✅       |       ✅       |
+| `write:rules`              | Write rules (create/update/delete only)              |    ✅   |        ✅       |       ✅       |
+| `read:custom-data-models`  | Read custom data models                              |    ✅   |        ✅       |       ✅       |
+| `write:custom-data-models` | Write custom data models (create/update/delete only) |    ✅   |        ✅       |       ✅       |
+| `admin:users`              | User management API                                  |    ❌   |        ✅       |       ✅       |
+| `admin:policies`           | Policy management API                                |    ❌   |        ✅       |       ✅       |
+| `admin:oauth-clients`      | OAuth client management API                          |    ❌   |        ✅       |       ✅       |
+| `admin:metrics`            | Metrics API                                          |    ❌   |        ✅       |       ✅       |
+| `admin:tenants`            | Tenant management API                                |    ❌   |        ❌       |       ✅       |
+| `permanent`                | Token never expires                                  |    —   |        —       |       —       |
+| `jwt`                      | JWT format token                                     |    —   |        —       |       —       |
 
-> ロール列は、セルフサービス (`/me/oauth-clients`) 経由でリクエスト可能なスコープを示します。管理者が作成したクライアント (`/admin/oauth-clients`) には、これらの制限は適用されません。
+> ロール列は、セルフサービス (`/me/oauth-clients`) 経由でリクエストできるスコープを示しています。管理者が作成したクライアント (`/admin/oauth-clients`) は、これらの制限の対象外です。
 
-**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ (JSON 文字列) を指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細は AUTH.md を参照してください。
+**リソーススコープ:** `POST /oauth/token` で `resource_scopes` パラメータ (JSON 文字列) を指定すると、エンティティレベルのアクセス制御を持つトークンが発行されます。詳細については、[AUTH.md](../reference/auth.md#resource-scopesgeonicdb-extension) を参照してください。
 
-**詳細:** AUTH.md の OAuth 2.0 セクションを参照してください。
+**詳細:** [AUTH.md](../reference/auth.md) の OAuth 2.0 セクションを参照してください。
 
----
+***
 
-## API キートークン交換 (ブラウザ SDK)
+## API キートークン交換 (Browser SDK)
 
-ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短時間有効なセッション JWT に交換できます。
+ブラウザベースのアプリケーションは、Nonce + Proof of Work を介して API キーを短期間有効なセッション JWT と交換できます。
 
 **主要なエンドポイント:**
-- `POST /auth/nonce` - Nonce + PoW チャレンジのリクエスト (API キー + Origin ヘッダーが必要)
-- `POST /oauth/token` (`grant_type=api_key`) - API キー + nonce + PoW 証明をセッション JWT に交換
+
+* `POST /auth/nonce` - Nonce + PoW チャレンジをリクエスト (API キー + Origin ヘッダーが必要)
+  
+* `POST /oauth/token` (`grant_type=api_key`) - API キー + nonce + PoW 証明をセッション JWT と交換
 
 **JavaScript SDK:** `npm install @geolonia/geonicdb-sdk` — トークン交換、DPoP、WebSocket、再接続を自動的に処理します。
 
-**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60 秒 TTL) → Proof of Work → 短時間有効な JWT (1 時間)
+**セキュリティレイヤー:** Origin 検証 → HMAC Nonce (60秒 TTL) → Proof of Work → 短期間有効な JWT (1時間)
 
-**詳細:** AUTH.md の API Key Token Exchange セクションおよび SDK ドキュメントで完全な API リファレンスを参照してください。
+**詳細:** 完全な API リファレンスについては、AUTH.md の [API Key Token Exchange](../reference/auth.md#api-key-token-exchange-browser-sdk) セクションおよび SDK ドキュメントを参照してください。
 
----
+***
 
 ## メタエンドポイント
 
-メタエンドポイントは認証を必要とせず、システムステータスと API 情報を提供します。
+メタエンドポイントは認証が不要で、システムステータスと API 情報を提供します。
 
-### API ドキュメント (llms.txt 形式)
+### API ドキュメント (llms.txt フォーマット)
 
 ```http
 GET /llms.txt
 ```
 
-AI フレンドリーな [llms.txt](https://llmstxt.org/) 形式で API ドキュメントを返します。AI エージェントや LLM が理解しやすいように構造化された Markdown 形式を使用します。
+AI フレンドリーな [llms.txt](https://llmstxt.org/) フォーマットで API ドキュメントを返します。AI エージェントや LLM が理解しやすいように構造化された Markdown フォーマットを使用します。
 
 **レスポンス**
-- Content-Type: `text/markdown; charset=utf-8`### API ドキュメント (JSON 形式)
+
+* Content-Type: `text/markdown; charset=utf-8`
+
+### API ドキュメント (JSON 形式)
 
 ```http
 GET /api.json
 ```
 
-JSON 形式で API エンドポイントの一覧を返します。
+JSON 形式で API エンドポイントのリストを返します。
 
 **レスポンス例**
 
@@ -918,16 +983,20 @@ JSON 形式で API エンドポイントの一覧を返します。
   }
 }
 ```
+
 ### OpenAPI 仕様
 
 ```http
 GET /openapi.json
 ```
 
-OpenAPI 3.0 仕様を JSON 形式で返します。Swagger UI や各種 API クライアント生成ツールで使用できます。
+JSON 形式で OpenAPI 3.0 仕様を返します。Swagger UI や各種 API クライアント生成ツールで使用できます。
 
 **レスポンス**
-- Content-Type: `application/json`- OpenAPI バージョン: 3.0.3
+
+* Content-Type: `application/json`
+  
+* OpenAPI バージョン: 3.0.3
 
 ### バージョン情報
 
@@ -959,7 +1028,7 @@ FIWARE Orion 互換のバージョン情報を返します。
 }
 ```
 
-### NGSI-LD API ディスカバリー
+### NGSI-LD API 検出
 
 ```http
 GET /.well-known/ngsi-ld
@@ -979,7 +1048,7 @@ NGSI-LD API サポート情報を返します。
 
 ### ヘルスチェック
 
-すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返した場合にセカンダリへ切り替えます。
+すべてのヘルスチェックエンドポイントは、マルチリージョン HA サポートのために `region` と `regionRole` を返します。Route 53 フェイルオーバーはこれらのエンドポイントを監視し、プライマリが `503` を返すとセカンダリに切り替えます。
 
 #### 基本ヘルス
 
@@ -987,7 +1056,7 @@ NGSI-LD API サポート情報を返します。
 GET /health
 ```
 
-サービスの基本的な稼働状態を返します。
+サービスの基本的な動作ステータスを返します。
 
 **レスポンス例**
 
@@ -1000,13 +1069,13 @@ GET /health
 }
 ```
 
-#### Liveness プローブ
+#### Liveness Probe
 
 ```http
 GET /health/live
 ```
 
-Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中かどうかをチェックします。
+Kubernetes / Route 53 の liveness probe 用。サービスが実行中かどうかをチェックします。
 
 **レスポンス例**
 
@@ -1019,23 +1088,28 @@ Kubernetes / Route 53 の Liveness プローブ用。サービスが実行中か
 }
 ```
 
-#### Readiness プローブ
+#### Readiness Probe
 
 ```http
 GET /health/ready
 ```
 
-Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチェックし、オプションで DynamoDB と EventBridge の詳細ヘルスチェックを実行します。
+Kubernetes / Route 53 の readiness probe 用。MongoDB の接続性をチェックし、オプションで DynamoDB と EventBridge の詳細なヘルスチェックを実行します。
 
 **環境変数による詳細ヘルスチェックの有効化**
 
-| 環境変数 | 説明 |
-|---------|------|
-| `HEALTH_CHECK_DYNAMODB=true` | DynamoDB DescribeTable 接続チェックを追加 |
-| `HEALTH_CHECK_EVENTBRIDGE=true` | EventBridge DescribeEventBus 接続チェックを追加 |
+| Environment Variable            | Description                                         |
+| ------------------------------- | --------------------------------------------------- |
+| `HEALTH_CHECK_DYNAMODB=true`    | Add DynamoDB DescribeTable connectivity check       |
+| `HEALTH_CHECK_EVENTBRIDGE=true` | Add EventBridge DescribeEventBus connectivity check |
 
 **レスポンス**
-- 成功: `200 OK` と `status: "healthy"`- 失敗: `503 Service Unavailable` と `status: "unhealthy"`**レスポンス例(詳細ヘルスチェック有効時)**
+
+* 成功: `200 OK` と `status: "healthy"`
+  
+* 失敗: `503 Service Unavailable` と `status: "unhealthy"`
+
+**レスポンス例(詳細ヘルスチェックが有効な場合)**
 
 ```json
 {
@@ -1051,9 +1125,10 @@ Kubernetes / Route 53 の Readiness プローブ用。MongoDB への接続をチ
   "totalLatencyMs": 35
 }
 ```
+
 ### 統計とメトリクス
 
-FIWARE Orion 互換の統計エンドポイントと、Prometheus 形式のメトリクスエンドポイントを提供します。
+FIWARE Orion 互換の統計エンドポイントと Prometheus 形式のメトリクスエンドポイントを提供します。
 
 #### 統計
 
@@ -1062,7 +1137,7 @@ GET /statistics
 Authorization: Bearer <token>
 ```
 
-サーバーの運用統計を FIWARE Orion 互換形式で返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+FIWARE Orion 互換形式でサーバーの動作統計を返します。認証が有効な場合(`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1102,7 +1177,7 @@ GET /cache/statistics
 Authorization: Bearer <token>
 ```
 
-サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。
+サブスクリプションと登録のキャッシュ統計を返します。認証が有効な場合(`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。
 
 **レスポンス例**
 
@@ -1132,10 +1207,13 @@ GET /metrics
 Authorization: Bearer <token>
 ```
 
-Prometheus エクスポジション形式でメトリクスを返します。認証が有効な場合 (`AUTH_ENABLED=true`)、認証済みユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
+Prometheus exposition 形式でメトリクスを返します。認証が有効な場合(`AUTH_ENABLED=true`)、認証されたユーザーのみがこのエンドポイントにアクセスできます。Kubernetes 環境での監視や Grafana ダッシュボードとの統合に使用できます。
 
 **レスポンス**
-- Content-Type: `text/plain; version=0.0.4`**レスポンス例**
+
+* Content-Type: `text/plain; version=0.0.4`
+
+**レスポンス例**
 
 ```text
 # HELP geonicdb_uptime_seconds Server uptime in seconds
@@ -1178,7 +1256,9 @@ GET /tools.json
 
 Claude Tool Use / OpenAI Function Calling と互換性のある JSON 形式でツール定義を返します。これは AI エージェントが API をツールとして使用するためのスキーマです。
 
-**提供されるツール**: `list_entities`、`get_entity`、`search_by_location`、`search_by_attribute`、`create_entity`、`update_entity`、`delete_entity`、`list_entity_types`、`get_temporal_data`、`subscribe`##### AI プラグインマニフェスト
+**提供されるツール**: `list_entities`, `get_entity`, `search_by_location`, `search_by_attribute`, `create_entity`, `update_entity`, `delete_entity`, `list_entity_types`, `get_temporal_data`, `subscribe`
+
+##### AI プラグインマニフェスト
 
 ```http
 GET /.well-known/ai-plugin.json
@@ -1194,7 +1274,7 @@ Content-Type: application/json
 Accept: application/json, text/event-stream
 ```
 
-MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、MCP tools/call 経由で 5 つのツールすべてが利用可能です。
+MCP Streamable HTTP エンドポイント。MCP 互換 AI クライアント(Claude Desktop など)から直接接続できます。ステートレスモード(JSON レスポンス)で動作し、5 つのツールすべてが MCP tools/call 経由で利用可能です。
 
 `AUTH_ENABLED=true` の場合、Bearer トークン(JWT)による認証が必要です。テナントアクセス制御も適用されます。
 
@@ -1215,9 +1295,10 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
   }
 }
 ```
-注意: `headers` は `AUTH_ENABLED=true` の場合のみ必要です。
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+注: `headers` は `AUTH_ENABLED=true` の場合にのみ必要です。
+
+詳細については、[AI\_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
 
 ##### A2A (Agent-to-Agent Protocol)
 
@@ -1225,7 +1306,7 @@ MCP Streamable HTTP エンドポイント。MCP 互換の AI クライアント(
 GET /.well-known/agent-card.json
 ```
 
-A2A Agent Card。このエージェントの機能、スキル、認証について説明します。認証は不要です。
+A2A Agent Card。このエージェントの機能、スキル、および認証を記述します。認証は不要です。
 
 ```http
 POST /a2a
@@ -1234,17 +1315,21 @@ Authorization: Bearer <token>
 Fiware-Service: <tenant>  (optional, falls back to default tenant)
 ```
 
-エージェント間通信のための A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合、認証が必要です。サポートされるメソッド:
-- `message/send` — メッセージを送信し、同期レスポンスを受信
-- `tasks/get` — タスクの現在の状態を取得
-- `tasks/list` — フィルタリングとページネーション付きでタスクを一覧表示
-- `tasks/cancel` — タスクのキャンセルをリクエスト
+エージェント間通信用の A2A JSON-RPC 2.0 エンドポイント。`AUTH_ENABLED=true` の場合、認証が必要です。サポートされているメソッド:
 
-5 つのスキルが利用可能: entities、batch、temporal、config、admin (MCP ツールと同じ)。
+* `message/send` — メッセージを送信し、同期レスポンスを受信
+  
+* `tasks/get` — タスクの現在の状態を取得
+  
+* `tasks/list` — フィルタリングとページネーションを使用してタスクを一覧表示
+  
+* `tasks/cancel` — タスクのキャンセルをリクエスト
 
-詳細は [AI_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+5 つのスキルが利用可能: entities、batch、temporal、config、admin(MCP ツールと同じ)。
 
-#### テナント別メトリクス (管理 API)
+詳細については、[AI\_INTEGRATION.md](../ai-integration/overview.md) を参照してください。
+
+#### テナント別メトリクス (Admin API)
 
 ```http
 GET /admin/metrics
@@ -1275,46 +1360,47 @@ Authorization: Bearer <accessToken>
   }
 }
 ```
----
+
+***
 
 ## NGSIv2 API
 
-NGSIv2 API の詳細については、[API_NGSIV2.md](./ngsiv2.md) を参照してください。
+NGSIv2 API の詳細については、[API\_NGSIV2.md](./ngsiv2.md) を参照してください。
 
----
+***
 
 ## NGSI-LD API
 
-NGSI-LD API の詳細については、[API_NGSILD.md](./ngsild.md) を参照してください。
+NGSI-LD API の詳細については、[API\_NGSILD.md](./ngsild.md) を参照してください。
 
----
+***
 
 ## クエリ言語
 
-属性値によるフィルタリングは `q` パラメータを使用して可能です。
+属性値によるフィルタリングは、`q` パラメータを使用して可能です。
 
 ### 基本構文
 
-| 演算子 | 説明 | 例 |
-|----------|-------------|---------|
-| `==` | 等しい | `temperature==23` |
-| `!=` | 等しくない | `status!=inactive` |
-| `>` | より大きい | `temperature>20` |
-| `<` | より小さい | `temperature<30` |
-| `>=` | 以上 | `temperature>=20` |
-| `<=` | 以下 | `temperature<=30` |
-| `..` | 範囲 | `temperature==20..30` |
-| `~=` | パターンマッチ (正規表現) | `name~=Room.*` |
+| Operator | Description                        | Example               |
+| -------- | ---------------------------------- | --------------------- |
+| `==`     | Equal to                           | `temperature==23`     |
+| `!=`     | Not equal to                       | `status!=inactive`    |
+| `>`      | Greater than                       | `temperature>20`      |
+| `<`      | Less than                          | `temperature<30`      |
+| `>=`     | Greater than or equal to           | `temperature>=20`     |
+| `<=`     | Less than or equal to              | `temperature<=30`     |
+| `..`     | Range                              | `temperature==20..30` |
+| `~=`     | Pattern match (regular expression) | `name~=Room.*`        |
 
-### 複数条件
+### 複数の条件
 
-AND 条件はセミコロン (`;`) で結合します:
+AND 条件をセミコロン(`;`)で組み合わせます:
 
 ```text
 q=temperature>20;pressure<800
 ```
 
-OR 条件はパイプ (`|`) で結合します (`;` は `|` より優先順位が高くなります):
+OR 条件をパイプ(`|`)で組み合わせます(`;` は `|` よりも優先順位が高くなります):
 
 ```text
 q=temperature==23|temperature==35
@@ -1323,7 +1409,7 @@ q=temperature>25;humidity<40|status==active
 
 ### 範囲クエリ
 
-`==` 演算子と `..` を組み合わせて範囲フィルタリングを行います (境界値を含む):
+`==` 演算子と `..` を組み合わせて範囲フィルタリングを行います(境界を含む):
 
 ```text
 q=temperature==20..30    # 20 or above and 30 or below
@@ -1336,27 +1422,27 @@ q=status~=act     # Partial match (regular expression)
 q=name==Room1     # Exact match
 ```
 
----
+***
 
-## ジオクエリ
+## 地理クエリ
 
-位置情報を持つエンティティは空間的にクエリできます。
+位置情報を持つエンティティは、空間的にクエリできます。
 
 ### パラメータ
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `georel` | 空間関係 (coveredBy、within、intersects、disjoint、equals) |
-| `geometry` | ジオメトリタイプ (point、polygon、line、box) |
-| `coords` | 座標 (NGSIv2: 緯度,経度 形式; NGSI-LD: 経度,緯度 形式; 複数のポイントはセミコロンで区切る) |
+| Parameter  | Description                                                                                                                  |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `georel`   | Spatial relationship (coveredBy, within, intersects, disjoint, equals)                                                       |
+| `geometry` | Geometry type (point, polygon, line, box)                                                                                    |
+| `coords`   | Coordinates (NGSIv2: latitude,longitude format; NGSI-LD: longitude,latitude format; multiple points separated by semicolons) |
 
-> **注意**: `georel`、`geometry`、`coords` (または NGSI-LD では `coordinates`) はすべて一緒に指定する必要があります。一部のみを指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 4.10)。
+> **注意**: `georel`、`geometry`、および `coords`(NGSI-LD では `coordinates`)は、すべて一緒に指定する必要があります。これらの一部のみを指定すると、`400 Bad Request` が返されます(ETSI GS CIM 009 V1.9.1 clause 4.10)。
 
-### 座標形式
+### 座標フォーマット
 
-NGSIv2 では、座標は **緯度,経度** の順序で指定します (NGSIv2 仕様に準拠)。NGSI-LD では、座標は **経度,緯度** の順序です (GeoJSON 標準に準拠)。
+NGSIv2 では、座標は **緯度,経度** の順序で指定されます(NGSIv2 仕様に準拠)。NGSI-LD では、座標は **経度,緯度** の順序で指定されます(GeoJSON 標準に準拠)。
 
-> **重要**: NGSIv2 における緯度,経度の順序は GeoJSON 標準 (経度,緯度) からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用しています。API を使用する際は、使用している API バージョンに合わせて正しい順序で座標を指定してください。
+> **重要**: NGSIv2 の緯度,経度の順序は、GeoJSON 標準(経度,緯度)からの逸脱です。これは NGSI-LD で修正され、GeoJSON と同じ経度,緯度の順序を使用します。API を使用する際は、使用している API バージョンに対応した正しい順序で座標を指定してください。
 
 ```text
 # NGSIv2 (latitude,longitude)
@@ -1369,7 +1455,7 @@ coordinates=[139.7671,35.6812]       # Single point
 
 ### エリア検索 (coveredBy / within)
 
-ポリゴン内のエンティティを検索します:
+ポリゴン内のエンティティを検索:
 
 ```http
 GET /v2/entities?georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138
@@ -1377,7 +1463,7 @@ GET /v2/entities?georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;3
 
 ### 交差検索 (intersects)
 
-ジオメトリと交差するエンティティを検索します:
+ジオメトリと交差するエンティティを検索:
 
 ```http
 GET /v2/entities?georel=intersects&geometry=box&coords=35.67,139.76;35.69,139.78
@@ -1385,22 +1471,23 @@ GET /v2/entities?georel=intersects&geometry=box&coords=35.67,139.76;35.69,139.78
 
 ### 非交差検索 (disjoint)
 
-ジオメトリと交差しないエンティティを検索します:
+ジオメトリと交差しないエンティティを検索:
 
 ```http
 GET /v2/entities?georel=disjoint&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138
 ```
+
 ### 近接検索 (near)
 
-指定された座標から一定の距離内にあるエンティティを検索します。
+指定した座標から一定の距離内にあるエンティティを検索します。
 
 #### パラメータ
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `maxDistance` | 最大距離(メートル) |
-| `minDistance` | 最小距離(メートル) |
-| `orderByDistance` | `true` に設定すると、結果を距離順にソートし、各エンティティに距離情報(`@distance`)を付加します |
+| Parameter         | Description                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------ |
+| `maxDistance`     | Maximum distance (meters)                                                                                    |
+| `minDistance`     | Minimum distance (meters)                                                                                    |
+| `orderByDistance` | When set to `true`, sorts results by distance and attaches distance information (`@distance`) to each entity |
 
 #### 基本的な使い方 (NGSIv2)
 
@@ -1417,7 +1504,7 @@ GET /v2/entities?georel=near;minDistance:500;maxDistance:10000&geometry=point&co
 
 #### NGSI-LD での使い方
 
-NGSI-LD では、`==` を使用してパラメータを指定します:
+NGSI-LD では、パラメータは `==` を使って指定します:
 
 ```http
 # Search for entities within 5km of Tokyo Station
@@ -1430,24 +1517,26 @@ GET /ngsi-ld/v1/entities?georel=near;minDistance==100000&geometry=Point&coordina
 GET /ngsi-ld/v1/entities?georel=near;minDistance==500;maxDistance==10000&geometry=Point&coordinates=[139.7671,35.6812]
 ```
 
-#### georel の構文比較
+#### georel 構文の比較
 
-georel パラメータの修飾子構文は NGSIv2 と NGSI-LD で異なります:
+georel パラメータ修飾子の構文は NGSIv2 と NGSI-LD で異なります:
 
-| 機能 | NGSIv2 | NGSI-LD | 説明 |
-|---------|--------|---------|-------------|
-| 最大距離 | `georel=near;maxDistance:5000` | `georel=near;maxDistance==5000` | `:` と `==` の違い |
-| 最小距離 | `georel=near;minDistance:1000` | `georel=near;minDistance==1000` | `:` と `==` の違い |
-| 距離範囲 | `georel=near;minDistance:500;maxDistance:10000` | `georel=near;minDistance==500;maxDistance==10000` | `:` と `==` の違い |
+| Feature        | NGSIv2                                          | NGSI-LD                                           | Description            |
+| -------------- | ----------------------------------------------- | ------------------------------------------------- | ---------------------- |
+| Max distance   | `georel=near;maxDistance:5000`                  | `georel=near;maxDistance==5000`                   | `:` vs `==` difference |
+| Min distance   | `georel=near;minDistance:1000`                  | `georel=near;minDistance==1000`                   | `:` vs `==` difference |
+| Distance range | `georel=near;minDistance:500;maxDistance:10000` | `georel=near;minDistance==500;maxDistance==10000` | `:` vs `==` difference |
 
-> **構文が異なる理由**: NGSIv2 では `:` を使用してパラメータ値を指定しますが、NGSI-LD では ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用する API バージョンに対応した構文を使用してください。
+> **構文が異なる理由**: NGSIv2 ではパラメータ値を指定するために `:` を使用しますが、NGSI-LD では ETSI 仕様に従って `==` を使用します。API を呼び出す際は、使用する API バージョンに対応した構文を使用してください。
 
-#### 距離のソートと距離情報
+#### 距離ソートと距離情報
 
 `orderByDistance=true` パラメータを指定すると、以下の機能が有効になります:
 
-1. **距離のソート**: 結果が指定された座標からの距離の昇順でソートされます
-2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定された座標からの距離(メートル単位)が返されます
+
+1. **距離ソート**: 結果は指定した座標からの距離の昇順でソートされます
+   
+2. **距離情報**: 各エンティティに `@distance` 属性が追加され、指定した座標からの距離 (メートル単位) が返されます
 
 この機能は MongoDB の `$geoNear` 集約パイプラインを使用して実装されています。
 
@@ -1494,7 +1583,7 @@ GET /ngsi-ld/v1/entities?georel=near;maxDistance==5000&geometry=Point&coordinate
 
 ##### 降順ソート
 
-`orderDirection=desc` と組み合わせて使用すると、距離の降順(遠い順)でソートされます:
+`orderDirection=desc` を併用して、距離の降順(遠い順)でソートします:
 
 ```http
 GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.7671&orderByDistance=true&orderDirection=desc
@@ -1502,40 +1591,41 @@ GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.
 
 #### 制限事項
 
-- **Point ジオメトリのみ**: `geometry=point` (NGSIv2) または `geometry=Point` (NGSI-LD) のみがサポートされています
+
+* **Point ジオメトリのみ**: `geometry=point` (NGSIv2) または `geometry=Point` (NGSI-LD) のみがサポートされています
 
 ### エラー処理
 
-geo-query パラメータが無効な場合、`400 Bad Request` が返されます。
+ジオクエリパラメータが無効な場合、`400 Bad Request` が返されます。
 
-| エラー条件 | エラーメッセージ例 |
-|----------------|-----------------------|
-| 無効な `georel` 値 | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
-| 無効な `geometry` 値 | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box` |
-| 不十分な座標 (Point) | `Point geometry requires at least 2 coordinates, but got 1` |
-| 不十分な座標 (Polygon) | `Polygon geometry requires at least 4 coordinate pairs (8 values), but got 6 values` |
-| 不十分な座標 (LineString) | `LineString geometry requires at least 2 coordinate pairs (4 values), but got 2 values` |
-| 不十分な座標 (Box) | `Box geometry requires 2 coordinate pairs (4 values), but got 2 values` |
-| 無効な座標値 | `Invalid coordinate value: xxx` |
-| 緯度が範囲外 | `Latitude out of range: 91. Must be between -90 and 90.` |
-| 経度が範囲外 | `Longitude out of range: 181. Must be between -180 and 180.` |
-| 距離なしの `near` | `The 'near' georel requires maxDistance and/or minDistance modifier` |
-| Point 以外のジオメトリでの `near` | `The 'near' georel requires Point geometry, but 'polygon' was provided` |
+| Error Condition                       | Example Error Message                                                                                    |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Invalid `georel` value                | `Invalid georel: xxx. Supported values: near, coveredBy, within, contains, intersects, disjoint, equals` |
+| Invalid `geometry` value              | `Unsupported geometry type: xxx. Supported types: point, polygon, linestring, line, box`                 |
+| Insufficient coordinates (Point)      | `Point geometry requires at least 2 coordinates, but got 1`                                              |
+| Insufficient coordinates (Polygon)    | `Polygon geometry requires at least 4 coordinate pairs (8 values), but got 6 values`                     |
+| Insufficient coordinates (LineString) | `LineString geometry requires at least 2 coordinate pairs (4 values), but got 2 values`                  |
+| Insufficient coordinates (Box)        | `Box geometry requires 2 coordinate pairs (4 values), but got 2 values`                                  |
+| Invalid coordinate value              | `Invalid coordinate value: xxx`                                                                          |
+| Latitude out of range                 | `Latitude out of range: 91. Must be between -90 and 90.`                                                 |
+| Longitude out of range                | `Longitude out of range: 181. Must be between -180 and 180.`                                             |
+| `near` without distance               | `The 'near' georel requires maxDistance and/or minDistance modifier`                                     |
+| `near` with non-Point geometry        | `The 'near' georel requires Point geometry, but 'polygon' was provided`                                  |
 
----
+***
 
 ## 空間 ID 検索
 
-日本のデジタル庁 / IPA が定めた 3 次元空間識別規格 (ZFXY 形式) に基づく空間検索をサポートします。
+日本のデジタル庁 / IPA によって確立された 3D 空間識別標準(ZFXY 形式)に基づく空間検索をサポートします。
 
 ### ZFXY 形式
 
-| 要素 | 説明 | 範囲 |
-|---------|-------------|-------|
-| Z | ズームレベル | 0-28 |
-| F | 垂直方向 (高度レベル) | 整数 |
-| X | 東西方向 (経度タイル) | 0 to 2^z-1 |
-| Y | 南北方向 (緯度タイル) | 0 to 2^z-1 |
+| Element | Description                           | Range      |
+| ------- | ------------------------------------- | ---------- |
+| Z       | Zoom level                            | 0-28       |
+| F       | Vertical direction (altitude level)   | Integer    |
+| X       | East-west direction (longitude tile)  | 0 to 2^z-1 |
+| Y       | North-south direction (latitude tile) | 0 to 2^z-1 |
 
 形式: `{z}/{f}/{x}/{y}` (例: `20/0/929593/410773`)
 
@@ -1551,9 +1641,9 @@ GET /v2/entities?spatialId=20/0/929593/410773
 GET /ngsi-ld/v1/entities?spatialId=20/0/929593/410773
 ```
 
-### 階層展開 (spatialIdDepth)
+### 階層的展開(spatialIdDepth)
 
-`spatialIdDepth` パラメータを指定すると、指定した空間 ID を中心とした周囲のタイルに検索を拡張します。
+`spatialIdDepth` パラメータを指定すると、指定された空間 ID を中心とした周囲のタイルに検索を拡張します。
 
 ```http
 # depth=1: Expands to a 3x3 tile grid (9 tiles)
@@ -1563,13 +1653,13 @@ GET /v2/entities?spatialId=20/0/929593/410773&spatialIdDepth=1
 GET /v2/entities?spatialId=20/0/929593/410773&spatialIdDepth=2
 ```
 
-| spatialIdDepth | 展開範囲 | タイル数 |
-|----------------|-----------------|------------|
-| 0 (デフォルト) | 指定したタイルのみ | 1 |
-| 1 | 3x3 | 9 |
-| 2 | 5x5 | 25 |
-| 3 | 7x7 | 49 |
-| 4 | 9x9 | 81 |
+| spatialIdDepth | Expansion Range     | Tile Count |
+| -------------- | ------------------- | ---------- |
+| 0 (default)    | Specified tile only | 1          |
+| 1              | 3x3                 | 9          |
+| 2              | 5x5                 | 25         |
+| 3              | 7x7                 | 49         |
+| 4              | 9x9                 | 81         |
 
 ### 使用例
 
@@ -1583,11 +1673,11 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&spatialIdDe
   -H "Fiware-Service: smartcity"
 ```
 
----
+***
 
 ## GeoJSON 出力
 
-RFC 7946 準拠の GeoJSON FeatureCollection 形式でエンティティを出力できます。
+エンティティは RFC 7946 準拠の GeoJSON FeatureCollection 形式で出力できます。
 
 ### NGSIv2 での使用方法
 
@@ -1653,7 +1743,7 @@ Accept: application/geo+json
 
 ### NGSI-LD における @context
 
-NGSI-LD で GeoJSON を出力する場合、`@context` が FeatureCollection レベルに含まれます:
+NGSI-LD で GeoJSON を出力する場合、`@context` は FeatureCollection レベルに含まれます:
 
 ```json
 {
@@ -1694,24 +1784,27 @@ curl "http://localhost:3000/v2/entities?spatialId=20/0/929592/410773&options=geo
 
 ### 注意事項
 
-- `location` 属性を持たないエンティティは `geometry: null` として出力されます
-- GeoJSON 出力は `keyValues` オプションと併用できます
-- Polygon、LineString、MultiPoint などのジオメトリタイプがサポートされています
 
----
+* `location` 属性を持たないエンティティは `geometry: null` として出力されます
+  
+* GeoJSON 出力は `keyValues` オプションと併用できます
+  
+* Polygon、LineString、MultiPoint などのジオメトリタイプがサポートされています
 
-## ベクタータイル
+***
 
-エンティティは XYZ タイル方式に基づいて GeoJSON ベクタータイルとして出力できます。大量のエンティティを地図上に効率的に表示するために最適化されています。
+## ベクトルタイル
+
+エンティティは XYZ タイルスキームに基づく GeoJSON ベクトルタイルとして出力できます。地図上で大量のエンティティを効率的に表示するために最適化されています。
 
 ### エンドポイント
 
-| エンドポイント | 説明 |
-|----------|-------------|
-| `GET /v2/tiles` | TileJSON メタデータ (NGSIv2) |
-| `GET /v2/tiles/{z}/{x}/{y}.geojson` | GeoJSON タイル (NGSIv2) |
-| `GET /ngsi-ld/v1/tiles` | TileJSON メタデータ (NGSI-LD) |
-| `GET /ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GeoJSON タイル (NGSI-LD) |
+| Endpoint                                    | Description                 |
+| ------------------------------------------- | --------------------------- |
+| `GET /v2/tiles`                             | TileJSON metadata (NGSIv2)  |
+| `GET /v2/tiles/{z}/{x}/{y}.geojson`         | GeoJSON tile (NGSIv2)       |
+| `GET /ngsi-ld/v1/tiles`                     | TileJSON metadata (NGSI-LD) |
+| `GET /ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GeoJSON tile (NGSI-LD)      |
 
 ### TileJSON メタデータ
 
@@ -1739,7 +1832,7 @@ curl "http://localhost:3000/v2/tiles" \
 
 ### GeoJSON タイルの取得
 
-XYZ 座標を指定してタイル内のエンティティを GeoJSON 形式で取得します:
+XYZ 座標を指定して、タイル内のエンティティを GeoJSON 形式で取得します:
 
 ```bash
 # Zoom level 14 tile around Tokyo
@@ -1749,10 +1842,10 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson" \
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `type` | エンティティタイプでフィルタリング |
-| `attrs` | 出力する属性をカンマ区切りリストで指定 |
+| Parameter | Description                                            |
+| --------- | ------------------------------------------------------ |
+| `type`    | Filter by entity type                                  |
+| `attrs`   | Specify attributes to output as a comma-separated list |
 
 **使用例**
 
@@ -1797,7 +1890,7 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 ### クラスタリング
 
-タイル内のエンティティ数が閾値(デフォルト: 1000)を超えた場合、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスター Feature が返されます。
+タイル内のエンティティ数が閾値(デフォルト: 1000)を超えると、自動的にクラスタリングされます。クラスタリングされた場合、タイル内のすべてのエンティティの重心座標を持つ単一のクラスタ Feature が返されます。
 
 **クラスタリング時のレスポンス例**
 
@@ -1834,24 +1927,27 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 **レスポンスヘッダー**
 
-| ヘッダー | 説明 |
-|--------|-------------|
-| `X-Tile-Mode` | `individual` (個別のエンティティ) または `clustered` (クラスタリング) |
-| `X-Total-Count` | タイル内のエンティティの総数 |
+| Header          | Description                                                    |
+| --------------- | -------------------------------------------------------------- |
+| `X-Tile-Mode`   | `individual` (individual entities) or `clustered` (clustering) |
+| `X-Total-Count` | Total number of entities in the tile                           |
 
 ### 設定
 
-| 環境変数 | デフォルト | 説明 |
-|----------------------|---------|-------------|
-| `MAX_ENTITIES_PER_REQUEST` | `1000` | クラスタリングの閾値(この値以上でクラスタリングが発生) |
+| Environment Variable       | Default | Description                                                         |
+| -------------------------- | ------- | ------------------------------------------------------------------- |
+| `MAX_ENTITIES_PER_REQUEST` | `1000`  | Threshold for clustering (clustering occurs at or above this value) |
 
 ### 参考文献
 
-- [TileJSON 3.0 仕様](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
-- [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
-- [XYZ タイル方式](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
 
----
+* [TileJSON 3.0 Specification](https://github.com/mapbox/tilejson-spec/tree/master/3.0.0)
+  
+* [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
+  
+* [XYZ Tile Scheme](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames)
+
+***
 
 ## 座標参照系 (CRS)
 
@@ -1859,11 +1955,11 @@ curl "http://localhost:3000/v2/tiles/14/14549/6451.geojson?attrs=name,category" 
 
 ### サポートされている CRS
 
-| CRS | EPSG | 説明 | 使用例 |
-|-----|------|-------------|----------|
-| WGS84 | EPSG:4326 | 世界測地系 1984 (デフォルト) | GPS、国際標準 |
-| JGD2011 | EPSG:6668 | 日本測地系 2011 | 日本国内の高精度測量 |
-| Web Mercator | EPSG:3857 | Web メルカトル図法 | Google Maps、OpenStreetMap など |
+| CRS          | EPSG      | Description                          | Use Case                          |
+| ------------ | --------- | ------------------------------------ | --------------------------------- |
+| WGS84        | EPSG:4326 | World Geodetic System 1984 (default) | GPS, international standard       |
+| JGD2011      | EPSG:6668 | Japanese Geodetic Datum 2011         | High-precision surveying in Japan |
+| Web Mercator | EPSG:3857 | Web Mercator projection              | Google Maps, OpenStreetMap, etc.  |
 
 ### CRS の指定方法
 
@@ -1893,19 +1989,19 @@ GET /ngsi-ld/v1/entities?type=Store&crs=urn:ogc:def:crs:EPSG::6668
 
 ### レスポンスヘッダー
 
-CRS を指定したリクエストに対するレスポンスには、`Content-Crs` ヘッダーが含まれます:
+CRS を指定したリクエストに対するレスポンスには `Content-Crs` ヘッダーが含まれます:
 
 ```text
 Content-Crs: EPSG:6668
 ```
 
-NGSI-LD で URN 形式が指定された場合、URN 形式で返されます:
+NGSI-LD で URN 形式が指定されている場合、URN 形式で返されます:
 
 ```text
 Content-Crs: urn:ogc:def:crs:EPSG::6668
 ```
 
-### 座標の入出力
+### 座標の入力/出力
 
 #### クエリ時(入力)
 
@@ -1916,9 +2012,9 @@ Content-Crs: urn:ogc:def:crs:EPSG::6668
 GET /v2/entities?georel=near;maxDistance:5000&geometry=point&coords=35.6812,139.7671&crs=EPSG:6668
 ```
 
-#### エンティティ作成時
+#### エンティティの作成時
 
-エンティティ作成時に `crs` パラメータを指定すると、入力座標が指定された CRS として解釈され、内部的に WGS84 に変換されて保存されます:
+エンティティ作成時に `crs` パラメータを指定すると、入力座標が指定された CRS として解釈され、保存のために内部的に WGS84 に変換されます:
 
 ```bash
 # Create entity with Web Mercator coordinates
@@ -1950,10 +2046,10 @@ curl "http://localhost:3000/v2/entities/Store1?crs=EPSG:6668" \
 
 ### 座標変換の精度
 
-| 変換 | 精度 |
-|------------|----------|
-| WGS84 ↔ JGD2011 | 数 cm から数十 cm |
-| WGS84 ↔ Web メルカトル | 計算精度に依存(緯度 ±85 度以内) |
+| Conversion           | Accuracy                                                       |
+| -------------------- | -------------------------------------------------------------- |
+| WGS84 ↔ JGD2011      | Several cm to tens of cm                                       |
+| WGS84 ↔ Web Mercator | Depends on calculation precision (within ±85 degrees latitude) |
 
 ### 使用例
 
@@ -2010,27 +2106,33 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Landmark&crs=EPSG:6668" \
 
 ### エラー
 
-| エラー | HTTP コード | 説明 |
-|-------|-----------|-------------|
-| Unsupported CRS | 400 | 指定された CRS コードはサポートされていません |
-| Invalid CRS format | 400 | 無効な CRS 形式が指定されました |
-| Coordinates out of range | 400 | Web メルカトルで緯度 ±85 度を超える座標 |
+| Error                    | HTTP Code | Description                                                |
+| ------------------------ | --------- | ---------------------------------------------------------- |
+| Unsupported CRS          | 400       | Specified CRS code is not supported                        |
+| Invalid CRS format       | 400       | Invalid CRS format specified                               |
+| Coordinates out of range | 400       | Coordinates exceeding ±85 degrees latitude in Web Mercator |
 
 ### 制限事項
 
-- Web メルカトル (EPSG:3857) は緯度 ±85 度を超える範囲をサポートしていません
-- すべての座標は内部的に WGS84 で保存されます
-- 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリを使用しています
 
-### 参考資料
+* Web Mercator (EPSG:3857) は緯度±85度を超える領域をサポートしていません
+  
+* すべての座標は内部的に WGS84 で保存されます
+  
+* 座標変換には [proj4](https://github.com/proj4js/proj4js) ライブラリが使用されます
 
-- [OGC API Features CRS Extension](https://docs.ogc.org/is/18-058r1/18-058r1.html)
-- [EPSG Geodetic Parameter Registry](https://epsg.io/)
-- [ETSI NGSI-LD CRS Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.08.01_60/gs_CIM009v010801p.pdf)
+### 参考文献
 
----
 
-## データカタログ API
+* [OGC API Features CRS Extension](https://docs.ogc.org/is/18-058r1/18-058r1.html)
+  
+* [EPSG Geodetic Parameter Registry](https://epsg.io/)
+  
+* [ETSI NGSI-LD CRS Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.08.01_60/gs_CIM009v010801p.pdf)
+
+***
+
+## Data Catalog API
 
 DCAT-AP 形式でエンティティタイプ情報を出力し、CKAN harvest 互換のエンドポイントを提供します。
 
@@ -2068,14 +2170,14 @@ GET /catalog
 GET /catalog/datasets
 ```
 
-DCAT 形式でデータセットの一覧を出力します。
+データセットのリストを DCAT 形式で出力します。
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 取得するデータセット数 |
-| `offset` | スキップするデータセット数 |
+| Parameter | Description                    |
+| --------- | ------------------------------ |
+| `limit`   | Number of datasets to retrieve |
+| `offset`  | Number of datasets to skip     |
 
 ### 個別データセット
 
@@ -2095,21 +2197,21 @@ GET /catalog/datasets/{datasetId}/sample
 
 **クエリパラメータ**
 
-| パラメータ | 説明 | デフォルト |
-|-----------|-------------|---------|
-| `limit` | 取得するサンプル数 | 5 |
+| Parameter | Description                   | Default |
+| --------- | ----------------------------- | ------- |
+| `limit`   | Number of samples to retrieve | 5       |
 
 ### CKAN 互換 API
 
 CKAN データカタログハーベスターと互換性のある API を提供します。
 
-#### パッケージ一覧
+#### パッケージリスト
 
 ```http
 GET /catalog/ckan/package_list
 ```
 
-すべてのパッケージ(データセット)の ID 一覧を取得します。
+すべてのパッケージ(データセット)の ID のリストを取得します。
 
 **レスポンス例**
 
@@ -2149,36 +2251,36 @@ GET /catalog/ckan/package_show?id={package_id}
 }
 ```
 
-#### リソース付きパッケージ一覧
+#### リソース付きパッケージリスト
 
 ```http
 GET /catalog/ckan/current_package_list_with_resources
 ```
 
-リソース情報を含むパッケージの一覧をページネーション形式で取得します。
+リソース情報を含むパッケージのページネーション形式のリストを取得します。
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `limit` | 取得するパッケージ数 |
-| `offset` | スキップするパッケージ数 |
+| Parameter | Description                    |
+| --------- | ------------------------------ |
+| `limit`   | Number of packages to retrieve |
+| `offset`  | Number of packages to skip     |
 
-詳細は外部連携ドキュメントを参照してください。
+詳細については、外部統合ドキュメントを参照してください。
 
----
+***
 
-## CADDE 連携
+## CADDE 統合
 
-CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの連携機能を提供します。
+CADDE (Connector Architecture for Decentralized Data Exchange) コネクタとの統合機能を提供します。
 
 ### 概要
 
-CADDE は、異なるセクター間でのデータ共有を可能にする日本のデータ交換アーキテクチャです。この Context Broker は CADDE コネクタからのリクエストを受け付け、来歴情報を含むレスポンスを返します。
+CADDE は、異なるセクター間でのデータ共有を可能にする日本のデータ交換アーキテクチャです。この Context Broker は CADDE コネクタからのリクエストを受け入れ、来歴情報を含むレスポンスを返します。
 
 ### 有効化
 
-CADDE 機能はデフォルトで無効になっています。Admin API (`PUT /admin/cadde`) を使用して設定を管理します:
+CADDE 機能はデフォルトで無効になっています。Admin API (`PUT /admin/cadde`) を使用して設定を管理してください:
 
 ```bash
 # Enable CADDE configuration
@@ -2192,52 +2294,52 @@ curl -X PUT "https://api.example.com/admin/cadde" \
   }'
 ```
 
-| 設定項目 | デフォルト値 | 説明 |
-|--------------------|---------|-------------|
-| `enabled` | `false` | CADDE 機能を有効化 |
-| `authEnabled` | `false` | Bearer 認証を有効化 |
-| `defaultProvider` | - | デフォルトのプロバイダ ID |
-| `jwtIssuer` | - | JWT 検証における期待される発行者 (`iss`) クレーム |
-| `jwtAudience` | - | JWT 検証における期待される対象者 (`aud`) クレーム |
-| `jwksUrl` | - | 署名検証用の JWKS エンドポイント URL (HTTPS が必要) |
+| Configuration Item | Default | Description                                                   |
+| ------------------ | ------- | ------------------------------------------------------------- |
+| `enabled`          | `false` | Enable CADDE functionality                                    |
+| `authEnabled`      | `false` | Enable Bearer authentication                                  |
+| `defaultProvider`  | -       | Default provider ID                                           |
+| `jwtIssuer`        | -       | Expected issuer (`iss`) claim for JWT validation              |
+| `jwtAudience`      | -       | Expected audience (`aud`) claim for JWT validation            |
+| `jwksUrl`          | -       | JWKS endpoint URL for signature verification (HTTPS required) |
 
-設定は MongoDB に保存されるため、デプロイ後に API 経由で動的に変更できます。
+設定は MongoDB に保存され、デプロイ後に API を介して動的に変更できます。
 
-### リクエストヘッダ
+### リクエストヘッダー
 
-CADDE コネクタからのリクエストには以下のヘッダが含まれます:
+CADDE コネクタからのリクエストには、以下のヘッダーが含まれます:
 
-| ヘッダ | 必須 | 説明 |
-|--------|----------|-------------|
-| `x-cadde-resource-url` | - | アクセスされるリソースの URL |
-| `x-cadde-resource-api-type` | - | API タイプ (例: `api/ngsi`) |
-| `x-cadde-provider` | - | データプロバイダ ID |
-| `x-cadde-options` | - | 追加オプション (テナントヘッダなど) |
+| Header                      | Required | Description                               |
+| --------------------------- | -------- | ----------------------------------------- |
+| `x-cadde-resource-url`      | -        | URL of the resource being accessed        |
+| `x-cadde-resource-api-type` | -        | API type (e.g., `api/ngsi`)               |
+| `x-cadde-provider`          | -        | Data provider ID                          |
+| `x-cadde-options`           | -        | Additional options (tenant headers, etc.) |
 
-### x-cadde-options のフォーマット
+### x-cadde-options フォーマット
 
-テナント情報やその他の詳細は `x-cadde-options` ヘッダで指定できます:
+テナント情報やその他の詳細は、`x-cadde-options` ヘッダーで指定できます:
 
 ```text
 x-cadde-options: Fiware-Service:smartcity, Fiware-ServicePath:/sensors
 ```
 
-このヘッダで指定された値は、通常の HTTP ヘッダよりも優先されます。
+このヘッダーで指定された値は、通常の HTTP ヘッダーよりも優先されます。
 
-### プロヴェナンスレスポンスヘッダ
+### 来歴レスポンスヘッダー
 
-CADDE リクエストへのレスポンスには以下のプロヴェナンスヘッダが含まれます:
+CADDE リクエストへのレスポンスには、以下の来歴ヘッダーが含まれます:
 
-| ヘッダ | 説明 |
-|--------|-------------|
-| `x-cadde-provenance-id` | リクエストの一意識別子 (Fiware-Correlator を使用) |
-| `x-cadde-provenance-timestamp` | レスポンス生成時刻 (ISO 8601 形式) |
-| `x-cadde-provenance-provider` | データプロバイダ ID |
-| `x-cadde-provenance-resource-url` | アクセスされたリソースの URL |
+| Header                            | Description                                                |
+| --------------------------------- | ---------------------------------------------------------- |
+| `x-cadde-provenance-id`           | Unique identifier for the request (uses Fiware-Correlator) |
+| `x-cadde-provenance-timestamp`    | Response generation time (ISO 8601 format)                 |
+| `x-cadde-provenance-provider`     | Data provider ID                                           |
+| `x-cadde-provenance-resource-url` | URL of the resource accessed                               |
 
 ### 認証
 
-`CADDE_AUTH_ENABLED=true` が設定されている場合、CADDE リクエストには Bearer 認証が必要です:
+`CADDE_AUTH_ENABLED=true` の場合、CADDE リクエストには Bearer 認証が必要です:
 
 ```http
 Authorization: Bearer <token>
@@ -2249,13 +2351,13 @@ Authorization: Bearer <token>
 
 `CADDE_JWKS_URL` を設定すると、Bearer トークンの完全な JWT 検証が有効になります:
 
-| 機能 | 説明 |
-|---------|-------------|
-| **署名検証** | RS256 または ES256 アルゴリズムをサポート。JWKS エンドポイントから公開鍵を自動取得 |
-| **有効期限検証** | `exp` (有効期限) クレームを検証し、期限切れトークンを拒否 |
-| **発行時刻検証** | `iat` (発行時刻) クレームを検証し、未来に発行されたトークンを拒否 |
-| **発行者検証** | `iss` クレームが `CADDE_JWT_ISSUER` が設定されている場合に検証 |
-| **対象者検証** | `aud` クレームが `CADDE_JWT_AUDIENCE` が設定されている場合に検証 |
+| Feature                     | Description                                                                                  |
+| --------------------------- | -------------------------------------------------------------------------------------------- |
+| **Signature verification**  | Supports RS256 or ES256 algorithms. Automatically fetches public keys from the JWKS endpoint |
+| **Expiration verification** | Validates the `exp` (expiration) claim and rejects expired tokens                            |
+| **Issued-at verification**  | Validates the `iat` (issued-at) claim and rejects tokens issued in the future                |
+| **Issuer verification**     | Validates the `iss` claim if `CADDE_JWT_ISSUER` is configured                                |
+| **Audience verification**   | Validates the `aud` claim if `CADDE_JWT_AUDIENCE` is configured                              |
 
 **設定例:**
 
@@ -2277,18 +2379,18 @@ curl -X PUT "https://api.example.com/admin/cadde" \
 
 JWT 検証が失敗した場合、詳細なエラーメッセージが返されます:
 
-| エラー | 説明 |
-|-------|-------------|
-| `Malformed JWT token` | 無効なトークン形式 |
-| `Invalid token signature` | 無効な署名 |
-| `Token has expired` | トークンの有効期限切れ |
-| `Invalid token issuer` | 発行者クレームが一致しない |
-| `Invalid token audience` | 対象者クレームが一致しない |
-| `Unsupported signing algorithm` | サポートされていないアルゴリズム (RS256/ES256 以外) |
-| `Unable to fetch signing keys` | JWKS エンドポイントへのアクセスに失敗 |
-| `Signing key not found` | 指定された kid を持つ鍵が JWKS に存在しない |
+| Error                           | Description                                           |
+| ------------------------------- | ----------------------------------------------------- |
+| `Malformed JWT token`           | Invalid token format                                  |
+| `Invalid token signature`       | Invalid signature                                     |
+| `Token has expired`             | Token has expired                                     |
+| `Invalid token issuer`          | Issuer claim does not match                           |
+| `Invalid token audience`        | Audience claim does not match                         |
+| `Unsupported signing algorithm` | Unsupported algorithm (other than RS256/ES256)        |
+| `Unable to fetch signing keys`  | Failed to access the JWKS endpoint                    |
+| `Signing key not found`         | The key with the specified kid does not exist in JWKS |
 
-**注意:** `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます (後方互換性のため)。
+**注意:** `jwksUrl` が設定されていない場合、トークンの存在のみがチェックされます(後方互換性のため)。
 
 ### 使用例
 
@@ -2309,7 +2411,7 @@ curl "http://localhost:3000/v2/entities" \
 
 ### NGSI-LD API での使用
 
-CADDE ヘッダは NGSI-LD API でも使用できます:
+CADDE ヘッダーは NGSI-LD API でも使用できます:
 
 ```bash
 curl "http://localhost:3000/ngsi-ld/v1/entities" \
@@ -2318,33 +2420,38 @@ curl "http://localhost:3000/ngsi-ld/v1/entities" \
   -H "x-cadde-provider: ld-provider" \
   -H "x-cadde-options: Fiware-Service:smartcity"
 ```
+
 ### CADDE Connector v4 API
 
-CADDE コネクタ v4 仕様に準拠した専用エンドポイント (CADDE 設定が有効な場合のみ利用可能、`PUT /admin/cadde` で設定)。
+CADDE connector v4 仕様に準拠した専用エンドポイント(CADDE 設定が有効な場合のみ利用可能、`PUT /admin/cadde` 経由で設定)。
 
-参考: https://github.com/CADDE-sip/connector
+参考: <https://github.com/CADDE-sip/connector>
 
 #### エンドポイント一覧
 
-| メソッド | パス | 説明 |
-|--------|------|-------------|
-| GET | `/cadde/api/v4/catalog` | カタログ検索 (横断検索 / 詳細検索) |
-| GET | `/cadde/api/v4/entities` | NGSI データ交換 |
+| Method | Path                     | Description                                            |
+| ------ | ------------------------ | ------------------------------------------------------ |
+| GET    | `/cadde/api/v4/catalog`  | Catalog search (cross-domain search / detailed search) |
+| GET    | `/cadde/api/v4/entities` | NGSI data exchange                                     |
 
 #### カタログ検索 (`/cadde/api/v4/catalog`
+
 )
 
 `x-cadde-search` ヘッダーを使用して検索タイプを指定します:
 
-| 検索タイプ | ヘッダー値 | 説明 |
-|-------------|--------------|-------------|
-| 横断検索 | `x-cadde-search: meta` | CKAN 形式のデータセット一覧を返却 (`q` パラメータによるキーワードフィルタリング) |
-| 詳細検索 | `x-cadde-search: detail` | 個別データセットの詳細を返却 (`id` または `fq` パラメータで指定) |
+| Search Type         | Header Value             | Description                                                                     |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------- |
+| Cross-domain search | `x-cadde-search: meta`   | Returns dataset list in CKAN format (keyword filtering via `q` parameter)       |
+| Detailed search     | `x-cadde-search: detail` | Returns details of an individual dataset (specified via `id` or `fq` parameter) |
 
 CADDE 固有のフィールドがレスポンスに追加されます:
-- `caddec_dataset_id_for_detail`: 詳細検索用のデータセット ID
-- `caddec_provider_id`: プロバイダ ID (`CADDE_DEFAULT_PROVIDER` が設定されている場合)
-- `caddec_resource_type`: リソースタイプ (`api/ngsi`)
+
+* `caddec_dataset_id_for_detail`: 詳細検索用のデータセット ID
+  
+* `caddec_provider_id`: プロバイダ ID(`CADDE_DEFAULT_PROVIDER` が設定されている場合)
+  
+* `caddec_resource_type`: リソースタイプ (`api/ngsi`)
 
 ```bash
 # Cross-domain search
@@ -2361,15 +2468,16 @@ curl "http://localhost:3000/cadde/api/v4/catalog?id=sensor" \
 ```
 
 #### NGSI データ交換 (`/cadde/api/v4/entities`
+
 )
 
 `x-cadde-resource-url` ヘッダーからクエリパラメータを解析してエンティティを取得します。
 
-| ヘッダー | 必須 | 説明 |
-|--------|----------|-------------|
-| `x-cadde-resource-url` | Yes | リソース URL (type、id、q、attrs、limit、offset をクエリパラメータとして含む) |
-| `x-cadde-resource-api-type` | - | レスポンス形式: `api/ngsi` (デフォルト) または `api/ngsi-ld` |
-| `x-cadde-provider` | - | データプロバイダ ID |
+| Header                      | Required | Description                                                                     |
+| --------------------------- | -------- | ------------------------------------------------------------------------------- |
+| `x-cadde-resource-url`      | Yes      | Resource URL (containing type, id, q, attrs, limit, offset as query parameters) |
+| `x-cadde-resource-api-type` | -        | Response format: `api/ngsi` (default) or `api/ngsi-ld`                          |
+| `x-cadde-provider`          | -        | Data provider ID                                                                |
 
 ```bash
 # Retrieve entities in NGSIv2 format
@@ -2401,15 +2509,18 @@ CADDE v4 エンドポイントは GeonicDB 認証 (`requireAuth`) をバイパ�
 
 ### 参考資料
 
-- [CADDE (分野間データ連携基盤)](https://www.data-ex.jp/)
-- [CADDE-sip/connector](https://github.com/CADDE-sip/connector)
-- [DATA-EX](https://data-ex.jp/)
 
----
+* [CADDE (Cross-sector Data Exchange Infrastructure)](https://www.data-ex.jp/)
+  
+* [CADDE-sip/connector](https://github.com/CADDE-sip/connector)
+  
+* [DATA-EX](https://data-ex.jp/)
+
+***
 
 ## イベントストリーミング
 
-WebSocket API Gateway を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化します。
+WebSocket API Gateway を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化されます。
 
 ### 接続
 
@@ -2419,22 +2530,22 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 
 ### クライアントメッセージ
 
-| アクション | 説明 |
-|--------|-------------|
-| `subscribe` | エンティティタイプ / ID パターンでフィルタを設定 |
-| `ping` | キープアライブ (`pong` レスポンス) |
+| Action      | Description                           |
+| ----------- | ------------------------------------- |
+| `subscribe` | Set filters by entity type/ID pattern |
+| `ping`      | Keep-alive (`pong` response)          |
 
 ### サーバーイベント
 
-| タイプ | 説明 |
-|------|-------------|
-| `entityCreated` | エンティティが作成されました |
-| `entityUpdated` | エンティティが更新されました |
-| `entityDeleted` | エンティティが削除されました |
+| Type            | Description           |
+| --------------- | --------------------- |
+| `entityCreated` | An entity was created |
+| `entityUpdated` | An entity was updated |
+| `entityDeleted` | An entity was deleted |
 
-詳細は [イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
+詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md)を参照してください。
 
----
+***
 
 ## エラーレスポンス
 
@@ -2447,10 +2558,10 @@ wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={tenantName}
 }
 ```
 
-### NGSI-LD エラーフォーマット (RFC 7807 ProblemDetails)
+### NGSI-LD エラーフォーマット(RFC 7807 ProblemDetails)
 
-NGSI-LD API のエラーレスポンスは [RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
-Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` ではなく標準の JSON MIME タイプが使用されます)。
+NGSI-LD API のエラーレスポンスは、[RFC 7807](https://tools.ietf.org/html/rfc7807) ProblemDetails フォーマットで返されます。
+Content-Type は `application/json` です(ETSI GS CIM 009 仕様に準拠するため、RFC 7807 の `application/problem+json` ではなく、標準の JSON MIME タイプが使用されます)。
 
 ```json
 {
@@ -2463,63 +2574,63 @@ Content-Type は `application/json` です (ETSI GS CIM 009 仕様に準拠す�
 
 ### HTTP ステータスコード
 
-| コード | 説明 |
-|------|-------------|
-| `200` | 成功 (データあり) |
-| `201` | 正常に作成されました |
-| `204` | 成功 (データなし) |
-| `207` | 部分的な成功 (バッチ操作) |
-| `400` | 不正なリクエスト |
-| `403` | 禁止 (認可エラー) |
-| `404` | リソースが見つかりません |
-| `405` | メソッドが許可されていません (NGSI-LD、`Allow` ヘッダー付き) |
-| `409` | 競合 (既に存在する、など) |
-| `500` | 内部サーバーエラー |
+| Code  | Description                                       |
+| ----- | ------------------------------------------------- |
+| `200` | Success (with data)                               |
+| `201` | Created successfully                              |
+| `204` | Success (no data)                                 |
+| `207` | Partial success (batch operations)                |
+| `400` | Bad request                                       |
+| `403` | Forbidden (authorization error)                   |
+| `404` | Resource not found                                |
+| `405` | Method not allowed (NGSI-LD, with `Allow` header) |
+| `409` | Conflict (already exists, etc.)                   |
+| `500` | Internal server error                             |
 
----
+***
 
 ## 実装状況
 
 ### 実装済み機能
 
-| 機能 | NGSIv2 | NGSI-LD |
-|---------|--------|---------|
-| エンティティ CRUD | Yes | Yes |
-| 属性操作 | Yes | Yes |
-| 属性値の直接取得/更新 | Yes | - |
-| バッチ操作 | Yes | Yes |
-| サブスクリプション (HTTP 通知) | Yes | Yes |
-| サブスクリプション (MQTT 通知) | Yes | Yes |
-| イベントストリーミング (WebSocket) | Yes | Yes |
-| エンティティタイプ | Yes | - |
-| クエリ言語 (q パラメータ) | Yes | Yes |
-| ソート (orderBy, orderDirection) | Yes | Yes |
-| メタデータ制御 (metadata / sysAttrs) | Yes | Yes |
-| 地理クエリ (coveredBy, within, intersects, disjoint) | Yes | Yes |
-| 空間 ID 検索 (ZFXY フォーマット) | Yes | Yes |
-| GeoJSON 出力 | Yes | Yes |
-| 座標参照系 (CRS) 変換 | Yes | Yes |
-| マルチテナンシー | Yes | Yes |
-| ページネーション | Yes | Yes |
-| keyValues フォーマット | Yes | Yes |
-| レジストレーション | Yes | Yes |
-| コンテキストプロバイダー (フェデレーション/クエリ転送) | Yes | Yes |
-| コンテキストプロバイダー (更新転送) | Yes | Yes |
-| CADDE 連携 | Yes | Yes |
-| 認証 API (JWT ベース) | Yes | Yes |
-| ユーザー/テナント管理 API | Yes | Yes |
-| `/version` エンドポイント | Yes | - |
-| `/.well-known/ngsi-ld` | - | Yes |
-| ヘルスチェック (`/health`) | Yes | Yes |
+| Feature                                               | NGSIv2 | NGSI-LD |
+| ----------------------------------------------------- | ------ | ------- |
+| Entity CRUD                                           | Yes    | Yes     |
+| Attribute operations                                  | Yes    | Yes     |
+| Direct attribute value retrieval/update               | Yes    | -       |
+| Batch operations                                      | Yes    | Yes     |
+| Subscriptions (HTTP notifications)                    | Yes    | Yes     |
+| Subscriptions (MQTT notifications)                    | Yes    | Yes     |
+| Event streaming (WebSocket)                           | Yes    | Yes     |
+| Entity types                                          | Yes    | -       |
+| Query language (q parameter)                          | Yes    | Yes     |
+| Sorting (orderBy, orderDirection)                     | Yes    | Yes     |
+| Metadata control (metadata / sysAttrs)                | Yes    | Yes     |
+| Geo-queries (coveredBy, within, intersects, disjoint) | Yes    | Yes     |
+| Spatial ID search (ZFXY format)                       | Yes    | Yes     |
+| GeoJSON output                                        | Yes    | Yes     |
+| Coordinate Reference System (CRS) conversion          | Yes    | Yes     |
+| Multi-tenancy                                         | Yes    | Yes     |
+| Pagination                                            | Yes    | Yes     |
+| keyValues format                                      | Yes    | Yes     |
+| Registrations                                         | Yes    | Yes     |
+| Context providers (federation/query forwarding)       | Yes    | Yes     |
+| Context providers (update forwarding)                 | Yes    | Yes     |
+| CADDE integration                                     | Yes    | Yes     |
+| Authentication API (JWT-based)                        | Yes    | Yes     |
+| User/tenant management API                            | Yes    | Yes     |
+| `/version` endpoint                                   | Yes    | -       |
+| `/.well-known/ngsi-ld`                                | -      | Yes     |
+| Health check (`/health`)                              | Yes    | Yes     |
 
 ### 制限事項
 
-| 機能 | ステータス | 備考 |
-|---------|--------|-------|
-| `near` 地理クエリ (近接検索) | サポート済み | ポイントジオメトリのみ。`orderByDistance=true` による距離ソートと距離情報をサポート |
-| `minDistance` / `maxDistance` | サポート済み | メートル単位で指定 |
+| Feature                             | Status    | Notes                                                                                               |
+| ----------------------------------- | --------- | --------------------------------------------------------------------------------------------------- |
+| `near` geo-query (proximity search) | Supported | Point geometry only; supports distance sorting and distance information with `orderByDistance=true` |
+| `minDistance` / `maxDistance`       | Supported | Specified in meters                                                                                 |
 
----
+***
 
 ## 使用例
 
@@ -2553,7 +2664,7 @@ curl -X GET "https://api.example.com/v2/entities?type=Room&q=temperature>25" \
   -H "Fiware-Service: smartcity"
 ```
 
-### ジオクエリ(ポリゴンエリア検索)
+### Geo-Query (ポリゴンエリア検索)
 
 ```bash
 curl -X GET "https://api.example.com/v2/entities?type=Place&georel=coveredBy&geometry=polygon&coords=34,138;34,141;37,141;37,138;34,138" \
@@ -2596,206 +2707,214 @@ curl -X POST "https://api.example.com/ngsi-ld/v1/entities" \
   }'
 ```
 
----
+***
 
 ## エンドポイントリファレンス
 
-このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、ステータスコード情報をまとめています。
+このセクションでは、すべての GeonicDB API エンドポイントのページネーション、認証/認可、およびステータスコード情報をまとめています。
 
 ### API カテゴリ
 
-| API カテゴリ | ベースパス | 認証 | Content-Type |
-|--------------|-----------|----------------|--------------|
-| Meta/Health | `/` | 不要*† | `application/json` |
-| Authentication | `/auth` | 不要 | `application/json` |
-| User | `/me` | 必要 | `application/json` |
-| NGSIv2 | `/v2` | 必要* | `application/json` |
-| NGSI-LD | `/ngsi-ld/v1` | 必要* | `application/ld+json` |
-| Admin | `/admin` | 必要 (super_admin / tenant_admin) | `application/json` |
-| Catalog | `/catalog` | 必要* | `application/json` |
+| API Category   | Base Path     | Authentication                          | Content-Type          |
+| -------------- | ------------- | --------------------------------------- | --------------------- |
+| Meta/Health    | `/`           | Not required\*†                         | `application/json`    |
+| Authentication | `/auth`       | Not required                            | `application/json`    |
+| User           | `/me`         | Required                                | `application/json`    |
+| NGSIv2         | `/v2`         | Required\*                              | `application/json`    |
+| NGSI-LD        | `/ngsi-ld/v1` | Required\*                              | `application/ld+json` |
+| Admin          | `/admin`      | Required (super\_admin / tenant\_admin) | `application/json`    |
+| Catalog        | `/catalog`    | Required\*                              | `application/json`    |
 
-\* `AUTH_ENABLED=false` の場合は認証不要
+\* `AUTH_ENABLED=false` の場合、認証は不要です
 
-† `/statistics`、`/cache/statistics`、`/metrics` は `AUTH_ENABLED=true` の場合に認証が必要
+† `/statistics`、`/cache/statistics`、`/metrics` は `AUTH_ENABLED=true` の場合、認証が必要です
 
-### パブリックエンドポイント (Meta/Health)
+### パブリックエンドポイント (メタ/ヘルス)
 
 認証なしでアクセス可能なエンドポイント。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/llms.txt` | GET | API ドキュメント (llms.txt) | 200 | - |
-| `/version` | GET | FIWARE Orion 互換バージョン情報 | 200 | - |
-| `/health` | GET | 基本ヘルスチェック | 200 | - |
-| `/health/live` | GET | Kubernetes liveness プローブ | 200 | - |
-| `/health/ready` | GET | Kubernetes readiness プローブ | 200 | 503 |
-| `/.well-known/ngsi-ld` | GET | NGSI-LD API ディスカバリー | 200 | - |
-| `/api.json` | GET | API リファレンス (JSON) | 200 | - |
-| `/openapi.json` | GET | OpenAPI 3.0 仕様 | 200 | - |
-| `/statistics` | GET | FIWARE Orion 互換統計情報(認証必要) | 200 | 401 |
-| `/cache/statistics` | GET | キャッシュ統計情報(認証必要) | 200 | 401 |
-| `/metrics` | GET | Prometheus メトリクス(認証必要) | 200 | 401 |
-| `/tools.json` | GET | AI ツール定義 (Claude Tool Use / OpenAI Function Calling) | 200 | - |
-| `/.well-known/ai-plugin.json` | GET | AI プラグインマニフェスト | 200 | - |
-| `/mcp` | POST | MCP (Model Context Protocol) Streamable HTTP エンドポイント | 200 | 400, 405, 500 |
-| `/.well-known/agent-card.json` | GET | A2A Agent Card | 200 | - |
+| Endpoint                       | Method | Description                                                     | Success | Error         |
+| ------------------------------ | ------ | --------------------------------------------------------------- | ------- | ------------- |
+| `/llms.txt`                    | GET    | API documentation (llms.txt)                                    | 200     | -             |
+| `/version`                     | GET    | FIWARE Orion-compatible version information                     | 200     | -             |
+| `/health`                      | GET    | Basic health check                                              | 200     | -             |
+| `/health/live`                 | GET    | Kubernetes liveness probe                                       | 200     | -             |
+| `/health/ready`                | GET    | Kubernetes readiness probe                                      | 200     | 503           |
+| `/.well-known/ngsi-ld`         | GET    | NGSI-LD API discovery                                           | 200     | -             |
+| `/api.json`                    | GET    | API reference (JSON)                                            | 200     | -             |
+| `/openapi.json`                | GET    | OpenAPI 3.0 specification                                       | 200     | -             |
+| `/statistics`                  | GET    | FIWARE Orion-compatible statistics (authentication required)    | 200     | 401           |
+| `/cache/statistics`            | GET    | Cache statistics (authentication required)                      | 200     | 401           |
+| `/metrics`                     | GET    | Prometheus metrics (authentication required)                    | 200     | 401           |
+| `/tools.json`                  | GET    | AI tool definitions (Claude Tool Use / OpenAI Function Calling) | 200     | -             |
+| `/.well-known/ai-plugin.json`  | GET    | AI plugin manifest                                              | 200     | -             |
+| `/mcp`                         | POST   | MCP (Model Context Protocol) Streamable HTTP endpoint           | 200     | 400, 405, 500 |
+| `/.well-known/agent-card.json` | GET    | A2A Agent Card                                                  | 200     | -             |
 
-### AI エージェントエンドポイント (AUTH_ENABLED=true の場合は認証必要)
+### AI エージェントエンドポイント (AUTH\_ENABLED=true の場合、認証が必要)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/a2a` | POST | A2A (Agent-to-Agent) JSON-RPC 2.0 エンドポイント | 200 | 400, 401, 405, 500 |
+| Endpoint | Method | Description                                | Success | Error              |
+| -------- | ------ | ------------------------------------------ | ------- | ------------------ |
+| `/a2a`   | POST   | A2A (Agent-to-Agent) JSON-RPC 2.0 endpoint | 200     | 400, 401, 405, 500 |
 
 ### 認証エンドポイント
 
-- `/auth/*` は `AUTH_ENABLED=true` の場合のみ利用可能
-- `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能(常に有効; `OAUTH_ENABLED` は非推奨)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/auth/login` | POST | ユーザーログイン (JWT) | 200 | 400, 401 |
-| `/auth/refresh` | POST | トークンリフレッシュ | 200 | 400, 401 |
-| `/auth/logout` | POST | ログアウト(すべてのセッションを無効化、認証必要) | 204 | 401 |
-| `/auth/nonce` | POST | Nonce + PoW チャレンジによる API キートークン交換 | 200 | 400 |
-| `/oauth/token` | POST | OAuth トークン取得 (M2M: `grant_type=client_credentials`、Browser SDK: `grant_type=api_key`) | 200 | 400, 401 |
+* `/auth/*` は `AUTH_ENABLED=true` の場合にのみ利用可能です
+  
+* `/oauth/token` は `AUTH_ENABLED=true` の場合に利用可能です (常に有効、`OAUTH_ENABLED` は非推奨)
+
+| Endpoint        | Method | Description                                                                                       | Success | Error    |
+| --------------- | ------ | ------------------------------------------------------------------------------------------------- | ------- | -------- |
+| `/auth/login`   | POST   | User login (JWT)                                                                                  | 200     | 400, 401 |
+| `/auth/refresh` | POST   | Token refresh                                                                                     | 200     | 400, 401 |
+| `/auth/logout`  | POST   | Logout (invalidate all sessions, authentication required)                                         | 204     | 401      |
+| `/auth/nonce`   | POST   | Nonce + PoW challenge for API key token exchange                                                  | 200     | 400      |
+| `/oauth/token`  | POST   | OAuth token acquisition (M2M: `grant_type=client_credentials`, Browser SDK: `grant_type=api_key`) | 200     | 400, 401 |
 
 ### SDK
 
-JavaScript SDK は npm パッケージとして提供されています: `npm install @geolonia/geonicdb-sdk`SDK は完全なパブリック API を提供します: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー(`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
+JavaScript SDK は npm パッケージとして利用可能です: `npm install @geolonia/geonicdb-sdk`
+
+SDK は完全なパブリック API を提供します: `login()`、`setCredentials()`、エンティティ CRUD、`request()`、`connect()`、`reconnect()`、`disconnect()`、`isConnected()`、`subscribe()`、`on()`/`off()` イベントリスナー (`tokenRefresh` イベントを含む)。詳細は SDK ドキュメントを参照してください。
 
 ### ユーザーエンドポイント
 
-認証されたユーザーが自分の情報を管理するためのエンドポイントです。
+認証されたユーザーが自分の情報を管理するためのエンドポイント。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | 最小ロール |
-|----------|--------|-------------|---------|-------|--------------|
-| `/me` | GET | 自分のプロフィールを取得 | 200 | 401 | user |
-| `/me/password` | POST | パスワードを変更 | 204 | 400, 401 | user |
+| Endpoint       | Method | Description          | Success | Error    | Minimum Role |
+| -------------- | ------ | -------------------- | ------- | -------- | ------------ |
+| `/me`          | GET    | Retrieve own profile | 200     | 401      | user         |
+| `/me/password` | POST   | Change password      | 204     | 400, 401 | user         |
 
 ### NGSIv2 / NGSI-LD エンドポイント
 
-エンドポイントの詳細な仕様については、以下を参照してください:
-- [NGSIv2 API リファレンス](./ngsiv2.md)
-- [NGSI-LD API リファレンス](./ngsild.md)
+詳細なエンドポイント仕様については、以下を参照してください:
+
+* [NGSIv2 API リファレンス](./ngsiv2.md)
+  
+* [NGSI-LD API リファレンス](./ngsild.md)
 
 ### Admin API
 
-テナントとユーザーを管理するための API です。エンドポイントには `super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントスコープのみ)。
+テナントとユーザーを管理するための API です。エンドポイントには `super_admin` または `tenant_admin` ロールが必要です(`tenant_admin` は自テナントのスコープのみ)。
 
 #### テナント管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/tenants` | GET | テナント一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/tenants` | POST | テナント作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/tenants/{tenantId}` | GET | テナント取得 | 200 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}` | PATCH | テナント更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/tenants/{tenantId}` | DELETE | テナント削除 (`?shred=true` による Crypto-Shredding) | 204 / 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/deletion-report` | GET | 削除レポート取得 | 200 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/activate` | POST | テナント有効化 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/deactivate` | POST | テナント無効化 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/ip-restrictions` | GET | テナント IP 制限取得 | 200 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/ip-restrictions` | PUT | テナント IP 制限更新 | 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | テナント IP 制限削除 | 204 | 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users` | GET | テナントメンバー一覧取得 (tenant_admin: 自テナントのみ) | 200 | 401, 403, 404 | あり (最大: 100) |
-| `/admin/tenants/{tenantId}/users/{userId}` | PUT | テナントにユーザーを追加 (tenant_admin: 自テナントのみ) | 200 | 400, 401, 403, 404 | - |
-| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | テナントからユーザーを削除 (tenant_admin: 自テナントのみ) | 204 | 400, 401, 403, 404 | - |
+| Endpoint                                    | Method | Description                                              | Success   | Error                   | Pagination     |
+| ------------------------------------------- | ------ | -------------------------------------------------------- | --------- | ----------------------- | -------------- |
+| `/admin/tenants`                            | GET    | List tenants                                             | 200       | 400, 401, 403           | Yes (max: 100) |
+| `/admin/tenants`                            | POST   | Create tenant                                            | 201       | 400, 401, 403, 409      | -              |
+| `/admin/tenants/{tenantId}`                 | GET    | Get tenant                                               | 200       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}`                 | PATCH  | Update tenant                                            | 204       | 400, 401, 403, 404, 409 | -              |
+| `/admin/tenants/{tenantId}`                 | DELETE | Delete tenant (Crypto-Shredding with `?shred=true`)      | 204 / 200 | 400, 401, 403, 404      | -              |
+| `/admin/tenants/{tenantId}/deletion-report` | GET    | Get deletion report                                      | 200       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/activate`        | POST   | Activate tenant                                          | 204       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/deactivate`      | POST   | Deactivate tenant                                        | 204       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/ip-restrictions` | GET    | Get tenant IP restrictions                               | 200       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/ip-restrictions` | PUT    | Update tenant IP restrictions                            | 200       | 400, 401, 403, 404      | -              |
+| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | Delete tenant IP restrictions                            | 204       | 401, 403, 404           | -              |
+| `/admin/tenants/{tenantId}/users`           | GET    | List tenant members (tenant\_admin: own tenant only)     | 200       | 401, 403, 404           | Yes (max: 100) |
+| `/admin/tenants/{tenantId}/users/{userId}`  | PUT    | Add user to tenant (tenant\_admin: own tenant only)      | 200       | 400, 401, 403, 404      | -              |
+| `/admin/tenants/{tenantId}/users/{userId}`  | DELETE | Remove user from tenant (tenant\_admin: own tenant only) | 204       | 400, 401, 403, 404      | -              |
 
 #### ユーザー管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/users` | GET | ユーザー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/users` | POST | ユーザー作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/users/{userId}` | GET | ユーザー取得 | 200 | 401, 403, 404 | - |
-| `/admin/users/{userId}` | PATCH | ユーザー更新 | 204 | 400, 401, 403, 404, 409 | - |
-| `/admin/users/{userId}` | DELETE | ユーザー削除 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/activate` | POST | ユーザー有効化 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/deactivate` | POST | ユーザー無効化 | 204 | 401, 403, 404 | - |
-| `/admin/users/{userId}/unlock` | POST | ログインロック解除 | 200 | 400, 401, 403, 404 | - |
-| `/admin/users/{userId}/tenants` | GET | ユーザーが所属するテナント一覧取得 (自分自身または super_admin) | 200 | 401, 403 | あり (最大: 100) |
+| Endpoint                           | Method | Description                                             | Success | Error                   | Pagination     |
+| ---------------------------------- | ------ | ------------------------------------------------------- | ------- | ----------------------- | -------------- |
+| `/admin/users`                     | GET    | List users                                              | 200     | 400, 401, 403           | Yes (max: 100) |
+| `/admin/users`                     | POST   | Create user                                             | 201     | 400, 401, 403, 409      | -              |
+| `/admin/users/{userId}`            | GET    | Get user                                                | 200     | 401, 403, 404           | -              |
+| `/admin/users/{userId}`            | PATCH  | Update user                                             | 204     | 400, 401, 403, 404, 409 | -              |
+| `/admin/users/{userId}`            | DELETE | Delete user                                             | 204     | 401, 403, 404           | -              |
+| `/admin/users/{userId}/activate`   | POST   | Activate user                                           | 204     | 401, 403, 404           | -              |
+| `/admin/users/{userId}/deactivate` | POST   | Deactivate user                                         | 204     | 401, 403, 404           | -              |
+| `/admin/users/{userId}/unlock`     | POST   | Unlock login                                            | 200     | 400, 401, 403, 404      | -              |
+| `/admin/users/{userId}/tenants`    | GET    | List tenants the user belongs to (self or super\_admin) | 200     | 401, 403                | Yes (max: 100) |
 
-#### ポリシー管理 (XACML 3.0 認可、super_admin / tenant_admin)
+#### ポリシー管理(XACML 3.0 認可、super\_admin / tenant\_admin)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/policies` | GET | ポリシー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/policies` | POST | ポリシー作成 | 201 | 400, 401, 403, 409 | - |
-| `/admin/policies/{policyId}` | GET | ポリシー取得 | 200 | 401, 403, 404 | - |
-| `/admin/policies/{policyId}` | PATCH | ポリシー部分更新 | 200 | 400, 401, 403, 404 | - |
-| `/admin/policies/{policyId}` | PUT | ポリシー置換 | 200 | 400, 401, 403, 404 | - |
-| `/admin/policies/{policyId}` | DELETE | ポリシー削除 | 204 | 401, 403, 404 | - |
-| `/admin/policies/{policyId}/activate` | POST | ポリシー有効化 | 200 | 401, 403, 404 | - |
-| `/admin/policies/{policyId}/deactivate` | POST | ポリシー無効化 | 200 | 401, 403, 404 | - |
+| Endpoint                                | Method | Description           | Success | Error              | Pagination     |
+| --------------------------------------- | ------ | --------------------- | ------- | ------------------ | -------------- |
+| `/admin/policies`                       | GET    | List policies         | 200     | 400, 401, 403      | Yes (max: 100) |
+| `/admin/policies`                       | POST   | Create policy         | 201     | 400, 401, 403, 409 | -              |
+| `/admin/policies/{policyId}`            | GET    | Get policy            | 200     | 401, 403, 404      | -              |
+| `/admin/policies/{policyId}`            | PATCH  | Partial policy update | 200     | 400, 401, 403, 404 | -              |
+| `/admin/policies/{policyId}`            | PUT    | Replace policy        | 200     | 400, 401, 403, 404 | -              |
+| `/admin/policies/{policyId}`            | DELETE | Delete policy         | 204     | 401, 403, 404      | -              |
+| `/admin/policies/{policyId}/activate`   | POST   | Activate policy       | 200     | 401, 403, 404      | -              |
+| `/admin/policies/{policyId}/deactivate` | POST   | Deactivate policy     | 200     | 401, 403, 404      | -              |
 
-ポリシー Target `resources` で利用可能な **リソース属性**:
+**リソース属性** はポリシー Target `resources` で利用可能です:
 
-| attributeId | 説明 | ソース |
-|-------------|-------------|--------|
-| `path` | HTTP リクエストパス (例: `/v2/entities/Room1`) | リクエスト |
-| `tenantService` | テナントサービス名 (`Fiware-Service` ヘッダー) | リクエスト |
-| `servicePath` | ServicePath (`Fiware-ServicePath` ヘッダー) | リクエスト |
-| `scope` | NGSI-LD エンティティスコープ (カンマ区切り) | エンティティコンテキスト |
-| `entityId` | 対象エンティティ ID (例: `Room1`) | エンティティコンテキスト |
-| `entityType` | 対象エンティティタイプ (例: `Room`) | リクエスト (自動抽出) / エンティティコンテキスト |
-| `entityOwner` | エンティティ作成者の userId (`createdBy` フィールド) | エンティティコンテキスト |
+| attributeId     | Description                                   | Source                                    |
+| --------------- | --------------------------------------------- | ----------------------------------------- |
+| `path`          | HTTP request path (e.g. `/v2/entities/Room1`) | Request                                   |
+| `tenantService` | Tenant service name (`Fiware-Service` header) | Request                                   |
+| `servicePath`   | Service path (`Fiware-ServicePath` header)    | Request                                   |
+| `scope`         | NGSI-LD entity scope (comma-separated)        | Entity context                            |
+| `entityId`      | Target entity ID (e.g. `Room1`)               | Entity context                            |
+| `entityType`    | Target entity type (e.g. `Room`)              | Request (auto-extracted) / Entity context |
+| `entityOwner`   | Entity creator's userId (`createdBy` field)   | Entity context                            |
 
-> `entityType` は、HTTP リクエストのパスレベルから自動的に抽出されます。`?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから取得され、エンティティレベルのチェックなしでエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、`scope` は、エンティティレベルの認可チェック(`requireEntityAuthz` 経由)でのみ利用可能です。`scope` は、NGSI-LD エンティティのスコープ配列をカンマ区切り文字列として結合したもので、柔軟なマッチングには `string-regexp` または `glob` を使用してください。
+> `entityType` はパスレベルの HTTP リクエストから自動的に抽出されます — `?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから — エンティティレベルのチェックを行わずにエンティティタイプベースのアクセス制御を可能にします。`entityId`、`entityOwner`、`scope` はエンティティレベルの認可チェック(`requireEntityAuthz` 経由)でのみ利用可能です。`scope` は NGSI-LD エンティティの scope 配列をカンマ区切り文字列として結合したものです — 柔軟なマッチングには `string-regexp` または `glob` を使用してください。
 
 #### OAuth クライアント管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/oauth-clients` | GET | OAuth クライアント一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/oauth-clients` | POST | OAuth クライアント作成 | 201 | 400, 401, 403 | - |
-| `/admin/oauth-clients/{clientId}` | GET | OAuth クライアント取得 | 200 | 401, 403, 404 | - |
-| `/admin/oauth-clients/{clientId}` | PATCH | OAuth クライアント更新 | 200 | 400, 401, 403, 404 | - |
-| `/admin/oauth-clients/{clientId}` | DELETE | OAuth クライアント削除 | 204 | 401, 403, 404 | - |
+| Endpoint                          | Method | Description         | Success | Error              | Pagination     |
+| --------------------------------- | ------ | ------------------- | ------- | ------------------ | -------------- |
+| `/admin/oauth-clients`            | GET    | List OAuth clients  | 200     | 400, 401, 403      | Yes (max: 100) |
+| `/admin/oauth-clients`            | POST   | Create OAuth client | 201     | 400, 401, 403      | -              |
+| `/admin/oauth-clients/{clientId}` | GET    | Get OAuth client    | 200     | 401, 403, 404      | -              |
+| `/admin/oauth-clients/{clientId}` | PATCH  | Update OAuth client | 200     | 400, 401, 403, 404 | -              |
+| `/admin/oauth-clients/{clientId}` | DELETE | Delete OAuth client | 204     | 401, 403, 404      | -              |
 
 #### セルフサービス OAuth クライアント管理
 
-ユーザーは自分自身の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアント。オプションの `policyId` により、クライアントを既存の XACML ポリシーにバインドできます。
+ユーザーは自分の OAuth クライアントを管理できます。ユーザーあたり最大 5 クライアントです。オプションの `policyId` はクライアントを既存の XACML ポリシーにバインドします。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/me/oauth-clients` | GET | 自分の OAuth クライアント一覧取得 | 200 | 400, 401 | あり (最大: 100) |
-| `/me/oauth-clients` | POST | 自分の OAuth クライアント作成 | 201 | 400, 401, 403 | - |
-| `/me/oauth-clients/{clientId}` | PATCH | 自分の OAuth クライアント更新 (部分更新) | 200 | 400, 401, 403, 404 | - |
-| `/me/oauth-clients/{clientId}` | DELETE | 自分の OAuth クライアント削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/oauth-clients/{clientId}/regenerate-secret` | POST | 自分のクライアントシークレット再生成 | 200 | 400, 401, 403, 404 | - |
+| Endpoint                                         | Method | Description                       | Success | Error              | Pagination     |
+| ------------------------------------------------ | ------ | --------------------------------- | ------- | ------------------ | -------------- |
+| `/me/oauth-clients`                              | GET    | List own OAuth clients            | 200     | 400, 401           | Yes (max: 100) |
+| `/me/oauth-clients`                              | POST   | Create own OAuth client           | 201     | 400, 401, 403      | -              |
+| `/me/oauth-clients/{clientId}`                   | PATCH  | Update own OAuth client (partial) | 200     | 400, 401, 403, 404 | -              |
+| `/me/oauth-clients/{clientId}`                   | DELETE | Delete own OAuth client           | 204     | 400, 401, 403, 404 | -              |
+| `/me/oauth-clients/{clientId}/regenerate-secret` | POST   | Regenerate own client secret      | 200     | 400, 401, 403, 404 | -              |
 
 #### API キー管理
 
-`X-Api-Key` ヘッダーによる認証用の API キーを管理します。新しいキーはプレーン UUID 形式(`randomUUID()`)を使用します。既存の `gdb_` プレフィックス付きキーは引き続き有効です。保存時は SHA-256 でハッシュ化され、平文キーは作成時と更新時のみ返されます。一覧取得/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドにより、キーを既存の XACML ポリシーにバインドできます(バインドされたポリシーのターゲットは評価時にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト(api_key = All Deny)にフォールバックします。
+`X-Api-Key` ヘッダーによる認証のための API キーを管理します。新しいキーはプレーン UUID 形式(`randomUUID()`)を使用します。`gdb_` プレフィックス付きの既存のキーは引き続き有効です。保存には SHA-256 ハッシュを使用します。プレーンテキストキーは作成時とリフレッシュ時のみ返されます。リスト/取得レスポンスは `"key": "******"` を返します。オプションの `policyId` フィールドはキーを既存の XACML ポリシーにバインドします(バインドされたポリシーのターゲットは評価時にバイパスされます)。`policyId` がない場合、キーはテナントポリシー + ロールデフォルト(api\_key = All Deny)にフォールバックします。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/api-keys` | POST | API キー作成 | 201 | 400, 401, 403 | - |
-| `/admin/api-keys` | GET | API キー一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/admin/api-keys/{keyId}` | GET | API キー取得 | 200 | 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}` | PATCH | API キー更新 | 204 | 400, 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}` | DELETE | API キー削除 | 204 | 401, 403, 404 | - |
-| `/admin/api-keys/{keyId}/refresh` | POST | API キー更新 (再生成) | 200 | 401, 403, 404 | - |
+| Endpoint                          | Method | Description                  | Success | Error              | Pagination     |
+| --------------------------------- | ------ | ---------------------------- | ------- | ------------------ | -------------- |
+| `/admin/api-keys`                 | POST   | Create API key               | 201     | 400, 401, 403      | -              |
+| `/admin/api-keys`                 | GET    | List API keys                | 200     | 400, 401, 403      | Yes (max: 100) |
+| `/admin/api-keys/{keyId}`         | GET    | Get API key                  | 200     | 401, 403, 404      | -              |
+| `/admin/api-keys/{keyId}`         | PATCH  | Update API key               | 204     | 400, 401, 403, 404 | -              |
+| `/admin/api-keys/{keyId}`         | DELETE | Delete API key               | 204     | 401, 403, 404      | -              |
+| `/admin/api-keys/{keyId}/refresh` | POST   | Refresh (regenerate) API key | 200     | 401, 403, 404      | -              |
 
-#### セルフサービス API キー管理ユーザーは自分の API キーを管理できます。1 ユーザーにつき最大 5 つのキーまで作成可能です。
+#### セルフサービス API キー管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/me/api-keys` | POST | 自分の API キーを作成 | 201 | 400, 401, 403 | - |
-| `/me/api-keys` | GET | 自分の API キーを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
-| `/me/api-keys/{keyId}` | PATCH | 自分の API キーを更新(部分更新) | 200 | 400, 401, 403, 404 | - |
-| `/me/api-keys/{keyId}` | DELETE | 自分の API キーを削除 | 204 | 400, 401, 403, 404 | - |
-| `/me/api-keys/{keyId}/refresh` | POST | 自分の API キーをリフレッシュ(再生成) | 200 | 401, 403, 404 | - |
+ユーザーは自分の API キーを管理できます。ユーザーあたり最大 5 個のキーです。
+
+| Endpoint                       | Method | Description                      | Success | Error              | Pagination     |
+| ------------------------------ | ------ | -------------------------------- | ------- | ------------------ | -------------- |
+| `/me/api-keys`                 | POST   | Create own API key               | 201     | 400, 401, 403      | -              |
+| `/me/api-keys`                 | GET    | List own API keys                | 200     | 400, 401, 403      | Yes (max: 100) |
+| `/me/api-keys/{keyId}`         | PATCH  | Update own API key (partial)     | 200     | 400, 401, 403, 404 | -              |
+| `/me/api-keys/{keyId}`         | DELETE | Delete own API key               | 204     | 400, 401, 403, 404 | -              |
+| `/me/api-keys/{keyId}/refresh` | POST   | Refresh (regenerate) own API key | 200     | 401, 403, 404      | -              |
 
 #### CADDE 設定管理
 
-API を介して CADDE (分野間データ連携基盤) の設定を管理します。設定は MongoDB に保存され、環境変数は不要です。
+API 経由で CADDE (分野間データ交換基盤) の設定を管理します。設定は MongoDB に保存され、環境変数は不要です。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/admin/cadde` | GET | CADDE 設定を取得 | 200 | 401, 403 | - |
-| `/admin/cadde` | PUT | CADDE 設定を更新(upsert) | 200 | 400, 401, 403 | - |
-| `/admin/cadde` | DELETE | CADDE 設定を削除(無効化) | 204 | 401, 403 | - |
+| Endpoint       | Method | Description                          | Success | Error         | Pagination |
+| -------------- | ------ | ------------------------------------ | ------- | ------------- | ---------- |
+| `/admin/cadde` | GET    | Get CADDE configuration              | 200     | 401, 403      | -          |
+| `/admin/cadde` | PUT    | Update CADDE configuration (upsert)  | 200     | 400, 401, 403 | -          |
+| `/admin/cadde` | DELETE | Delete CADDE configuration (disable) | 204     | 401, 403      | -          |
 
 **リクエストボディ (PUT)**
 
@@ -2810,56 +2929,56 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 }
 ```
 
-| フィールド | 型 | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `enabled` | boolean | Yes | CADDE 機能を有効/無効化 |
-| `authEnabled` | boolean | Yes | Bearer 認証を有効/無効化 |
-| `defaultProvider` | string | - | デフォルトのプロバイダー ID |
-| `jwtIssuer` | string | - | JWT の issuer クレーム検証値 |
-| `jwtAudience` | string | - | JWT の audience クレーム検証値 |
-| `jwksUrl` | string | - | JWKS 公開鍵エンドポイント URL (HTTPS 必須) |
+| Field             | Type    | Required | Description                                   |
+| ----------------- | ------- | -------- | --------------------------------------------- |
+| `enabled`         | boolean | Yes      | Enable/disable CADDE functionality            |
+| `authEnabled`     | boolean | Yes      | Enable/disable Bearer authentication          |
+| `defaultProvider` | string  | -        | Default provider ID                           |
+| `jwtIssuer`       | string  | -        | JWT issuer claim validation value             |
+| `jwtAudience`     | string  | -        | JWT audience claim validation value           |
+| `jwksUrl`         | string  | -        | JWKS public key endpoint URL (HTTPS required) |
 
 #### ルールエンジン管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/rules` | GET | ルールを一覧表示 | 200 | 400, 401, 403 | Yes (max: 100) |
-| `/rules` | POST | ルールを作成 | 201 | 400, 401, 403, 409 | - |
-| `/rules/{ruleId}` | GET | ルールを取得 | 200 | 401, 403, 404 | - |
-| `/rules/{ruleId}` | PATCH | ルールを更新 | 204 | 400, 401, 403, 404 | - |
-| `/rules/{ruleId}` | DELETE | ルールを削除 | 204 | 401, 403, 404 | - |
-| `/rules/{ruleId}/activate` | POST | ルールを有効化 | 200 | 401, 403, 404 | - |
-| `/rules/{ruleId}/deactivate` | POST | ルールを無効化 | 200 | 401, 403, 404 | - |
+| Endpoint                     | Method | Description     | Success | Error              | Pagination     |
+| ---------------------------- | ------ | --------------- | ------- | ------------------ | -------------- |
+| `/rules`                     | GET    | List rules      | 200     | 400, 401, 403      | Yes (max: 100) |
+| `/rules`                     | POST   | Create rule     | 201     | 400, 401, 403, 409 | -              |
+| `/rules/{ruleId}`            | GET    | Get rule        | 200     | 401, 403, 404      | -              |
+| `/rules/{ruleId}`            | PATCH  | Update rule     | 204     | 400, 401, 403, 404 | -              |
+| `/rules/{ruleId}`            | DELETE | Delete rule     | 204     | 401, 403, 404      | -              |
+| `/rules/{ruleId}/activate`   | POST   | Activate rule   | 200     | 401, 403, 404      | -              |
+| `/rules/{ruleId}/deactivate` | POST   | Deactivate rule | 200     | 401, 403, 404      | -              |
 
 ### カスタムデータモデル API
 
-テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要で、XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールがテナント内のカスタムデータモデルを管理できます。
+テナント固有のカスタムデータモデルを管理するための API です。JWT 認証が必要です。XACML ポリシーベースの認可により、`tenant_admin` および `user` ロールは自分のテナント内でカスタムデータモデルを管理できます。
 
-**関連ドキュメント**: [SMART_DATA_MODELS.md](../features/smart-data-models.md)
+**関連ドキュメント**: [SMART\_DATA\_MODELS.md](../features/smart-data-models.md)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/custom-data-models` | GET | カスタムデータモデルの一覧取得 | 200 | 400, 401, 403 | あり (最大: 100) |
-| `/custom-data-models` | POST | カスタムデータモデルの作成 | 201 | 400, 401, 403, 409 | - |
-| `/custom-data-models/{type}` | GET | カスタムデータモデルの取得 | 200 | 401, 403, 404 | - |
-| `/custom-data-models/{type}` | PATCH | カスタムデータモデルの更新 | 200 | 400, 401, 403, 404 | - |
-| `/custom-data-models/{type}` | DELETE | カスタムデータモデルの削除 | 204 | 401, 403, 404 | - |
+| Endpoint                     | Method | Description              | Success | Error              | Pagination     |
+| ---------------------------- | ------ | ------------------------ | ------- | ------------------ | -------------- |
+| `/custom-data-models`        | GET    | List custom data models  | 200     | 400, 401, 403      | Yes (max: 100) |
+| `/custom-data-models`        | POST   | Create custom data model | 201     | 400, 401, 403, 409 | -              |
+| `/custom-data-models/{type}` | GET    | Get custom data model    | 200     | 401, 403, 404      | -              |
+| `/custom-data-models/{type}` | PATCH  | Update custom data model | 200     | 400, 401, 403, 404 | -              |
+| `/custom-data-models/{type}` | DELETE | Delete custom data model | 204     | 401, 403, 404      | -              |
 
 #### エンティティの検証
 
-カスタムデータモデルが定義されている場合、エンティティの作成または更新時に自動的に検証が実行されます。検証は `isActive: true` を持つモデルにのみ適用されます。
+カスタムデータモデルが定義されると、エンティティの作成または更新時に自動的に検証が実行されます。検証は `isActive: true` のモデルにのみ適用されます。
 
 **検証チェック:**
 
-| チェック | 説明 |
-|-------|-------------|
-| 追加プロパティ | `additionalProperties: false` の場合、`propertyDetails` で定義されていない属性は拒否されます (デフォルト: `true` — 任意の属性を許可) |
-| 必須フィールド | `required: true` を持つ属性が存在するかどうか |
-| 型チェック | `valueType` に基づく型検証 (string, number, integer, boolean, array, object, GeoJSON) |
-| minLength / maxLength | 文字列長の制約 |
-| minimum / maximum | 数値範囲の制約 |
-| pattern | 正規表現パターンマッチ |
-| enum | 許可された値のリスト |
+| Check                 | Description                                                                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Additional properties | When `additionalProperties: false`, attributes not defined in `propertyDetails` are rejected (default: `true` — allows any attributes) |
+| Required fields       | Whether attributes with `required: true` are present                                                                                   |
+| Type check            | Type validation based on `valueType` (string, number, integer, boolean, array, object, GeoJSON)                                        |
+| minLength / maxLength | String length constraints                                                                                                              |
+| minimum / maximum     | Numeric range constraints                                                                                                              |
+| pattern               | Regular expression pattern match                                                                                                       |
+| enum                  | List of permitted values                                                                                                               |
 
 検証失敗時は `400 Bad Request` が返されます:
 
@@ -2872,11 +2991,11 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 
 #### 自動 JSON Schema 生成
 
-カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動生成され、レスポンスの `jsonSchema` フィールドに含まれます。また、`jsonSchema` を手動で指定することも可能です。
+カスタムデータモデルが作成または更新されると、`propertyDetails` から JSON Schema (Draft 2020-12) が自動的に生成され、レスポンスの `jsonSchema` フィールドに含まれます。`jsonSchema` を手動で指定することも可能です。
 
 #### プロパティ @context (JSON-LD 語彙マッピング)
 
-`propertyDetails` の各プロパティには、JSON-LD 語彙マッピング用の HTTP(S) URL を指定できるオプションの `@context` フィールドを含めることができます。これにより、自動生成された URI の代わりに、よく知られた語彙 (例: schema.org) を使用できます。
+`propertyDetails` の各プロパティには、JSON-LD 語彙マッピング用の HTTP(S) URL を持つオプションの `@context` フィールドを含めることができます。これにより、自動生成された URI の代わりに、よく知られた語彙(例: schema.org)を使用できます。
 
 ```json
 {
@@ -2896,67 +3015,77 @@ API を介して CADDE (分野間データ連携基盤) の設定を管理しま
 }
 ```
 
-- `@context` を持つプロパティ → 指定された URL が JSON-LD コンテキストで使用されます
-- `@context` を持たないプロパティ → 自動生成された URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`)
-- プロパティ URI はエンティティタイプに依存しません (同じプロパティ名はテナント内で同じ URI を共有します)
-- `@context` は HTTP(S) URL である必要があります (URN は受け付けません)
 
-#### @context 解決の拡張
+* `@context` を持つプロパティ → JSON-LD コンテキストで指定された URL が使用されます
+  
+* `@context` を持たないプロパティ → 自動生成された URL (`https://geonicdb.geolonia.com/vocab/{tenantId}/{propertyName}`) が使用されます
+  
+* プロパティ URI はエンティティタイプに依存しません(同じプロパティ名はテナント内で同じ URI を共有します)
+  
+* `@context` は HTTP(S) URL である必要があります(URN は受け付けられません)
 
-NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストはエンティティの `@context` に自動的に含まれます (コアコンテキストと一緒に配列として返されます)。
+#### @context 解決拡張
+
+NGSI-LD レスポンスにおいて、カスタムデータモデルに `contextUrl` が設定されている場合、カスタムコンテキストがエンティティの `@context` に自動的に含まれます(コアコンテキストと一緒に配列として返されます)。
 
 ### カタログ API
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/catalog` | GET | DCAT-AP カタログの取得 | 200 | 401 | - |
-| `/catalog/datasets` | GET | データセットの一覧取得 | 200 | 400, 401 | あり (最大: 1000) |
-| `/catalog/datasets/{datasetId}` | GET | データセットの取得 | 200 | 401, 404 | - |
-| `/catalog/datasets/{datasetId}/sample` | GET | サンプルデータの取得 | 200 | 401, 404 | - |
+| Endpoint                               | Method | Description         | Success | Error    | Pagination      |
+| -------------------------------------- | ------ | ------------------- | ------- | -------- | --------------- |
+| `/catalog`                             | GET    | Get DCAT-AP catalog | 200     | 401      | -               |
+| `/catalog/datasets`                    | GET    | List datasets       | 200     | 400, 401 | Yes (max: 1000) |
+| `/catalog/datasets/{datasetId}`        | GET    | Get dataset         | 200     | 401, 404 | -               |
+| `/catalog/datasets/{datasetId}/sample` | GET    | Get sample data     | 200     | 401, 404 | -               |
 
-### ベクタータイル API
+### ベクトルタイル API
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|----------|--------|-------------|---------|-------|
-| `/v2/tiles` | GET | TileJSON メタデータの取得 (NGSIv2) | 200 | 401 |
-| `/v2/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルの取得 (NGSIv2) | 200 | 400, 401 |
-| `/ngsi-ld/v1/tiles` | GET | TileJSON メタデータの取得 (NGSI-LD) | 200 | 401 |
-| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルの取得 (NGSI-LD) | 200 | 400, 401 |
+| Endpoint                                | Method | Description                     | Success | Error    |
+| --------------------------------------- | ------ | ------------------------------- | ------- | -------- |
+| `/v2/tiles`                             | GET    | Get TileJSON metadata (NGSIv2)  | 200     | 401      |
+| `/v2/tiles/{z}/{x}/{y}.geojson`         | GET    | Get GeoJSON tile (NGSIv2)       | 200     | 400, 401 |
+| `/ngsi-ld/v1/tiles`                     | GET    | Get TileJSON metadata (NGSI-LD) | 200     | 401      |
+| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET    | Get GeoJSON tile (NGSI-LD)      | 200     | 400, 401 |
 
-### イベントストリーミング API
+### Event Streaming API
 
 WebSocket を使用したリアルタイムエンティティ変更ストリーミング。`EVENT_STREAMING_ENABLED=true` で有効化されます。
 
-| エンドポイント | プロトコル | 説明 |
-|----------|----------|-------------|
-| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | エンティティ変更イベントのストリーム配信 (認証は `Authorization` ヘッダー経由で送信) |
+| Endpoint                                                                  | Protocol  | Description                                                                  |
+| ------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------- |
+| `wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant={name}` | WebSocket | Stream entity change events (authentication sent via `Authorization` header) |
 
-詳細については、[イベントストリーミングドキュメント](../features/subscriptions.md) を参照してください。
+詳細は、[Event Streaming Documentation](../features/subscriptions.md) を参照してください。
 
 ### アクセス許可の概要
 
-| API カテゴリ | user | tenant_admin | super_admin |
-|--------------|------|--------------|-------------|
-| パブリックエンドポイント | Yes | Yes | Yes |
-| `/auth/*` | Yes | Yes | Yes |
-| `/me/*` | Yes | Yes | Yes |
-| `/statistics`、`/metrics`、`/cache/statistics` | Yes | Yes | Yes |
-| `/v2/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/ngsi-ld/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/catalog/*` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/admin/policies`、`/admin/policy-sets` | No | Yes (自テナント) | Yes (全テナント) |
-| `/admin/*` (その他) | No | No | Yes |
-| `/custom-data-models` | Yes (自テナント) | Yes (自テナント) | Denied (403) |
-| `/rules` | No | Yes (自テナント) | Denied (403) |
-| WebSocket | Yes (自テナント) | Yes (自テナント) | Denied (403) |
+| API Category                                   | user             | tenant\_admin    | super\_admin      |
+| ---------------------------------------------- | ---------------- | ---------------- | ----------------- |
+| Public endpoints                               | Yes              | Yes              | Yes               |
+| `/auth/*`                                      | Yes              | Yes              | Yes               |
+| `/me/*`                                        | Yes              | Yes              | Yes               |
+| `/statistics`, `/metrics`, `/cache/statistics` | Yes              | Yes              | Yes               |
+| `/v2/*`                                        | Yes (own tenant) | Yes (own tenant) | Denied (403)      |
+| `/ngsi-ld/*`                                   | Yes (own tenant) | Yes (own tenant) | Denied (403)      |
+| `/catalog/*`                                   | Yes (own tenant) | Yes (own tenant) | Denied (403)      |
+| `/admin/policies`, `/admin/policy-sets`        | No               | Yes (own tenant) | Yes (all tenants) |
+| `/admin/*` (other)                             | No               | No               | Yes               |
+| `/custom-data-models`                          | Yes (own tenant) | Yes (own tenant) | Denied (403)      |
+| `/rules`                                       | No               | Yes (own tenant) | Denied (403)      |
+| WebSocket                                      | Yes (own tenant) | Yes (own tenant) | Denied (403)      |
 
----
+***
 
 ## 関連リンク
 
-- [FIWARE NGSI v2 仕様](https://fiware.github.io/specifications/ngsiv2/stable/)
-- [ETSI NGSI-LD 仕様](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf)
-- [FIWARE Orion Context Broker ドキュメント](https://fiware-orion.readthedocs.io/)
-- [IPA 空間 ID ガイドライン](https://www.ipa.go.jp/digital/architecture/guidelines/4dspatio-temporal-guideline.html)
-- [デジタル庁 空間 ID](https://www.digital.go.jp/policies/mobility_and_infrastructure/spatial-id)
-- [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
+
+* [FIWARE NGSI v2 Specification](https://fiware.github.io/specifications/ngsiv2/stable/)
+  
+* [ETSI NGSI-LD Specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.06.01_60/gs_CIM009v010601p.pdf)
+  
+* [FIWARE Orion Context Broker Documentation](https://fiware-orion.readthedocs.io/)
+  
+* [IPA Spatial ID Guidelines](https://www.ipa.go.jp/digital/architecture/guidelines/4dspatio-temporal-guideline.html)
+  
+* [Digital Agency Spatial ID](https://www.digital.go.jp/policies/mobility_and_infrastructure/spatial-id)
+  
+* [RFC 7946 GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)

--- a/docs/ja/api-reference/ngsild.md
+++ b/docs/ja/api-reference/ngsild.md
@@ -5,40 +5,40 @@ outline: deep
 ---
 # NGSI-LD API
 
-> このドキュメントは [API.md](./endpoints.md) から分離されました。メイン API 仕様については [API.md](./endpoints.md) を参照してください。
+> このドキュメントは [API.md](./endpoints.md) から分離されました。主な API 仕様については、[API.md](./endpoints.md) を参照してください。
 
----
+***
 
 NGSI-LD は JSON-LD ベースのコンテキスト情報管理 API です。
 
-> **注意:** NGSI-LD API は ETSI GS CIM 009 仕様に従い `Fiware-ServicePath` ヘッダーを無視します。階層構造は `scope` エンティティプロパティと `scopeQ` クエリパラメータで管理されます。`servicePath` と `scope` は独立した概念であり、自動的に同期されません ([INTEROPERABILITY.md](../core-concepts/ngsiv2-vs-ngsild.md#3-scope-scope-hierarchy) を参照)。
+> **注意:** NGSI-LD API は ETSI GS CIM 009 仕様に従い、`Fiware-ServicePath` ヘッダーを無視します。階層は `scope` エンティティプロパティと `scopeQ` クエリパラメータを通じて管理されます。`servicePath` と `scope` は独立した概念であり、自動的に同期されることはありません([INTEROPERABILITY.md](../core-concepts/ngsiv2-vs-ngsild.md#3-scope-scope-hierarchy) を参照)。
 >
-> **注意:** NGSIv2 と NGSI-LD のエンティティは完全に分離されています。NGSIv2 で作成されたエンティティは NGSI-LD からは見えず、その逆も同様です (各エンティティの `protocol` フィールド、#964)。
+> **注意:** NGSIv2 と NGSI-LD のエンティティは完全に分離されています。NGSIv2 を介して作成されたエンティティは NGSI-LD からは見えず、その逆も同様です(各エンティティの `protocol` フィールド、#964)。
 
 ## 仕様準拠
 
 このドキュメントは **[ETSI GS CIM 009 V1.9.1 (2025-07)](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.09.01_60/gs_CIM009v010901p.pdf)** に準拠しています。各機能の詳細については、以下の ETSI 仕様セクションを参照してください:
 
-| 機能カテゴリ | ETSI GS CIM 009 セクション |
-|-------------|---------------------------|
-| エンティティ操作 | Section 5.6 |
-| クエリ操作 | Section 5.7 |
-| サブスクリプション | Section 5.8 |
-| コンテキストソース登録 | Section 5.9 |
-| Temporal API | Section 5.6.12-5.6.19 |
-| EntityMaps | Section 5.14 |
-| JSON-LD コンテキスト管理 | Section 5.12 |
-| 分散操作 | Section 5.10 |
+| Feature Category            | ETSI GS CIM 009 Section |
+| --------------------------- | ----------------------- |
+| Entity Operations           | Section 5.6             |
+| Query Operations            | Section 5.7             |
+| Subscriptions               | Section 5.8             |
+| Context Source Registration | Section 5.9             |
+| Temporal API                | Section 5.6.12-5.6.19   |
+| EntityMaps                  | Section 5.14            |
+| JSON-LD Context Management  | Section 5.12            |
+| Distributed Operations      | Section 5.10            |
 
-### コンテントネゴシエーションと @context
+### コンテンツネゴシエーションと @context
 
-NGSI-LD API は `Accept` ヘッダーを介したコンテントネゴシエーションをサポートしています。
+NGSI-LD API は `Accept` ヘッダーを介したコンテンツネゴシエーションをサポートしています。
 
-| Accept ヘッダー | レスポンス形式 | @context の処理 |
-|----------------|--------------|----------------|
-| `application/ld+json` | JSON-LD | `@context` はレスポンスボディに含まれます |
-| `application/json` | JSON | `@context` は `Link` ヘッダーで返されます |
-| `application/geo+json` | GeoJSON | `@context` は `Link` ヘッダーで返されます |
+| Accept Header          | Response Format | @context Handling                            |
+| ---------------------- | --------------- | -------------------------------------------- |
+| `application/ld+json`  | JSON-LD         | `@context` is included in the response body  |
+| `application/json`     | JSON            | `@context` is returned via the `Link` header |
+| `application/geo+json` | GeoJSON         | `@context` is returned via the `Link` header |
 
 `Accept: application/json` の場合、レスポンスには `Link` ヘッダーが含まれます:
 
@@ -48,15 +48,13 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 
 ### 自然言語照合 (lang + orderBy)
 
-`lang` パラメータと `orderBy` を組み合わせることで、指定された言語のロケールに基づいて結果をソートできます。たとえば、`lang=ja` は日本語の照合順序をソートに適用します。
+`lang` パラメータと `orderBy` を組み合わせることで、指定された言語のロケールに基づいて結果をソートできます。例えば、`lang=ja` は日本語の照合順序をソートに適用します。
 
 ### エンティティ操作 (NGSI-LD)
 
 > **ETSI GS CIM 009 リファレンス**: セクション 5.6 - エンティティ操作
 
-#
-
-### エンティティリストの取得
+#### エンティティリストの取得
 
 ```http
 GET /ngsi-ld/v1/entities
@@ -71,31 +69,31 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|-----|------|-----------|
-| `id` | string | エンティティ ID でフィルタ (複数の場合はカンマ区切り、URI 形式) | - |
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
-| `orderBy` | string | ソート条件 (`entityId`、`entityType`、`modifiedAt`) | - |
-| `orderDirection` | string | ソート方向 (`asc`、`desc`) | `asc` |
-| `type` | string | エンティティタイプでフィルタ | - |
-| `idPattern` | string | エンティティ ID の正規表現パターン | - |
-| `q` | string | 属性値でフィルタ | - |
-| `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `pick` | string | 取得する属性名 (カンマ区切り、`omit` と排他) | - |
-| `omit` | string | 除外する属性名 (カンマ区切り、`pick` と排他、`id`/`type` は不可) | - |
-| `scopeQ` | string | スコープクエリ (例: `/Madrid`、`/Madrid/#`、`/Madrid/+`) | - |
-| `lang` | string | LanguageProperty の言語フィルタ (BCP 47、カンマ区切りの優先順、すべての言語は `*`) | - |
-| `georel` | string | ジオクエリ演算子 | - |
-| `geometry` | string | ジオメトリタイプ | - |
-| `coordinates` | string | 座標 | - |
-| `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search) を参照) | - |
-| `spatialIdDepth` | integer | 空間 ID 階層展開の深さ (0-4) | 0 |
-| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs) を参照)。URN 形式も可 | `EPSG:4326` |
-| `geoproperty` | string | ジオクエリに使用する GeoProperty 名 | `location` |
-| `format` | string | 出力形式 (keyValues 形式は `simplified`、GeoJSON 形式は `geojson`)。GeoJSON は `Accept: application/geo+json` ヘッダーでも指定可 | - |
-| `expandValues` | string | 展開する属性名 (カンマ区切り、展開された値を返す) | - |
-| `options` | string | `keyValues`、`concise`、`entityMap`、`sysAttrs` (システム属性を出力)、`splitEntities` (タイプごとに分割してレスポンス) | - |
+| Parameter        | Type    | Description                                                                                                                                               | Default     |
+| ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `id`             | string  | Filter by entity ID (comma-separated for multiple, URI format)                                                                                            | -           |
+| `limit`          | integer | Number of results to retrieve                                                                                                                             | 20          |
+| `offset`         | integer | Offset                                                                                                                                                    | 0           |
+| `orderBy`        | string  | Sort criteria (`entityId`, `entityType`, `modifiedAt`)                                                                                                    | -           |
+| `orderDirection` | string  | Sort direction (`asc`, `desc`)                                                                                                                            | `asc`       |
+| `type`           | string  | Filter by entity type                                                                                                                                     | -           |
+| `idPattern`      | string  | Regular expression pattern for entity ID                                                                                                                  | -           |
+| `q`              | string  | Filter by attribute value                                                                                                                                 | -           |
+| `attrs`          | string  | Attribute names to retrieve (comma-separated)                                                                                                             | -           |
+| `pick`           | string  | Attribute names to retrieve (comma-separated, mutually exclusive with `omit`)                                                                             | -           |
+| `omit`           | string  | Attribute names to exclude (comma-separated, mutually exclusive with `pick`, `id`/`type` not allowed)                                                     | -           |
+| `scopeQ`         | string  | Scope query (e.g., `/Madrid`, `/Madrid/#`, `/Madrid/+`)                                                                                                   | -           |
+| `lang`           | string  | Language filter for LanguageProperty (BCP 47, comma-separated priority order, `*` for all languages)                                                      | -           |
+| `georel`         | string  | Geo-query operator                                                                                                                                        | -           |
+| `geometry`       | string  | Geometry type                                                                                                                                             | -           |
+| `coordinates`    | string  | Coordinates                                                                                                                                               | -           |
+| `spatialId`      | string  | Filter by spatial ID (ZFXY format) (see [Spatial ID Search](./endpoints.md#spatial-id-search))                                                            | -           |
+| `spatialIdDepth` | integer | Depth of spatial ID hierarchy expansion (0-4)                                                                                                             | 0           |
+| `crs`            | string  | Coordinate reference system (see [Coordinate Reference System (CRS)](./endpoints.md#coordinate-reference-system-crs)). URN format also accepted           | `EPSG:4326` |
+| `geoproperty`    | string  | GeoProperty name to use for geo-queries                                                                                                                   | `location`  |
+| `format`         | string  | Output format (`simplified` for keyValues format, `geojson` for GeoJSON format). GeoJSON can also be specified with `Accept: application/geo+json` header | -           |
+| `expandValues`   | string  | Attribute names to expand (comma-separated, returns expanded values)                                                                                      | -           |
+| `options`        | string  | `keyValues`, `concise`, `entityMap`, `sysAttrs` (output system attributes), `splitEntities` (split response by type)                                      | -           |
 
 **レスポンス例**
 
@@ -124,13 +122,11 @@ Link: <https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld>; rel="http:/
 
 **レスポンスヘッダー**
 
-| ヘッダー | 説明 |
-|---------|------|
-| `NGSILD-Results-Count` | 総件数 (常に返される) |
+| Header                 | Description                   |
+| ---------------------- | ----------------------------- |
+| `NGSILD-Results-Count` | Total count (always returned) |
 
-#
-
-### エンティティの作成
+#### エンティティの作成
 
 ```http
 POST /ngsi-ld/v1/entities
@@ -158,7 +154,7 @@ Content-Type: application/ld+json
 
 **一時エンティティ (expiresAt)**
 
-エンティティに `expiresAt` フィールド (ISO 8601 形式) を指定すると、有効期限付きの一時エンティティとして作成されます。有効期限は未来の日付である必要があります。
+`expiresAt` フィールド (ISO 8601 形式) をエンティティに指定することで、有効期限を持つ一時エンティティとして作成されます。有効期限は未来の日付である必要があります。
 
 ```json
 {
@@ -171,12 +167,16 @@ Content-Type: application/ld+json
 ```
 
 **レスポンス**
-- ステータス: `201 Created`- ステータス: 同じ ID のエンティティが既に存在する場合は `409 AlreadyExists` (タイプに関係なく)
-- ヘッダー: `Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Room:001`> **注意**: エンティティ ID はテナントとServicePathスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成すると `409 AlreadyExists` が返されます。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
-#
+* ステータス:`201 Created`
+  
+* ステータス:`409 AlreadyExists` 同じ ID を持つエンティティが既に存在する場合(タイプに関係なく)
+  
+* ヘッダー:`Location: /ngsi-ld/v1/entities/urn:ngsi-ld:Room:001`
 
-### 単一エンティティの取得
+> **注意**:エンティティ ID はテナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成すると `409 AlreadyExists` が返されます。詳細は [Entity ID Uniqueness](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
+
+#### 単一エンティティの取得
 
 ```http
 GET /ngsi-ld/v1/entities/{entityId}
@@ -184,18 +184,16 @@ GET /ngsi-ld/v1/entities/{entityId}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `type` | string | エンティティタイプ |
-| `attrs` | string | 取得する属性名 (カンマ区切り) |
-| `pick` | string | 取得する属性名 (カンマ区切り、`omit` と排他) |
-| `omit` | string | 除外する属性名 (カンマ区切り、`pick` と排他、`id`/`type` は不可) |
-| `lang` | string | LanguageProperty の言語フィルタ (BCP 47) |
-| `options` | string | `keyValues`、`concise`、`entityMap` |
+| Parameter | Type   | Description                                                                                           |
+| --------- | ------ | ----------------------------------------------------------------------------------------------------- |
+| `type`    | string | Entity type                                                                                           |
+| `attrs`   | string | Attribute names to retrieve (comma-separated)                                                         |
+| `pick`    | string | Attribute names to retrieve (comma-separated, mutually exclusive with `omit`)                         |
+| `omit`    | string | Attribute names to exclude (comma-separated, mutually exclusive with `pick`, `id`/`type` not allowed) |
+| `lang`    | string | Language filter for LanguageProperty (BCP 47)                                                         |
+| `options` | string | `keyValues`, `concise`, `entityMap`                                                                   |
 
-#
-
-### エンティティの置換
+#### エンティティの置換
 
 ```http
 PUT /ngsi-ld/v1/entities/{entityId}
@@ -203,22 +201,26 @@ PUT /ngsi-ld/v1/entities/{entityId}
 
 エンティティのすべての属性を置き換えます。リクエストボディに含まれない属性は削除されます。
 
-**レスポンス**: `204 No Content`#
+**レスポンス**:`204 No Content`
 
-### エンティティの更新
+#### エンティティの更新
 
 ```http
 PATCH /ngsi-ld/v1/entities/{entityId}
 ```
+
 **Merge-Patch セマンティクス** (ETSI GS CIM 009 Section 5.6.4):
 
-- `Content-Type: application/merge-patch+json` を使用すると、リクエストボディに含まれない属性は保持されます(マージモード)。標準の `application/json` / `application/ld+json` では、すべての属性が置き換えられます。
-- プロパティ値として `urn:ngsi-ld:null` を指定すると、その属性が削除されます。
-- クエリパラメータ `options=keyValues` または `options=concise` を指定すると、簡略化された入力形式を使用できます。
 
-**レスポンス**: `204 No Content`#
+* `Content-Type: application/merge-patch+json` を使用すると、リクエストボディに含まれない属性は保持されます(マージモード)。標準の `application/json` / `application/ld+json` では、すべての属性が置き換えられます。
+  
+* プロパティ値として `urn:ngsi-ld:null` を指定すると、その属性が削除されます。
+  
+* クエリパラメータ `options=keyValues` または `options=concise` を指定すると、簡略化された入力形式を使用できます。
 
-### 属性の追加
+**レスポンス**:`204 No Content`
+
+#### 属性の追加
 
 ```http
 POST /ngsi-ld/v1/entities/{entityId}
@@ -227,13 +229,13 @@ Content-Type: application/ld+json
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|------|
-| `options=noOverwrite` | 既存の属性を上書きしない(既存の属性は保持され、新しい属性のみが追加されます) |
+| Parameter             | Description                                                                                             |
+| --------------------- | ------------------------------------------------------------------------------------------------------- |
+| `options=noOverwrite` | Do not overwrite existing attributes (existing attributes are preserved, only new attributes are added) |
 
-**レスポンス**: `204 No Content`#
+**レスポンス**:`204 No Content`
 
-### 複数属性の部分更新
+#### 複数属性の部分更新
 
 ```http
 PATCH /ngsi-ld/v1/entities/{entityId}/attrs
@@ -253,27 +255,27 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### エンティティの削除
+#### エンティティの削除
 
 ```http
 DELETE /ngsi-ld/v1/entities/{entityId}
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### エンティティのすべての属性を取得
+#### エンティティの全属性の取得
 
 ```http
 GET /ngsi-ld/v1/entities/{entityId}/attrs
 ```
 
-エンティティのすべての属性を取得します。
+エンティティの全属性を取得します。
 
-**レスポンス**: `200 OK`#
+**レスポンス**: `200 OK`
 
-### 単一属性の取得
+#### 単一属性の取得
 
 ```http
 GET /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
@@ -281,9 +283,9 @@ GET /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 
 エンティティの特定の属性を取得します。
 
-**レスポンス**: `200 OK`#
+**レスポンス**: `200 OK`
 
-### 属性の上書き (PUT)
+#### 属性の上書き (PUT)
 
 ```http
 PUT /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
@@ -301,16 +303,16 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### 属性の置換
+#### 属性の置換
 
 ```http
 POST /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 Content-Type: application/ld+json
 ```
 
-指定された属性を新しい値で置き換えます。
+指定された属性を新しい値で置換します。
 
 **リクエストボディ**
 
@@ -321,9 +323,9 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### 属性の部分更新
+#### 属性の部分更新
 
 ```http
 PATCH /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
@@ -339,11 +341,11 @@ Content-Type: application/ld+json
 }
 ```
 
-**レスポンス**: `204 No Content`> **注意**: エンティティまたは属性が存在しない場合、`404 Not Found` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.6.4)。この操作は既存の属性の部分更新のみを実行し、新しい属性は作成しません。
+**レスポンス**: `204 No Content`
 
-#
+> **注**: エンティティまたは属性が存在しない場合、`404 Not Found` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.6.4)。この操作は既存の属性の部分更新のみを実行し、新しい属性は作成しません。
 
-### 属性の削除
+#### 属性の削除
 
 ```http
 DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
@@ -351,23 +353,22 @@ DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `datasetId` | string | 削除するマルチ属性インスタンスの datasetId |
-| `deleteAll` | boolean | `true` の場合、すべてのインスタンスを削除します |
+| Parameter   | Type    | Description                                         |
+| ----------- | ------- | --------------------------------------------------- |
+| `datasetId` | string  | datasetId of the multi-attribute instance to delete |
+| `deleteAll` | boolean | If `true`, deletes all instances                    |
 
 **レスポンス**: `204 No Content`
-### マルチ属性 (datasetId)
 
-> **ETSI GS CIM 009 リファレンス**: Section 4.5.3 - Multi-Attribute
+### Multi-Attribute (datasetId)
 
-NGSI-LD では、同じ属性名に対して複数のインスタンスを保持できます。各インスタンスは `datasetId` (URI 形式) によって区別されます。`datasetId` を持たないインスタンスは「デフォルトインスタンス」と呼ばれ、属性ごとに最大 1 つ存在できます。
+> **ETSI GS CIM 009 Reference**: Section 4.5.3 - Multi-Attribute
 
-#
+NGSI-LD では、同じ属性名に対して複数のインスタンスを保持することができます。各インスタンスは `datasetId` (URI 形式) によって区別されます。`datasetId` を持たないインスタンスは「デフォルトインスタンス」と呼ばれ、属性ごとに最大 1 つまで存在できます。
 
-### 作成 (CREATE)
+#### 作成 (CREATE)
 
-エンティティを作成する際、属性を配列形式で指定することで複数のインスタンスを作成できます。
+エンティティを作成する際、配列形式で属性を指定することで複数のインスタンスを作成できます。
 
 ```json
 {
@@ -393,17 +394,13 @@ NGSI-LD では、同じ属性名に対して複数のインスタンスを保持
 }
 ```
 
-上記の例では、`speed` 属性に対して 3 つのインスタンスがあります: GPS から 1 つ、OBD から 1 つ、そしてデフォルトインスタンスが 1 つです。
+上記の例では、`speed` 属性に対して 3 つのインスタンスがあります: GPS からのもの、OBD からのもの、そしてデフォルトインスタンスです。
 
-#
+#### 取得 (RETRIEVE)
 
-### 取得 (RETRIEVE)
+エンティティを取得する際、multi-attributes は配列形式で返されます。`keyValues` 形式では、デフォルトインスタンス (`datasetId` なし) の値のみが返されます。
 
-エンティティを取得する際、マルチ属性は配列形式で返されます。`keyValues` 形式では、デフォルトインスタンス (`datasetId` なし) の値のみが返されます。
-
-#
-
-### 更新 (UPDATE)
+#### 更新 (UPDATE)
 
 属性を更新する際 (PATCH/POST)、`datasetId` を指定することで特定のインスタンスのみを更新できます。
 
@@ -417,26 +414,22 @@ NGSI-LD では、同じ属性名に対して複数のインスタンスを保持
 }
 ```
 
-#
+#### 削除 (DELETE)
 
-### 削除 (DELETE)
-
-属性を削除する際、`datasetId` クエリパラメータを指定すると特定のインスタンスのみが削除されます。`deleteAll=true` を指定すると、すべてのインスタンスが削除されます。
+属性を削除する際、`datasetId` クエリパラメータを指定すると特定のインスタンスのみが削除されます。`deleteAll=true` を指定するとすべてのインスタンスが削除されます。
 
 ```http
 DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}?datasetId=urn:ngsi-ld:dataset:gps
 DELETE /ngsi-ld/v1/entities/{entityId}/attrs/{attrName}?deleteAll=true
 ```
 
----
+***
 
 ### バッチ操作 (NGSI-LD)
 
-> **注意**: バッチ操作は、1 リクエストあたり最大 **1,000** 個のエンティティを処理できます。1,000 個を超えるリクエストは `400 Bad Request` エラーになります。
+> **注意**: バッチ操作は 1 リクエストあたり最大 **1,000** エンティティまで処理できます。1,000 を超えるリクエストは `400 Bad Request` エラーになります。
 
-#
-
-### バッチ作成
+#### バッチ作成
 
 ```http
 POST /ngsi-ld/v1/entityOperations/create
@@ -463,9 +456,12 @@ Content-Type: application/ld+json
 ```
 
 **レスポンス**
-- すべて成功: `201 Created`- 部分的に成功: `207 Multi-Status`#
 
-### バッチアップサート
+* すべて成功: `201 Created`
+  
+* 部分的成功: `207 Multi-Status`
+
+#### バッチ Upsert
 
 ```http
 POST /ngsi-ld/v1/entityOperations/upsert
@@ -473,24 +469,29 @@ POST /ngsi-ld/v1/entityOperations/upsert
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|------|
-| `options=replace` | 既存エンティティのすべての属性を置き換える |
+| Parameter         | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `options=replace` | Replace all attributes of existing entities |
 
 **レスポンス**
-- すべて成功: `201 Created` (新規作成) または `204 No Content` (更新)
-- 部分的に成功: `207 Multi-Status`#
 
-### バッチ更新
+* すべて成功: `201 Created` (新規作成) または `204 No Content` (更新)
+  
+* 部分的成功: `207 Multi-Status`
+
+#### バッチ更新
 
 ```http
 POST /ngsi-ld/v1/entityOperations/update
 ```
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的に成功: `207 Multi-Status`#
 
-### バッチ削除
+* すべて成功: `204 No Content`
+  
+* 部分的成功: `207 Multi-Status`
+
+#### バッチ削除
 
 ```http
 POST /ngsi-ld/v1/entityOperations/delete
@@ -507,9 +508,12 @@ Content-Type: application/json
 ```
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的に成功: `207 Multi-Status`#
 
-### エンティティパージ
+* すべて成功: `204 No Content`
+  
+* 部分的成功: `207 Multi-Status`
+
+#### エンティティパージ
 
 ```http
 POST /ngsi-ld/v1/entityOperations/purge
@@ -520,14 +524,17 @@ Content-Type: application/json
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 |
-|-----------|-----|------|
-| `type` | string | 削除するエンティティタイプ (必須) |
+| Parameter | Type   | Description                      |
+| --------- | ------ | -------------------------------- |
+| `type`    | string | Entity type to delete (required) |
 
 **レスポンス**
-- 成功: `204 No Content`- タイプが指定されていない: `400 Bad Request`#
 
-### バッチクエリ
+* 成功: `204 No Content`
+  
+* タイプが指定されていない: `400 Bad Request`
+
+#### バッチクエリ
 
 ```http
 POST /ngsi-ld/v1/entityOperations/query
@@ -551,16 +558,14 @@ Content-Type: application/json
 
 **レスポンス**: エンティティの配列
 
-#
-
-### バッチマージ
+#### バッチマージ
 
 ```http
 POST /ngsi-ld/v1/entityOperations/merge
 Content-Type: application/ld+json
 ```
 
-Merge-Patch セマンティクスを使用して、複数のエンティティに対して一括更新を実行します。既存の属性はマージされ、リクエストに含まれていない属性は保持されます。`urn:ngsi-ld:null` を値として指定すると、その属性が削除されます。
+Merge-Patch セマンティクスを使用して、複数のエンティティに対して一括更新を実行します。既存の属性はマージされ、リクエストに含まれていない属性は保持されます。値として `urn:ngsi-ld:null` を指定すると、その属性が削除されます。
 
 **リクエストボディ**
 
@@ -577,26 +582,27 @@ Merge-Patch セマンティクスを使用して、複数のエンティティ�
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|------|
-| `options=noOverwrite` | 既存の属性を上書きしない |
+| Parameter             | Description                          |
+| --------------------- | ------------------------------------ |
+| `options=noOverwrite` | Do not overwrite existing attributes |
 
 **レスポンス**
-- すべて成功: `204 No Content`
-- 部分的な成功: `207 Multi-Status`
----
 
-### 時系列・バッチ操作 (NGSI-LD)
+* すべて成功: `204 No Content`
+  
+* 部分的に成功: `207 Multi-Status`
 
-> **ETSI GS CIM 009 参照**: セクション 5.6.12-5.6.19 - エンティティの時系列表現
+***
 
-時系列エンティティのバッチ操作。リクエストごとに最大 **1,000** エンティティを処理できます。
+### 時系列バッチ操作 (NGSI-LD)
 
-> **注**: 時系列 entityOperations の create / upsert / delete は、ETSI GS CIM 009 仕様には含まれていない GeonicDB の拡張機能です。仕様に準拠しているのは query のみです。これらの拡張機能は、時系列データの一括取り込みの効率を向上させるために提供されています。
+> **ETSI GS CIM 009 リファレンス**: セクション 5.6.12-5.6.19 - エンティティの時系列表現
 
-#
+時系列エンティティのバッチ操作。リクエストごとに最大 **1,000** エンティティまで処理できます。
 
-### 時系列・バッチ作成
+> **注意**: 時系列 entityOperations の create / upsert / delete は GeonicDB 拡張機能であり、ETSI GS CIM 009 仕様には含まれていません。クエリのみが仕様準拠です。これらの拡張機能は、時系列データの一括取り込みの効率を向上させるために提供されています。
+
+#### 時系列バッチ作成
 
 ```http
 POST /ngsi-ld/v1/temporal/entityOperations/create
@@ -605,20 +611,20 @@ Content-Type: application/ld+json
 
 時系列エンティティを一括作成します。リクエストボディは時系列エンティティの配列です。
 
-**レスポンス**: すべて成功した場合は `201 Created`、部分的に失敗した場合は `207 Multi-Status`#
+**レスポンス**: すべて成功した場合は `201 Created`、部分的な失敗の場合は `207 Multi-Status`
 
-### 時系列・バッチアップサート
+#### 時系列バッチアップサート
 
 ```http
 POST /ngsi-ld/v1/temporal/entityOperations/upsert
 Content-Type: application/ld+json
 ```
 
-時系列エンティティを一括作成または更新します (既存のエンティティに属性を追加します)。
+時系列エンティティを一括作成または更新します(既存のエンティティに属性を追加します)。
 
-**レスポンス**: すべて成功した場合は `204 No Content`、部分的に失敗した場合は `207 Multi-Status`#
+**レスポンス**: すべて成功した場合は `204 No Content`、部分的な失敗の場合は `207 Multi-Status`
 
-### 時系列・バッチ削除
+#### 時系列バッチ削除
 
 ```http
 POST /ngsi-ld/v1/temporal/entityOperations/delete
@@ -627,9 +633,9 @@ Content-Type: application/ld+json
 
 時系列エンティティを一括削除します。リクエストボディはエンティティ ID の配列です。
 
-**レスポンス**: すべて成功した場合は `204 No Content`、部分的に失敗した場合は `207 Multi-Status`#
+**レスポンス**: すべて成功した場合は `204 No Content`、部分的な失敗の場合は `207 Multi-Status`
 
-### 時系列・バッチクエリ
+#### 時系列バッチクエリ
 
 ```http
 POST /ngsi-ld/v1/temporal/entityOperations/query
@@ -652,23 +658,21 @@ POST ベースの時系列クエリ。クエリ条件はリクエストボディ
 
 **レスポンス**: `200 OK` - 時系列エンティティの配列
 
-#
+#### 時系列クエリパラメータ
 
-### 時系列クエリパラメータ
+以下のクエリパラメータは、時系列エンティティの GET エンドポイントで使用できます。
 
-以下のクエリパラメータは時系列エンティティの GET エンドポイントで使用できます。
-
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `timerel` | string | 時系列関係演算子 (`after`, `before`, `between`) |
-| `timeAt` | string | 基準時刻 (ISO 8601 形式) |
-| `endTimeAt` | string | 終了時刻 (`timerel=between` のときに必須、ISO 8601 形式) |
-| `lastN` | integer | 最新の N 個のインスタンスのみを返す (正の整数、ETSI GS CIM 009 セクション 5.6.12) |
-| `options` | string | `temporalValues`: 簡易時系列表現 |
+| Parameter   | Type    | Description                                                                           |
+| ----------- | ------- | ------------------------------------------------------------------------------------- |
+| `timerel`   | string  | Temporal relationship operator (`after`, `before`, `between`)                         |
+| `timeAt`    | string  | Reference time (ISO 8601 format)                                                      |
+| `endTimeAt` | string  | End time (required when `timerel=between`, ISO 8601 format)                           |
+| `lastN`     | integer | Return only the latest N instances (positive integer, ETSI GS CIM 009 Section 5.6.12) |
+| `options`   | string  | `temporalValues`: Simplified temporal representation                                  |
 
 **lastN パラメータ**
 
-`lastN` を指定すると、時系列データの最新 N 個のインスタンスのみを返します。`timerel`/`timeAt` と組み合わせて、時間範囲内の最新 N 個のインスタンスを取得できます。
+`lastN` を指定すると、時系列データの最新 N インスタンスのみが返されます。`timerel`/`timeAt` と組み合わせることで、時間範囲内の最新 N インスタンスを取得できます。
 
 ```bash
 # Retrieve the latest 10 temporal data instances
@@ -676,13 +680,12 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
   -H "Fiware-Service: myservice"
 ```
 
-#
+#### 時系列レスポンスフォーマットオプション
 
-### 時系列レスポンス形式オプション
-
-`options=temporalValues` を指定すると、各属性が `values` 配列 (`[value, timestamp]` のペア) を含む簡易形式で返されます。
+`options=temporalValues` を指定すると、各属性が `values` 配列(`[value, timestamp]` のペア)を持つ簡略化されたフォーマットで返されます。
 
 **例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?options=temporalValues`
+
 ```json
 {
   "id": "urn:ngsi-ld:Sensor:1",
@@ -694,18 +697,17 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 }
 ```
 
-#
+#### 時系列集約クエリ (単一エンティティ)
 
-### 時系列集計クエリ (単一エンティティ)
+集約クエリは、`aggrMethods` および `aggrPeriodDuration` クエリパラメータを使用して、時系列エンティティ GET エンドポイントで実行できます。リスト取得エンドポイントと単一エンティティ取得エンドポイントの両方で利用可能です。
 
-時系列エンティティの GET エンドポイントでは、`aggrMethods` および `aggrPeriodDuration` クエリパラメータを使用して集計クエリを実行できます。リスト取得エンドポイントと単一エンティティ取得エンドポイントの両方で利用可能です。
-
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `aggrMethods` | string | 集計メソッド (カンマ区切り): `totalCount`, `distinctCount`, `sum`, `avg`, `min`, `max`, `stddev`, `sumsq` |
-| `aggrPeriodDuration` | string | ISO 8601 期間 (例: `PT1H` は 1 時間)。`aggrMethods` 指定時に必須 |
+| Parameter            | Type   | Description                                                                                                         |
+| -------------------- | ------ | ------------------------------------------------------------------------------------------------------------------- |
+| `aggrMethods`        | string | Aggregation methods (comma-separated): `totalCount`, `distinctCount`, `sum`, `avg`, `min`, `max`, `stddev`, `sumsq` |
+| `aggrPeriodDuration` | string | ISO 8601 duration (e.g., `PT1H` for 1 hour). Required when `aggrMethods` is specified                               |
 
 **例**: `GET /ngsi-ld/v1/temporal/entities/{entityId}?aggrMethods=avg&aggrPeriodDuration=PT1H&timerel=after&timeAt=2024-01-01T00:00:00Z`
+
 ```json
 {
   "id": "urn:ngsi-ld:Sensor:1",
@@ -723,23 +725,24 @@ curl "http://localhost:3000/ngsi-ld/v1/temporal/entities/urn:ngsi-ld:Sensor:001?
 }
 ```
 
-> **注**: `aggrPeriodDuration` なしで `aggrMethods` を指定すると、`400 Bad Request` エラーが返されます。
+> **注意**: `aggrPeriodDuration` を指定せずに `aggrMethods` を指定すると、`400 Bad Request` エラーが返されます。
 
-> **注**: 集計クエリは **暗号化テナント** (テナントで `encryptionEnabled: true` が設定されている場合) では **サポートされていません**。属性値が保存時に暗号化されているため、MongoDB の集計パイプラインは暗号化されたデータに対して数値演算を実行できません。暗号化テナントで集計をリクエストすると `400 Bad Request` が返されます。`temporalValues` エンドポイントを使用して復号化された値を取得し、アプリケーション層で集計を実行してください。
+> **注意**: 集約クエリは **暗号化されたテナントではサポートされていません** (`encryptionEnabled: true` のテナント)。属性値が保存時に暗号化されているため、MongoDB 集約パイプラインは暗号化されたデータに対して数値演算を実行できません。暗号化されたテナントで集約をリクエストすると `400 Bad Request` が返されます。復号化された値を取得してアプリケーション層で集約を実行するには、`temporalValues` エンドポイントを使用してください。
 
----
+***
 
 ### エンティティタイプ操作 (NGSI-LD)
 
-#
-
-### タイプリストの取得
+#### タイプリストの取得
 
 ```http
 GET /ngsi-ld/v1/types
 ```
 
-**パラメータ**: `limit`、`offset`**レスポンス** (200):
+**パラメータ**: `limit`、`offset`
+
+**レスポンス** (200):
+
 ```json
 [
   {
@@ -752,17 +755,16 @@ GET /ngsi-ld/v1/types
 ]
 ```
 
-**ヘッダー**: 合計数は `NGSILD-Results-Count` 経由で返されます
+**ヘッダー**: 合計件数は `NGSILD-Results-Count` で返されます
 
-#
-
-### タイプ詳細の取得
+#### タイプ詳細の取得
 
 ```http
 GET /ngsi-ld/v1/types/{typeName}
 ```
 
 **レスポンス** (200):
+
 ```json
 {
   "id": "urn:ngsi-ld:EntityType:Room",
@@ -784,15 +786,16 @@ GET /ngsi-ld/v1/types/{typeName}
 
 ### 属性操作 (NGSI-LD)
 
-#
-
-### 属性リストの取得
+#### 属性リストを取得
 
 ```http
 GET /ngsi-ld/v1/attributes
 ```
 
-**パラメータ**: `limit`、`offset`**レスポンス** (200):
+**パラメータ**: `limit`、`offset`
+
+**レスポンス** (200):
+
 ```json
 [
   {
@@ -805,17 +808,16 @@ GET /ngsi-ld/v1/attributes
 ]
 ```
 
-**ヘッダー**: 合計数は `NGSILD-Results-Count` 経由で返されます
+**ヘッダー**: 合計カウントは `NGSILD-Results-Count` 経由で返される
 
-#
-
-### 属性詳細の取得
+#### 属性の詳細を取得
 
 ```http
 GET /ngsi-ld/v1/attributes/{attrName}
 ```
 
 **レスポンス** (200):
+
 ```json
 {
   "id": "urn:ngsi-ld:Attribute:temperature",
@@ -830,15 +832,13 @@ GET /ngsi-ld/v1/attributes/{attrName}
 
 **エラー**: 404 (属性が存在しない場合)
 
----
+***
 
 ### サブスクリプション (NGSI-LD)
 
-> **ETSI GS CIM 009 リファレンス**: セクション 5.8 - サブスクリプション操作
+> **ETSI GS CIM 009 リファレンス**: Section 5.8 - Subscription Operations
 
-#
-
-### サブスクリプションの作成
+#### サブスクリプションの作成
 
 ```http
 POST /ngsi-ld/v1/subscriptions
@@ -893,28 +893,32 @@ NGSI-LD では、エンドポイント URI に `mqtt://` または `mqtts://` �
 
 **MQTT notifierInfo 設定**
 
-| キー | 値 | 説明 |
-|-----|-----|------|
-| `MQTT-Version` | `mqtt3.1.1` または `mqtt5.0` | MQTT プロトコルバージョン |
-| `MQTT-QoS` | `0`、`1`、または `2` | QoS レベル |
+| Key            | Value                    | Description           |
+| -------------- | ------------------------ | --------------------- |
+| `MQTT-Version` | `mqtt3.1.1` or `mqtt5.0` | MQTT protocol version |
+| `MQTT-QoS`     | `0`, `1`, or `2`         | QoS level             |
 
 **サブスクリプション拡張フィールド**
 
-| フィールド | 型 | 説明 |
-|-----------|-----|------|
-| `cooldown` | integer | 通知間の最小間隔 (秒)。正の整数のみ。指定された秒数以内に再通知しません |
-| `notificationTrigger` | string[] | 通知をトリガーするイベントタイプ。`entityCreated`、`entityUpdated`、`entityChanged`、`entityDeleted`、`attributeCreated`、`attributeUpdated`、`attributeDeleted`。`entityChanged` は属性値が実際に変更された場合にのみトリガーされます (同じ値での更新は無視されます) |
-| `showChanges` | boolean | `true` の場合、通知データに以前の属性値を `previousValue` として含めます |
-| `notification.onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみを通知ペイロードに含めます。`notification.attributes` と組み合わせて使用できます |
-| `expiresAt` | string (ISO 8601) | サブスクリプション有効期限 |
+| Field                           | Type              | Description                                                                                                                                                                                                                                                                               |
+| ------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cooldown`                      | integer           | Minimum interval between notifications (seconds). Positive integers only. Will not re-notify within the specified number of seconds                                                                                                                                                       |
+| `notificationTrigger`           | string\[]         | Event types that trigger notifications. `entityCreated`, `entityUpdated`, `entityChanged`, `entityDeleted`, `attributeCreated`, `attributeUpdated`, `attributeDeleted`. `entityChanged` is only triggered when attribute values actually change (updates with the same value are ignored) |
+| `showChanges`                   | boolean           | If `true`, includes the previous attribute value as `previousValue` in the notification data                                                                                                                                                                                              |
+| `notification.onlyChangedAttrs` | boolean           | If `true`, includes only attributes that have actually changed in the notification payload. Can be combined with `notification.attributes`                                                                                                                                                |
+| `expiresAt`                     | string (ISO 8601) | Subscription expiration time                                                                                                                                                                                                                                                              |
 
-**バリデーション**
-- `watchedAttributes` と `timeInterval` は相互排他的です。両方を同時に指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.8.1)
+**検証**
+
+* `watchedAttributes` と `timeInterval` は相互に排他的です。両方を同時に指定すると `400 Bad Request` が返されます (ETSI GS CIM 009 V1.9.1 clause 5.8.1)
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/subscriptions/{subscriptionId}`#
 
-### サブスクリプション一覧
+* ステータス: `201 Created`
+  
+* ヘッダー: `Location: /ngsi-ld/v1/subscriptions/{subscriptionId}`
+
+#### サブスクリプション一覧
 
 ```http
 GET /ngsi-ld/v1/subscriptions
@@ -922,14 +926,12 @@ GET /ngsi-ld/v1/subscriptions
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|-----|------|-----------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
+| Parameter | Type    | Description                   | Default |
+| --------- | ------- | ----------------------------- | ------- |
+| `limit`   | integer | Number of results to retrieve | 20      |
+| `offset`  | integer | Offset                        | 0       |
 
-#
-
-### サブスクリプションの取得
+#### サブスクリプションの取得
 
 ```http
 GET /ngsi-ld/v1/subscriptions/{subscriptionId}
@@ -937,48 +939,44 @@ GET /ngsi-ld/v1/subscriptions/{subscriptionId}
 
 **通知ステータスフィールド (読み取り専用)**
 
-| フィールド | 型 | 説明 |
-|-----------|-----|------|
-| `notification.status` | string | `ok` または `failed` |
-| `notification.lastNotification` | string | 最後に通知を送信した日時 (ISO 8601) |
-| `notification.lastFailure` | string | 最後に通知が失敗した日時 (ISO 8601) |
-| `notification.lastFailureReason` | string | 最後の失敗の理由 (例: `HTTP 500: Internal Server Error`)。成功時にクリアされます |
-| `notification.lastSuccess` | string | 最後に通知が成功した日時 (ISO 8601) |
-| `notification.timesSent` | integer | 送信された通知の数 |
+| Field                            | Type    | Description                                                                               |
+| -------------------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `notification.status`            | string  | `ok` or `failed`                                                                          |
+| `notification.lastNotification`  | string  | Date and time of last notification sent (ISO 8601)                                        |
+| `notification.lastFailure`       | string  | Date and time of last notification failure (ISO 8601)                                     |
+| `notification.lastFailureReason` | string  | Reason for the last failure (e.g., `HTTP 500: Internal Server Error`). Cleared on success |
+| `notification.lastSuccess`       | string  | Date and time of last successful notification (ISO 8601)                                  |
+| `notification.timesSent`         | integer | Number of notifications sent                                                              |
 
-**リトライ動作**: 通知配信が失敗した場合、一時的なエラー (5xx、ネットワークエラー) に対しては、指数バックオフ (1 秒、2 秒、4 秒) で最大 3 回のリトライが実行されます。4xx エラーに対してはリトライは実行されません。
+**リトライ動作**: 通知配信が失敗した場合、一時的なエラー (5xx、ネットワークエラー) に対して指数バックオフ (1 秒、2 秒、4 秒) で最大 3 回のリトライが実行されます。4xx エラーに対してはリトライは実行されません。
 
-#
-
-### サブスクリプションの更新
+#### サブスクリプションの更新
 
 ```http
 PATCH /ngsi-ld/v1/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### サブスクリプションの削除
+#### サブスクリプションの削除
 
 ```http
 DELETE /ngsi-ld/v1/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### 所有権検証 (GeonicDB 拡張)
+#### 所有権検証 (GeonicDB 拡張)
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) および削除 (DELETE) 操作は、`createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みると `403 Forbidden` を受け取ります。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細については、AUTH.md を参照してください。
+認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みると `403 Forbidden` を受け取ります。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細については、[AUTH.md](../reference/auth.md) を参照してください。
 
----
+***
 
 ### レジストレーション (NGSI-LD)
 
-NGSI-LD では、外部コンテキストプロバイダーは Context Source Registration として登録されます。
+NGSI-LD では、外部コンテキストプロバイダーは Context Source Registrations として登録されます。
 
-#
-
-### レジストレーションの作成
+#### レジストレーションの作成
 
 ```http
 POST /ngsi-ld/v1/csourceRegistrations
@@ -1016,35 +1014,38 @@ Content-Type: application/ld+json
 
 **リクエストフィールド**
 
-| フィールド | 型 | 必須 | 説明 |
-|-----------|-----|------|------|
-| `type` | string | ✓ | 固定値: `ContextSourceRegistration` |
-| `registrationName` | string | - | レジストレーション名 |
-| `description` | string | - | レジストレーションの説明 |
-| `endpoint` | string | ✓ | プロバイダーのエンドポイント URL |
-| `information` | array | ✓ | 提供される情報 (entities、propertyNames、relationshipNames) |
-| `observationInterval` | object | - | 観測期間 (start、end) |
-| `managementInterval` | object | - | 管理期間 (start、end) |
-| `location` | GeoJSON | - | 地理的範囲 |
-| `expiresAt` | string | - | 有効期限 (ISO 8601 形式) |
-| `status` | string | - | ステータス (`active` / `inactive`) |
-| `mode` | string | - | モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`) |
+| Field                 | Type    | Required | Description                                                       |
+| --------------------- | ------- | -------- | ----------------------------------------------------------------- |
+| `type`                | string  | ✓        | Fixed: `ContextSourceRegistration`                                |
+| `registrationName`    | string  | -        | Registration name                                                 |
+| `description`         | string  | -        | Registration description                                          |
+| `endpoint`            | string  | ✓        | Provider endpoint URL                                             |
+| `information`         | array   | ✓        | Provided information (entities, propertyNames, relationshipNames) |
+| `observationInterval` | object  | -        | Observation interval (start, end)                                 |
+| `managementInterval`  | object  | -        | Management interval (start, end)                                  |
+| `location`            | GeoJSON | -        | Geographic scope                                                  |
+| `expiresAt`           | string  | -        | Expiration time (ISO 8601 format)                                 |
+| `status`              | string  | -        | Status (`active` / `inactive`)                                    |
+| `mode`                | string  | -        | Mode (`inclusive` / `exclusive` / `redirect` / `auxiliary`)       |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/csourceRegistrations/{registrationId}`#
 
-### レジストレーション一覧の取得
+* ステータス: `201 Created`
+  
+* ヘッダー: `Location: /ngsi-ld/v1/csourceRegistrations/{registrationId}`
+
+#### レジストレーションリストの取得
 
 ```http
 GET /ngsi-ld/v1/csourceRegistrations
 ```
 
-**クエリパラメータ**
+**クエリパラメーター**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|-----|------|-----------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
+| Parameter | Type    | Description                   | Default |
+| --------- | ------- | ----------------------------- | ------- |
+| `limit`   | integer | Number of results to retrieve | 20      |
+| `offset`  | integer | Offset                        | 0       |
 
 **レスポンス例**
 
@@ -1066,17 +1067,13 @@ GET /ngsi-ld/v1/csourceRegistrations
 ]
 ```
 
-#
-
-### レジストレーションの取得
+#### レジストレーションの取得
 
 ```http
 GET /ngsi-ld/v1/csourceRegistrations/{registrationId}
 ```
 
-#
-
-### レジストレーションの更新
+#### 登録の更新
 
 ```http
 PATCH /ngsi-ld/v1/csourceRegistrations/{registrationId}
@@ -1091,52 +1088,46 @@ PATCH /ngsi-ld/v1/csourceRegistrations/{registrationId}
 }
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### レジストレーションの削除
+#### 登録の削除
 
 ```http
 DELETE /ngsi-ld/v1/csourceRegistrations/{registrationId}
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### 所有権の検証 (GeonicDB 拡張)
+#### 所有権検証 (GeonicDB 拡張)
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、レジストレーションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みると `403 Forbidden` を受け取ります。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
+認証が有効な場合(`AUTH_ENABLED=true`)、登録の更新(PATCH)および削除(DELETE)操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みると `403 Forbidden` を受け取ります。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細については、[AUTH.md](../reference/auth.md) を参照してください。
 
-#
+#### CSR 拡張フィールド (ETSI GS CIM 009 V1.9.1)
 
-### CSR 拡張フィールド (ETSI GS CIM 009 V1.9.1)
+Context Source Registration では以下の拡張フィールドがサポートされています:
 
-Context Source Registration では、以下の拡張フィールドがサポートされています:
-
-| フィールド | 型 | 説明 |
-|-----------|-----|------|
-| `cacheDuration` | string (ISO 8601 duration) | コンテキストソースからのレスポンスのキャッシュ期間 |
-| `refreshRate` | string (ISO 8601 duration) | コンテキストソースへの定期的なリフレッシュの間隔 |
-| `timeout` | integer (ms) | コンテキストソースへのリクエストタイムアウト |
-| `contextSourceAlias` | string | コンテキストソースのエイリアス名 |
-| `contextSourceInfo` | object[] | コンテキストソースの追加メタデータ |
-| `operationGroup` | string[] | 操作グループ: `federationOps`、`retrieveOps`、`updateOps`、`redirectionOps` |
+| Field                | Type                       | Description                                                                     |
+| -------------------- | -------------------------- | ------------------------------------------------------------------------------- |
+| `cacheDuration`      | string (ISO 8601 duration) | Cache duration for responses from the context source                            |
+| `refreshRate`        | string (ISO 8601 duration) | Interval for periodic refresh to the context source                             |
+| `timeout`            | integer (ms)               | Request timeout to the context source                                           |
+| `contextSourceAlias` | string                     | Alias name for the context source                                               |
+| `contextSourceInfo`  | object\[]                  | Additional metadata for the context source                                      |
+| `operationGroup`     | string\[]                  | Operation groups: `federationOps`, `retrieveOps`, `updateOps`, `redirectionOps` |
 
 ### 分散操作情報
 
-#
-
-### Context Broker ID の取得
+#### Context Broker識別情報の取得
 
 ```http
 GET /ngsi-ld/v1/info/sourceIdentity
 ```
 
-コンテキストブローカーの ID 情報を返します。分散環境における Context Broker の識別に使用されます。
+コンテキストブローカーの識別情報を返します。分散環境におけるContext Broker識別に使用されます。
 
 **レスポンス**: `200 OK` (`application/ld+json`)
 
-#
-
-### 適合性情報の取得
+#### 適合性情報の取得
 
 ```http
 GET /ngsi-ld/v1/info/conformance
@@ -1146,35 +1137,27 @@ NGSI-LD 仕様への準拠状況を返します。
 
 **レスポンス**: `200 OK` (`application/ld+json`)
 
-#
+#### 分散クエリパラメータ
 
-### 分散クエリパラメータ
+| Parameter   | Type    | Description                                                                 |
+| ----------- | ------- | --------------------------------------------------------------------------- |
+| `localOnly` | boolean | If `true`, skips federation and returns only local data                     |
+| `csf`       | string  | Context Source Filter expression (e.g., `name==value`, `endpoint~=pattern`) |
 
-| パラメータ | タイプ | 説明 |
-|-----------|-----|------|
-| `localOnly` | boolean | `true` の場合、フェデレーションをスキップしてローカルデータのみを返します |
-| `csf` | string | コンテキストソースフィルタ式 (例: `name==value`、`endpoint~=pattern`) |
+#### 分散操作レスポンスヘッダー
 
-#
+| Header           | Description                                                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `NGSILD-Warning` | Warning message set when some context sources fail during federation (ETSI GS CIM 009 - 6.3.6)                                  |
+| `Via`            | Header for loop detection in distributed operations. The broker adds its own ID to forwarded requests (ETSI GS CIM 009 - 6.3.5) |
 
-### 分散操作レスポンスヘッダー
+#### CSR 変更通知
 
-| ヘッダー | 説明 |
-|----------|------|
-| `NGSILD-Warning` | フェデレーション中に一部のコンテキストソースが失敗した場合に設定される警告メッセージ (ETSI GS CIM 009 - 6.3.6) |
-| `Via` | 分散操作におけるループ検出用のヘッダー。Context Broker は転送されたリクエストに自身の ID を追加します (ETSI GS CIM 009 - 6.3.5) |
+Context Source Registration が作成、更新、または削除されると、一致する CSource Subscription の通知エンドポイントに自動的に通知が送信されます (ETSI GS CIM 009 - 5.11)。通知には、変更の種類を示す `Ngsild-Trigger` ヘッダー(`csourceRegistration-created`、`csourceRegistration-updated`、`csourceRegistration-deleted`)が含まれます。
 
-#
+#### 分散型と属性の発見
 
-### CSR 変更通知
-
-コンテキストソース登録が作成、更新、または削除されると、一致する CSource サブスクリプションの通知エンドポイントに自動的に通知が送信されます (ETSI GS CIM 009 - 5.11)。通知には変更のタイプを示す `Ngsild-Trigger` ヘッダー (`csourceRegistration-created`、`csourceRegistration-updated`、`csourceRegistration-deleted`) が含まれます。
-
-#
-
-### 分散型タイプと属性の検出
-
-`/ngsi-ld/v1/types` と `/ngsi-ld/v1/attributes` エンドポイントは、ローカルエンティティに加えて、コンテキストソース登録に登録されたエンティティタイプと属性を返します (ETSI GS CIM 009 - 5.9.3.3)。
+`/ngsi-ld/v1/types` および `/ngsi-ld/v1/attributes` エンドポイントは、ローカルエンティティに加えて、Context Source Registration に登録されたエンティティタイプと属性を返します (ETSI GS CIM 009 - 5.9.3.3)。
 
 ### EntityMap 操作
 
@@ -1182,11 +1165,9 @@ NGSI-LD 仕様への準拠状況を返します。
 
 NGSI-LD EntityMap は、クエリ結果をマップとして保存し、後でエンティティ ID による効率的なアクセスを可能にする機能です。
 
-#
+#### EntityMap 形式でエンティティを取得
 
-### EntityMap 形式でエンティティを取得
-
-`options=entityMap` を `GET /ngsi-ld/v1/entities` のクエリパラメータに指定すると、レスポンスがエンティティ ID をキーとするオブジェクトとして返されます。
+`GET /ngsi-ld/v1/entities` のクエリパラメータに `options=entityMap` を指定すると、エンティティ ID をキーとするオブジェクトとしてレスポンスが返されます。
 
 ```bash
 curl "http://localhost:3000/ngsi-ld/v1/entities?type=Room&options=entityMap" \
@@ -1210,20 +1191,16 @@ curl "http://localhost:3000/ngsi-ld/v1/entities?type=Room&options=entityMap" \
 }
 ```
 
-#
-
-### EntityMap の作成
+#### EntityMap を作成
 
 ```http
 POST /ngsi-ld/v1/entityMaps
 Content-Type: application/ld+json
 ```
 
-**レスポンス**: `201 Created`、作成された EntityMap の URL が `Location` ヘッダに含まれます
+**レスポンス**: `201 Created`、作成された EntityMap の URL が `Location` ヘッダーに含まれる
 
-#
-
-### EntityMap リストの取得
+#### EntityMap リストを取得
 
 ```http
 GET /ngsi-ld/v1/entityMaps
@@ -1231,45 +1208,46 @@ GET /ngsi-ld/v1/entityMaps
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `limit` | integer | 最大結果数 (デフォルト: 20、最大: 1000) |
-| `offset` | integer | スキップする結果数 (デフォルト: 0) |
+| Parameter | Type    | Description                                        |
+| --------- | ------- | -------------------------------------------------- |
+| `limit`   | integer | Maximum number of results (default: 20, max: 1000) |
+| `offset`  | integer | Number of results to skip (default: 0)             |
 
-**レスポンス**: `200 OK`#
+**レスポンス**: `200 OK`
 
-### EntityMap の取得
+#### EntityMap を取得
 
 ```http
 GET /ngsi-ld/v1/entityMaps/{entityMapId}
 ```
 
-**レスポンス**: `200 OK`#
+**レスポンス**: `200 OK`
 
-### EntityMap の更新
+#### EntityMap を更新
 
 ```http
 PATCH /ngsi-ld/v1/entityMaps/{entityMapId}
 Content-Type: application/ld+json
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### EntityMap の削除
+#### EntityMap を削除
 
 ```http
 DELETE /ngsi-ld/v1/entityMaps/{entityMapId}
 ```
 
 **レスポンス**: `204 No Content`
-### リンクエンティティの取得 (join/joinLevel)
 
-エンティティ取得エンドポイント (`GET /ngsi-ld/v1/entities` と `GET /ngsi-ld/v1/entities/{entityId}`) では、`join` と `joinLevel` のクエリパラメータを使用してリンクされたエンティティを取得できます。
+### リンクされたエンティティの取得 (join/joinLevel)
 
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `join` | string | リンクエンティティ取得モード: `inline` (Relationship 内にネスト) または `flat` (結果配列に追加) |
-| `joinLevel` | integer | リンクエンティティ解決の深さ (デフォルト: 1) |
+エンティティ取得エンドポイント (`GET /ngsi-ld/v1/entities` および `GET /ngsi-ld/v1/entities/{entityId}`) では、`join` および `joinLevel` クエリパラメータを使用してリンクされたエンティティを取得できます。
+
+| Parameter   | Type    | Description                                                                                              |
+| ----------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `join`      | string  | Linked entity retrieval mode: `inline` (nested inside Relationship) or `flat` (appended to result array) |
+| `joinLevel` | integer | Depth of linked entity resolution (default: 1)                                                           |
 
 **使用例**
 
@@ -1282,13 +1260,12 @@ curl "https://api.example.com/ngsi-ld/v1/entities?type=Room&join=inline&joinLeve
 curl "https://api.example.com/ngsi-ld/v1/entities/urn:ngsi-ld:Room:001?join=flat&joinLevel=1" \
   -H "Fiware-Service: smartcity"
 ```
-### コンテキスト ソース登録サブスクリプション
 
-NGSI-LD では、コンテキスト ソース登録サブスクリプション (CSR サブスクリプション) は、コンテキスト ソース登録の変更を監視するサブスクリプションを管理します。
+### コンテキストソース登録サブスクリプション
 
-#
+NGSI-LD では、コンテキストソース登録サブスクリプション (CSR サブスクリプション) は、コンテキストソース登録の変更を監視するサブスクリプションを管理します。
 
-### CSR サブスクリプションの作成
+#### CSR サブスクリプションの作成
 
 ```http
 POST /ngsi-ld/v1/csourceSubscriptions
@@ -1312,21 +1289,24 @@ Content-Type: application/ld+json
 
 **リクエストフィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-----------|-----|------|------|
-| `type` | string | ✓ | 固定値: `Subscription` |
-| `entities` | array | ✓ | 監視対象のエンティティ (type、id、idPattern) |
-| `notification` | object | ✓ | 通知設定 (endpoint.uri は必須) |
-| `description` | string | - | サブスクリプションの説明 |
-| `watchedAttributes` | array | - | 監視する属性のリスト |
-| `expiresAt` | string | - | 有効期限 (ISO 8601 形式) |
-| `throttling` | number | - | 通知間隔 (秒) |
-| `isActive` | boolean | - | アクティブ状態 (デフォルト: true) |
+| Field               | Type    | Required | Description                                      |
+| ------------------- | ------- | -------- | ------------------------------------------------ |
+| `type`              | string  | ✓        | Fixed: `Subscription`                            |
+| `entities`          | array   | ✓        | Target entities to monitor (type, id, idPattern) |
+| `notification`      | object  | ✓        | Notification settings (endpoint.uri is required) |
+| `description`       | string  | -        | Subscription description                         |
+| `watchedAttributes` | array   | -        | List of attributes to monitor                    |
+| `expiresAt`         | string  | -        | Expiration time (ISO 8601 format)                |
+| `throttling`        | number  | -        | Notification interval (seconds)                  |
+| `isActive`          | boolean | -        | Active state (default: true)                     |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}`#
 
-### CSR サブスクリプションリストの取得
+* ステータス: `201 Created`
+  
+* ヘッダー: `Location: /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}`
+
+#### CSR サブスクリプションリストの取得
 
 ```http
 GET /ngsi-ld/v1/csourceSubscriptions
@@ -1334,10 +1314,10 @@ GET /ngsi-ld/v1/csourceSubscriptions
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
-|-----------|-----|------|-----------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
+| Parameter | Type    | Description                   | Default |
+| --------- | ------- | ----------------------------- | ------- |
+| `limit`   | integer | Number of results to retrieve | 20      |
+| `offset`  | integer | Offset                        | 0       |
 
 **レスポンス例**
 
@@ -1356,17 +1336,13 @@ GET /ngsi-ld/v1/csourceSubscriptions
 ]
 ```
 
-#
-
-### CSR サブスクリプションの取得
+#### CSR サブスクリプションの取得
 
 ```http
 GET /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 ```
 
-#
-
-### CSR サブスクリプションの更新
+#### CSR サブスクリプションの更新
 
 ```http
 PATCH /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
@@ -1381,22 +1357,21 @@ PATCH /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 }
 ```
 
-**レスポンス**: `204 No Content`#
+**レスポンス**: `204 No Content`
 
-### CSR サブスクリプションの削除
+#### CSR サブスクリプションの削除
 
 ```http
 DELETE /ngsi-ld/v1/csourceSubscriptions/{subscriptionId}
 ```
 
 **レスポンス**: `204 No Content`
-### JSON-LD Context 管理
 
-ETSI GS CIM 009 Section 5.12 に準拠した JSON-LD context 管理 API です。ユーザー定義の JSON-LD context の登録と管理が可能です。
+### JSON-LD コンテキスト管理
 
-#
+ETSI GS CIM 009 Section 5.12 に準拠した JSON-LD コンテキスト管理 API。ユーザー定義 JSON-LD コンテキストの登録と管理を可能にします。
 
-### JSON-LD Context の登録
+#### JSON-LD コンテキストの登録
 
 ```http
 POST /ngsi-ld/v1/jsonldContexts
@@ -1416,9 +1391,12 @@ Content-Type: application/json
 ```
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /ngsi-ld/v1/jsonldContexts/{contextId}`#
 
-### JSON-LD Context リストの取得
+* ステータス:`201 Created`
+  
+* ヘッダー:`Location: /ngsi-ld/v1/jsonldContexts/{contextId}`
+
+#### JSON-LD コンテキストリストの取得
 
 ```http
 GET /ngsi-ld/v1/jsonldContexts
@@ -1426,14 +1404,14 @@ GET /ngsi-ld/v1/jsonldContexts
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|-----|------|-----------|
-| `limit` | integer | 取得する結果の最大数 | 20 |
-| `offset` | integer | スキップする結果の数 | 0 |
+| Parameter | Type    | Description               | Default |
+| --------- | ------- | ------------------------- | ------- |
+| `limit`   | integer | Maximum number of results | 20      |
+| `offset`  | integer | Number of results to skip | 0       |
 
-**レスポンス**: `200 OK`#
+**レスポンス**:`200 OK`
 
-### JSON-LD Context の取得
+#### JSON-LD コンテキストの取得
 
 ```http
 GET /ngsi-ld/v1/jsonldContexts/{contextId}
@@ -1441,37 +1419,36 @@ GET /ngsi-ld/v1/jsonldContexts/{contextId}
 
 **キャッシュヘッダー**
 
-レスポンスには以下のキャッシュ関連ヘッダーが含まれます:
+レスポンスには、以下のキャッシュ関連ヘッダーが含まれます:
 
-| ヘッダー | 説明 |
-|---------|------|
-| `ETag` | context ボディの MD5 ハッシュ |
-| `Last-Modified` | context の作成日時 |
-| `Cache-Control` | `public, max-age=3600` |
+| Header          | Description                           |
+| --------------- | ------------------------------------- |
+| `ETag`          | MD5 hash of the context body          |
+| `Last-Modified` | Creation date and time of the context |
+| `Cache-Control` | `public, max-age=3600`                |
 
 **条件付きリクエスト**
 
-| リクエストヘッダー | 動作 |
-|------------------|------|
-| `If-None-Match` | ETag が一致する場合 `304 Not Modified` を返す |
-| `If-Modified-Since` | 指定日時以降に変更がない場合 `304 Not Modified` を返す |
+| Request Header      | Behavior                                                          |
+| ------------------- | ----------------------------------------------------------------- |
+| `If-None-Match`     | Returns `304 Not Modified` if the ETag matches                    |
+| `If-Modified-Since` | Returns `304 Not Modified` if no changes since the specified date |
 
-**レスポンス**: `200 OK` / `304 Not Modified`#
+**レスポンス**:`200 OK` / `304 Not Modified`
 
-### JSON-LD Context の削除
+#### JSON-LD コンテキストの削除
 
 ```http
 DELETE /ngsi-ld/v1/jsonldContexts/{contextId}
 ```
 
-**レスポンス**: `204 No Content`
+**レスポンス**:`204 No Content`
+
 ### Vector Tiles (NGSI-LD)
 
-地図可視化のためにエンティティデータを GeoJSON ベクタータイルとして提供します。TileJSON 3.0 準拠のメタデータと、ズームレベルおよびタイル座標による GeoJSON タイルの取得をサポートします。
+マップ可視化のためにエンティティデータを GeoJSON ベクタータイルとして提供します。TileJSON 3.0 準拠のメタデータと、ズームレベルおよびタイル座標による GeoJSON タイル取得をサポートします。
 
-#
-
-### TileJSON メタデータの取得
+#### TileJSON メタデータの取得
 
 ```http
 GET /ngsi-ld/v1/tiles
@@ -1479,9 +1456,7 @@ GET /ngsi-ld/v1/tiles
 
 **レスポンス**: `200 OK` (TileJSON 3.0 形式)
 
-#
-
-### GeoJSON タイルの取得
+#### GeoJSON タイルの取得
 
 ```http
 GET /ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson
@@ -1489,61 +1464,61 @@ GET /ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson
 
 **パスパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `z` | integer | ズームレベル |
-| `x` | integer | タイル X 座標 |
-| `y` | integer | タイル Y 座標 |
+| Parameter | Type    | Description       |
+| --------- | ------- | ----------------- |
+| `z`       | integer | Zoom level        |
+| `x`       | integer | Tile X coordinate |
+| `y`       | integer | Tile Y coordinate |
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|-----|------|
-| `type` | string | エンティティタイプのフィルタ |
-| `attrs` | string | 取得する属性 (カンマ区切り) |
-| `q` | string | NGSI-LD クエリ言語を使用した属性フィルタ |
-| `limit` | integer | 取得する結果の最大数 (デフォルト: 20、最大: 1000) |
-| `offset` | integer | スキップする結果の数 (デフォルト: 0) |
+| Parameter | Type    | Description                                        |
+| --------- | ------- | -------------------------------------------------- |
+| `type`    | string  | Entity type filter                                 |
+| `attrs`   | string  | Attributes to retrieve (comma-separated)           |
+| `q`       | string  | Attribute filter using NGSI-LD query language      |
+| `limit`   | integer | Maximum number of results (default: 20, max: 1000) |
+| `offset`  | integer | Number of results to skip (default: 0)             |
 
 **レスポンス**: `200 OK` (GeoJSON FeatureCollection 形式)
 
----
+***
 
 ## HTTP キャッシュ制御
 
-NGSI-LD GET エンドポイントは、エンドポイントクラスごとにキャッシュ関連のヘッダーを返します:
+NGSI-LD GET エンドポイントは、エンドポイントクラスごとにキャッシュ関連ヘッダーを返します:
 
-### データエンドポイント (entities, subscriptions, csourceRegistrations, csourceSubscriptions) — RFC 7232 + RFC 7234 完全サポート
+### データエンドポイント (entities、subscriptions、csourceRegistrations、csourceSubscriptions) — 完全な RFC 7232 + RFC 7234 サポート
 
-| ヘッダー | 値 | 目的 |
-|--------|-------|---------|
-| `ETag` | `W/"..."` | 弱い検証子。生成シードには `path + Accept + tenant + Fiware-ServicePath` (tenant = `NGSILD-Tenant` ?? `Fiware-Service`) が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープの混合。単一: `modifiedAt` のハッシュとスコープの混合。 |
-| `Last-Modified` | RFC 1123 HTTP-date | 結果セット内の最新の `modifiedAt` のタイムスタンプ。 |
-| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制します。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュのためのテナント + 認証 + コンテンツネゴシエーション分離。 |
+| Header          | Value                                                                  | Purpose                                                                                                                                                                                                                                                                                                                                                     |
+| --------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETag`          | `W/"..."`                                                              | Weak validator. Generation seeds include `path + Accept + tenant + Fiware-ServicePath` (tenant = `NGSILD-Tenant` ?? `Fiware-Service`) so distinct endpoints / Accept / tenants / service paths always produce distinct ETags. Lists: streaming digest of `id + modifiedAt` mixed with total count and scope. Single: hash of `modifiedAt` mixed with scope. |
+| `Last-Modified` | RFC 1123 HTTP-date                                                     | Timestamp of the latest `modifiedAt` in the result set.                                                                                                                                                                                                                                                                                                     |
+| `Cache-Control` | `private, no-cache`                                                    | `private` blocks shared / intermediate cache storage; `no-cache` forces revalidation from the private cache.                                                                                                                                                                                                                                                |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | Tenant + auth + content-negotiation isolation for shared caches.                                                                                                                                                                                                                                                                                            |
 
 条件付きリクエストがサポートされています:
 
-| リクエストヘッダー | 動作 |
-|----------------|----------|
-| `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified` (空のボディ) を返します。 |
-| `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。 |
-| `Cache-Control: no-store` | サーバーはレスポンス `Cache-Control` を `no-store` にオーバーライドします。 |
+| Request Header                   | Behavior                                                 |
+| -------------------------------- | -------------------------------------------------------- |
+| `If-None-Match: <ETag>`          | Returns `304 Not Modified` (empty body) if matched.      |
+| `If-Modified-Since: <HTTP-date>` | Returns `304` if the resource is unchanged.              |
+| `Cache-Control: no-store`        | Server overrides response `Cache-Control` to `no-store`. |
 
-### メタエンドポイント (types, attributes) — Cache-Control + Vary のみ (ETag / 304 なし)
+### メタエンドポイント (types、attributes) — Cache-Control + Vary のみ (ETag なし / 304 なし)
 
-| ヘッダー | 値 | 目的 |
-|--------|-------|---------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` | バックグラウンド再検証を伴う短期キャッシング。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証分離。 |
+| Header          | Value                                                                  | Purpose                                          |
+| --------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120`                               | Short-term caching with background revalidation. |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | Same tenant/auth isolation as data endpoints.    |
 
 メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
 
-> **注**: `/ngsi-ld/v1/jsonldContexts/{contextId}` には追加のコンテキスト固有のキャッシュセマンティクスがあります — 上記の JSON-LD コンテキスト管理セクションを参照してください。
+> **注意**: `/ngsi-ld/v1/jsonldContexts/{contextId}` には追加のコンテキスト固有のキャッシュセマンティクスがあります — 上記の JSON-LD Context Management セクションを参照してください。
 
-完全なセマンティクスについては、[API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
+完全なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
 
----
+***
 
 ## エンドポイント一覧
 
@@ -1551,147 +1526,155 @@ ETSI NGSI-LD 互換 Context Broker API。
 
 ### 共通仕様
 
-- **Content-Type**: `application/ld+json` または `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
-- **テナント分離**: `NGSILD-Tenant` または `Fiware-Service` ヘッダー
-- **ページネーション**: `limit`/`offset` パラメータ、総数は常に `NGSILD-Results-Count` ヘッダーで返されます
-- **OPTIONS メソッド**: すべての NGSI-LD エンドポイントは OPTIONS メソッドをサポートします。`Allow` および `Accept-Patch` ヘッダーと共に 204 レスポンスを返します
-- **405 Method Not Allowed**: 許可されていない HTTP メソッドに対して 405 レスポンスを返します (RFC 7807 ProblemDetails 形式、`Allow` ヘッダー付き)
-- **エラー形式**: NGSI-LD エラーレスポンスは RFC 7807 ProblemDetails 形式 (`application/json`) で返されます
+
+* **Content-Type**: `application/ld+json` または `application/json`
+  
+* **認証**: `AUTH_ENABLED=true` の場合は必須
+  
+* **テナント分離**: `NGSILD-Tenant` または `Fiware-Service` ヘッダー
+  
+* **ページネーション**: `limit`/`offset` パラメータ、総数は常に `NGSILD-Results-Count` ヘッダー経由で返されます
+  
+* **OPTIONS メソッド**: すべての NGSI-LD エンドポイントは OPTIONS メソッドをサポートします。`Allow` および `Accept-Patch` ヘッダー付きの 204 レスポンスを返します
+  
+* **405 Method Not Allowed**: 許可されていない HTTP メソッドに対して 405 レスポンスを返します (RFC 7807 ProblemDetails 形式、`Allow` ヘッダー付き)
+  
+* **エラー形式**: NGSI-LD エラーレスポンスは RFC 7807 ProblemDetails 形式 (`application/json`) で返されます
 
 ### エンティティ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/entities` | GET | エンティティリストの取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/entities` | POST | エンティティの作成 | 201 | 400, 401, 409, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}` | GET | エンティティの取得 | 200 | 400, 401, 404 | - |
-| `/ngsi-ld/v1/entities/{entityId}` | PUT | エンティティの置換 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}` | PATCH | エンティティの更新 (マージパッチ) | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}` | POST | 属性の追加 | 204/207 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}` | DELETE | エンティティの削除 | 204 | 401, 404 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs` | GET | エンティティのすべての属性を取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs` | POST | 属性の追加 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs` | PATCH | 属性の部分更新 | 204/207 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | GET | 単一属性の取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | POST | 属性の置換 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | PUT | 属性の置換 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | PATCH | 属性の部分更新 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | DELETE | 属性の削除 | 204 | 401, 404 | - |
+| Endpoint                                           | Method | Description                       | Success | Error              | Pagination    |
+| -------------------------------------------------- | ------ | --------------------------------- | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/entities`                             | GET    | Retrieve entity list              | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/entities`                             | POST   | Create entity                     | 201     | 400, 401, 409, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}`                  | GET    | Retrieve entity                   | 200     | 400, 401, 404      | -             |
+| `/ngsi-ld/v1/entities/{entityId}`                  | PUT    | Replace entity                    | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}`                  | PATCH  | Update entity (merge patch)       | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}`                  | POST   | Add attributes                    | 204/207 | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}`                  | DELETE | Delete entity                     | 204     | 401, 404           | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs`            | GET    | Retrieve all attributes of entity | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs`            | POST   | Add attributes                    | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs`            | PATCH  | Partial attribute update          | 204/207 | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | GET    | Retrieve single attribute         | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | POST   | Replace attribute                 | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | PUT    | Replace attribute                 | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | PATCH  | Partial attribute update          | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entities/{entityId}/attrs/{attrName}` | DELETE | Delete attribute                  | 204     | 401, 404           | -             |
 
 ### タイプ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/types` | GET | エンティティタイプリストの取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/types/{typeName}` | GET | エンティティタイプ詳細の取得 | 200 | 401, 404 | - |
+| Endpoint                       | Method | Description                  | Success | Error    | Pagination    |
+| ------------------------------ | ------ | ---------------------------- | ------- | -------- | ------------- |
+| `/ngsi-ld/v1/types`            | GET    | Retrieve entity type list    | 200     | 400, 401 | ✅ (max: 1000) |
+| `/ngsi-ld/v1/types/{typeName}` | GET    | Retrieve entity type details | 200     | 401, 404 | -             |
 
 ### 属性操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/attributes` | GET | 属性リストの取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/attributes/{attrName}` | GET | 属性詳細の取得 | 200 | 401, 404 | - |
+| Endpoint                            | Method | Description                | Success | Error    | Pagination    |
+| ----------------------------------- | ------ | -------------------------- | ------- | -------- | ------------- |
+| `/ngsi-ld/v1/attributes`            | GET    | Retrieve attribute list    | 200     | 400, 401 | ✅ (max: 1000) |
+| `/ngsi-ld/v1/attributes/{attrName}` | GET    | Retrieve attribute details | 200     | 401, 404 | -             |
 
 ### サブスクリプション操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/subscriptions` | GET | サブスクリプション一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/subscriptions` | POST | サブスクリプション作成 | 201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/subscriptions/{subscriptionId}` | GET | サブスクリプション取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/subscriptions/{subscriptionId}` | PATCH | サブスクリプション更新 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/subscriptions/{subscriptionId}` | DELETE | サブスクリプション削除 | 204 | 401, 404 | - |
+| Endpoint                                     | Method | Description           | Success | Error              | Pagination    |
+| -------------------------------------------- | ------ | --------------------- | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/subscriptions`                  | GET    | Subscription list     | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/subscriptions`                  | POST   | Create subscription   | 201     | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/subscriptions/{subscriptionId}` | GET    | Retrieve subscription | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/subscriptions/{subscriptionId}` | PATCH  | Update subscription   | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/subscriptions/{subscriptionId}` | DELETE | Delete subscription   | 204     | 401, 404           | -             |
 
 ### コンテキストソース登録操作 (フェデレーション)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/csourceRegistrations` | GET | 登録一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/csourceRegistrations` | POST | 登録作成 | 201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/csourceRegistrations/{registrationId}` | GET | 登録取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/csourceRegistrations/{registrationId}` | PATCH | 登録更新 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/csourceRegistrations/{registrationId}` | DELETE | 登録削除 | 204 | 401, 404 | - |
+| Endpoint                                            | Method | Description           | Success | Error              | Pagination    |
+| --------------------------------------------------- | ------ | --------------------- | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/csourceRegistrations`                  | GET    | Registration list     | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/csourceRegistrations`                  | POST   | Create registration   | 201     | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/csourceRegistrations/{registrationId}` | GET    | Retrieve registration | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/csourceRegistrations/{registrationId}` | PATCH  | Update registration   | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/csourceRegistrations/{registrationId}` | DELETE | Delete registration   | 204     | 401, 404           | -             |
 
 ### コンテキストソース登録サブスクリプション操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/csourceSubscriptions` | GET | CSR サブスクリプション一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/csourceSubscriptions` | POST | CSR サブスクリプション作成 | 201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/csourceSubscriptions/{subscriptionId}` | GET | CSR サブスクリプション取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/csourceSubscriptions/{subscriptionId}` | PATCH | CSR サブスクリプション更新 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/csourceSubscriptions/{subscriptionId}` | DELETE | CSR サブスクリプション削除 | 204 | 401, 404 | - |
+| Endpoint                                            | Method | Description               | Success | Error              | Pagination    |
+| --------------------------------------------------- | ------ | ------------------------- | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/csourceSubscriptions`                  | GET    | CSR subscription list     | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/csourceSubscriptions`                  | POST   | Create CSR subscription   | 201     | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/csourceSubscriptions/{subscriptionId}` | GET    | Retrieve CSR subscription | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/csourceSubscriptions/{subscriptionId}` | PATCH  | Update CSR subscription   | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/csourceSubscriptions/{subscriptionId}` | DELETE | Delete CSR subscription   | 204     | 401, 404           | -             |
 
-### 分散オペレーション情報
+### 分散操作情報
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー |
-|---------------|---------|------|------|--------|
-| `/ngsi-ld/v1/info/sourceIdentity` | GET | Context Broker 識別情報の取得 | 200 | - |
-| `/ngsi-ld/v1/info/conformance` | GET | NGSI-LD 準拠情報の取得 | 200 | - |
+| Endpoint                          | Method | Description                              | Success | Error |
+| --------------------------------- | ------ | ---------------------------------------- | ------- | ----- |
+| `/ngsi-ld/v1/info/sourceIdentity` | GET    | Retrieve broker identity                 | 200     | -     |
+| `/ngsi-ld/v1/info/conformance`    | GET    | Retrieve NGSI-LD conformance information | 200     | -     |
 
 ### JSON-LD コンテキスト管理
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/jsonldContexts` | GET | JSON-LD コンテキスト一覧 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/jsonldContexts` | POST | JSON-LD コンテキスト登録 | 201 | 400, 401, 409, 415 | - |
-| `/ngsi-ld/v1/jsonldContexts/{contextId}` | GET | JSON-LD コンテキスト取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/jsonldContexts/{contextId}` | DELETE | JSON-LD コンテキスト削除 | 204 | 401, 404 | - |
+| Endpoint                                 | Method | Description              | Success | Error              | Pagination    |
+| ---------------------------------------- | ------ | ------------------------ | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/jsonldContexts`             | GET    | JSON-LD context list     | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/jsonldContexts`             | POST   | Register JSON-LD context | 201     | 400, 401, 409, 415 | -             |
+| `/ngsi-ld/v1/jsonldContexts/{contextId}` | GET    | Retrieve JSON-LD context | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/jsonldContexts/{contextId}` | DELETE | Delete JSON-LD context   | 204     | 401, 404           | -             |
 
 ### EntityMap 操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/entityMaps` | GET | EntityMap 一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/entityMaps` | POST | EntityMap 作成 | 201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/entityMaps/{entityMapId}` | GET | EntityMap 取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/entityMaps/{entityMapId}` | PATCH | EntityMap 更新 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/entityMaps/{entityMapId}` | DELETE | EntityMap 削除 | 204 | 401, 404 | - |
+| Endpoint                               | Method | Description             | Success | Error              | Pagination    |
+| -------------------------------------- | ------ | ----------------------- | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/entityMaps`               | GET    | Retrieve EntityMap list | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/entityMaps`               | POST   | Create EntityMap        | 201     | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/entityMaps/{entityMapId}` | GET    | Retrieve EntityMap      | 200     | 401, 404           | -             |
+| `/ngsi-ld/v1/entityMaps/{entityMapId}` | PATCH  | Update EntityMap        | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/entityMaps/{entityMapId}` | DELETE | Delete EntityMap        | 204     | 401, 404           | -             |
 
 ### スナップショット操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/snapshots` | GET | スナップショット一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/snapshots` | POST | スナップショット作成 | 201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/snapshots` | DELETE | 全スナップショット削除 | 200 | 401 | - |
-| `/ngsi-ld/v1/snapshots/{snapshotId}` | GET | スナップショット取得 | 200 | 401, 404 | - |
-| `/ngsi-ld/v1/snapshots/{snapshotId}` | PATCH | スナップショットステータス更新 | 204 | 400, 401, 404 | - |
-| `/ngsi-ld/v1/snapshots/{snapshotId}` | DELETE | スナップショット削除 | 204 | 401, 404 | - |
-| `/ngsi-ld/v1/snapshots/{snapshotId}/clone` | POST | スナップショット複製 (復元) | 200 | 400, 401, 404 | - |
+| Endpoint                                   | Method | Description              | Success | Error         | Pagination    |
+| ------------------------------------------ | ------ | ------------------------ | ------- | ------------- | ------------- |
+| `/ngsi-ld/v1/snapshots`                    | GET    | Retrieve snapshot list   | 200     | 400, 401      | ✅ (max: 1000) |
+| `/ngsi-ld/v1/snapshots`                    | POST   | Create snapshot          | 201     | 400, 401, 415 | -             |
+| `/ngsi-ld/v1/snapshots`                    | DELETE | Purge all snapshots      | 200     | 401           | -             |
+| `/ngsi-ld/v1/snapshots/{snapshotId}`       | GET    | Retrieve snapshot        | 200     | 401, 404      | -             |
+| `/ngsi-ld/v1/snapshots/{snapshotId}`       | PATCH  | Update snapshot status   | 204     | 400, 401, 404 | -             |
+| `/ngsi-ld/v1/snapshots/{snapshotId}`       | DELETE | Delete snapshot          | 204     | 401, 404      | -             |
+| `/ngsi-ld/v1/snapshots/{snapshotId}/clone` | POST   | Clone snapshot (restore) | 200     | 400, 401, 404 | -             |
 
 ### バッチ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/entityOperations/create` | POST | バッチ作成 (最大: 1000) | 200/201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/entityOperations/upsert` | POST | バッチアップサート (最大: 1000) | 200/201 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/entityOperations/update` | POST | バッチ更新 (最大: 1000) | 200/204 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/entityOperations/delete` | POST | バッチ削除 (最大: 1000) | 200/204 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/entityOperations/query` | POST | バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/entityOperations/merge` | POST | バッチマージパッチ (最大: 1000) | 204/207 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/entityOperations/purge` | POST | エンティティ一括削除 | 204 | 400, 401, 415 | - |
+| Endpoint                              | Method | Description                   | Success | Error         | Pagination    |
+| ------------------------------------- | ------ | ----------------------------- | ------- | ------------- | ------------- |
+| `/ngsi-ld/v1/entityOperations/create` | POST   | Batch create (max: 1000)      | 200/201 | 400, 401, 415 | -             |
+| `/ngsi-ld/v1/entityOperations/upsert` | POST   | Batch upsert (max: 1000)      | 200/201 | 400, 401, 415 | -             |
+| `/ngsi-ld/v1/entityOperations/update` | POST   | Batch update (max: 1000)      | 200/204 | 400, 401, 415 | -             |
+| `/ngsi-ld/v1/entityOperations/delete` | POST   | Batch delete (max: 1000)      | 200/204 | 400, 401, 415 | -             |
+| `/ngsi-ld/v1/entityOperations/query`  | POST   | Batch query                   | 200     | 400, 401, 415 | ✅ (max: 1000) |
+| `/ngsi-ld/v1/entityOperations/merge`  | POST   | Batch merge patch (max: 1000) | 204/207 | 400, 401, 415 | -             |
+| `/ngsi-ld/v1/entityOperations/purge`  | POST   | Bulk entity purge             | 204     | 400, 401, 415 | -             |
 
 ### Temporal API (時系列データ)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/temporal/entities` | GET | 時系列エンティティ一覧取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/ngsi-ld/v1/temporal/entities` | POST | 時系列エンティティ作成 | 201 | 400, 401, 409, 415 | - |
-| `/ngsi-ld/v1/temporal/entities/{entityId}` | GET | 時系列エンティティ取得 | 200 | 400, 401, 404 | - |
-| `/ngsi-ld/v1/temporal/entities/{entityId}` | PATCH | 時系列エンティティの属性マージ | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/temporal/entities/{entityId}` | DELETE | 時系列エンティティ削除 | 204 | 401, 404 | - |
-| `/ngsi-ld/v1/temporal/entities/{entityId}/attrs` | POST | 属性インスタンス追加 | 204 | 400, 401, 404, 415 | - |
-| `/ngsi-ld/v1/temporal/entities/{entityId}/attrs/{attrName}` | DELETE | 属性インスタンス削除 | 204 | 401, 404 | - |
-| `/ngsi-ld/v1/temporal/entities/{entityId}/attrs/{attrName}/{instanceId}` | PATCH | 属性インスタンス変更 | 204 | 400, 401, 404 | - |
-| `/ngsi-ld/v1/temporal/entityOperations/create` | POST | 時系列バッチ作成 (最大: 1000) | 201/207 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/temporal/entityOperations/upsert` | POST | 時系列バッチアップサート (最大: 1000) | 204/207 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/temporal/entityOperations/delete` | POST | 時系列バッチ削除 | 204/207 | 400, 401, 415 | - |
-| `/ngsi-ld/v1/temporal/entityOperations/query` | POST | 時系列バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
+| Endpoint                                                                 | Method | Description                         | Success | Error              | Pagination    |
+| ------------------------------------------------------------------------ | ------ | ----------------------------------- | ------- | ------------------ | ------------- |
+| `/ngsi-ld/v1/temporal/entities`                                          | GET    | Retrieve temporal entity list       | 200     | 400, 401           | ✅ (max: 1000) |
+| `/ngsi-ld/v1/temporal/entities`                                          | POST   | Create temporal entity              | 201     | 400, 401, 409, 415 | -             |
+| `/ngsi-ld/v1/temporal/entities/{entityId}`                               | GET    | Retrieve temporal entity            | 200     | 400, 401, 404      | -             |
+| `/ngsi-ld/v1/temporal/entities/{entityId}`                               | PATCH  | Merge attributes of temporal entity | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/temporal/entities/{entityId}`                               | DELETE | Delete temporal entity              | 204     | 401, 404           | -             |
+| `/ngsi-ld/v1/temporal/entities/{entityId}/attrs`                         | POST   | Add attribute instance              | 204     | 400, 401, 404, 415 | -             |
+| `/ngsi-ld/v1/temporal/entities/{entityId}/attrs/{attrName}`              | DELETE | Delete attribute instance           | 204     | 401, 404           | -             |
+| `/ngsi-ld/v1/temporal/entities/{entityId}/attrs/{attrName}/{instanceId}` | PATCH  | Modify attribute instance           | 204     | 400, 401, 404      | -             |
+| `/ngsi-ld/v1/temporal/entityOperations/create`                           | POST   | Temporal batch create (max: 1000)   | 201/207 | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/temporal/entityOperations/upsert`                           | POST   | Temporal batch upsert (max: 1000)   | 204/207 | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/temporal/entityOperations/delete`                           | POST   | Temporal batch delete               | 204/207 | 400, 401, 415      | -             |
+| `/ngsi-ld/v1/temporal/entityOperations/query`                            | POST   | Temporal batch query                | 200     | 400, 401, 415      | ✅ (max: 1000) |
 
 ### ベクタータイル操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|---------------|---------|------|------|--------|-----------------|
-| `/ngsi-ld/v1/tiles` | GET | TileJSON 3.0 メタデータを取得 | 200 | 401 | - |
-| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET | GeoJSON タイルを取得 | 200 | 400, 401 | ✅ (最大: 1000) |
+| Endpoint                                | Method | Description                    | Success | Error    | Pagination    |
+| --------------------------------------- | ------ | ------------------------------ | ------- | -------- | ------------- |
+| `/ngsi-ld/v1/tiles`                     | GET    | Retrieve TileJSON 3.0 metadata | 200     | 401      | -             |
+| `/ngsi-ld/v1/tiles/{z}/{x}/{y}.geojson` | GET    | Retrieve GeoJSON tile          | 200     | 400, 401 | ✅ (max: 1000) |

--- a/docs/ja/api-reference/ngsiv2.md
+++ b/docs/ja/api-reference/ngsiv2.md
@@ -5,11 +5,13 @@ outline: deep
 ---
 # NGSIv2 API
 
-> このドキュメントは[API.md](./endpoints.md)から分割されました。メインの API 仕様については、[API.md](./endpoints.md)を参照してください。
+> このドキュメントは [API.md](./endpoints.md) から分割されました。メインの API 仕様については、[API.md](./endpoints.md) を参照してください。
 
----
+***
 
-## エンティティ操作### エンティティの一覧取得
+## エンティティ操作
+
+### エンティティのリスト取得
 
 ```http
 GET /v2/entities
@@ -17,40 +19,42 @@ GET /v2/entities
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `id` | string | エンティティ ID でフィルタ (複数の値をカンマ区切りリストで指定可能) | - |
-| `limit` | integer | 取得する結果の数 (最大: 1000) | 20 |
-| `offset` | integer | オフセット (ページネーション用) | 0 |
-| `orderBy` | string | ソート条件 (`entityId`、`entityType`、`modifiedAt`、または属性名)。FIWARE Orion 互換の `!` プレフィックスで降順指定可能 (例: `!temperature`) | - |
-| `orderDirection` | string | ソート方向 (`asc`、`desc`)。**GeonicDB 拡張** (公式仕様は `!` プレフィックス方式のみサポート) | `asc` |
-| `type` | string | エンティティタイプでフィルタ | - |
-| `typePattern` | string | エンティティタイプの正規表現パターン | - |
-| `idPattern` | string | エンティティ ID の正規表現パターン | - |
-| `q` | string | 属性値でフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
-| `mq` | string | メタデータでフィルタ ([クエリ言語](./endpoints.md#query-language)を参照) | - |
-| `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`)。**GeonicDB 拡張** (公式仕様では `*` ワイルドカードなどを含むカンマ区切りの名前リストを使用) | `on` |
-| `georel` | string | ジオクエリ演算子 ([ジオクエリ](./endpoints.md#geo-queries)を参照) | - |
-| `geometry` | string | ジオメトリタイプ | - |
-| `coords` | string | 座標 (緯度,経度 形式、セミコロン区切り) | - |
-| `spatialId` | string | 空間 ID でフィルタ (ZFXY 形式) ([空間 ID 検索](./endpoints.md#spatial-id-search)を参照) | - |
-| `spatialIdDepth` | integer | 空間 ID 階層展開の深さ (0-4) | 0 |
-| `crs` | string | 座標参照系 ([座標参照系 (CRS)](./endpoints.md#coordinate-reference-system-crs)を参照) | `EPSG:4326` |
-| `options` | string | `keyValues`、`values`、`count`、`geojson`、`sysAttrs`、`unique` | - |
+| Parameter        | Type    | Description                                                                                                                                              | Default     |
+| ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `id`             | string  | Filter by entity ID (multiple values can be specified as a comma-separated list)                                                                         | -           |
+| `limit`          | integer | Number of results to retrieve (max: 1000)                                                                                                                | 20          |
+| `offset`         | integer | Offset (for pagination)                                                                                                                                  | 0           |
+| `orderBy`        | string  | Sort criteria (`entityId`, `entityType`, `modifiedAt`, or attribute name). FIWARE Orion-compatible `!` prefix for descending order (e.g. `!temperature`) | -           |
+| `orderDirection` | string  | Sort direction (`asc`, `desc`). **GeonicDB extension** (the official specification only supports the `!` prefix approach)                                | `asc`       |
+| `type`           | string  | Filter by entity type                                                                                                                                    | -           |
+| `typePattern`    | string  | Regular expression pattern for entity type                                                                                                               | -           |
+| `idPattern`      | string  | Regular expression pattern for entity ID                                                                                                                 | -           |
+| `q`              | string  | Filter by attribute value (see [Query Language](./endpoints.md#query-language))                                                                          | -           |
+| `mq`             | string  | Filter by metadata (see [Query Language](./endpoints.md#query-language))                                                                                 | -           |
+| `attrs`          | string  | Attribute names to retrieve (comma-separated)                                                                                                            | -           |
+| `metadata`       | string  | Metadata output control (`on`, `off`). **GeonicDB extension** (the official specification uses a comma-separated name list with `*` wildcards, etc.)     | `on`        |
+| `georel`         | string  | Geo-query operator (see [Geo-queries](./endpoints.md#geo-queries))                                                                                       | -           |
+| `geometry`       | string  | Geometry type                                                                                                                                            | -           |
+| `coords`         | string  | Coordinates (latitude,longitude format, semicolon-separated)                                                                                             | -           |
+| `spatialId`      | string  | Filter by spatial ID (ZFXY format) (see [Spatial ID Search](./endpoints.md#spatial-id-search))                                                           | -           |
+| `spatialIdDepth` | integer | Depth of spatial ID hierarchy expansion (0-4)                                                                                                            | 0           |
+| `crs`            | string  | Coordinate reference system (see [Coordinate Reference System (CRS)](./endpoints.md#coordinate-reference-system-crs))                                    | `EPSG:4326` |
+| `options`        | string  | `keyValues`, `values`, `count`, `geojson`, `sysAttrs`, `unique`                                                                                          | -           |
 
 **組み込み属性**
 
-`attrs` パラメータは、ユーザー定義属性に加えて、以下の組み込み属性をサポートします:
+`attrs` パラメータは、ユーザー定義属性に加えて、以下の組み込み属性をサポートしています:
 
-| 組み込み属性 | 型 | 説明 |
-|---|---|---|
-| `dateCreated` | DateTime | エンティティ作成タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateModified` | DateTime | 最終更新タイムスタンプ (`options=sysAttrs` でも利用可能) |
-| `dateExpires` | DateTime | 一時エンティティの有効期限タイムスタンプ |
-| `servicePath` | Text | エンティティが保存されているServicePath (作成時の `Fiware-ServicePath` ヘッダー値) |
+| Builtin Attribute | Type     | Description                                                                             |
+| ----------------- | -------- | --------------------------------------------------------------------------------------- |
+| `dateCreated`     | DateTime | Entity creation timestamp (also available via `options=sysAttrs`)                       |
+| `dateModified`    | DateTime | Last modification timestamp (also available via `options=sysAttrs`)                     |
+| `dateExpires`     | DateTime | Transient entity expiration timestamp                                                   |
+| `servicePath`     | Text     | Service path where the entity is stored (`Fiware-ServicePath` header value at creation) |
 
-例: `GET /v2/entities?attrs=temperature,servicePath`**レスポンス例**
+例: `GET /v2/entities?attrs=temperature,servicePath`
+
+**レスポンス例**
 
 ```json
 [
@@ -71,7 +75,7 @@ GET /v2/entities
 ]
 ```
 
-**keyValues 形式** (`options=keyValues`)
+**keyValues フォーマット** (`options=keyValues`)
 
 ```json
 [
@@ -86,11 +90,11 @@ GET /v2/entities
 
 **count オプション** (`options=count`)
 
-レスポンスに `Fiware-Total-Count` ヘッダーが追加されます。
+`Fiware-Total-Count` ヘッダーがレスポンスに追加されます。
 
 **geojson オプション** (`options=geojson` または `Accept: application/geo+json` ヘッダー)
 
-レスポンスを GeoJSON FeatureCollection として返します。
+GeoJSON FeatureCollection としてレスポンスを返します。
 
 ```bash
 # Specified via options parameter
@@ -129,9 +133,9 @@ POST /v2/entities
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `options` | string | `upsert`: エンティティが既に存在する場合は更新。`keyValues`: リクエストボディを keyValues 形式として解釈 |
+| Parameter | Type   | Description                                                                                                   |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| `options` | string | `upsert`: Update the entity if it already exists. `keyValues`: Interpret the request body in keyValues format |
 
 **リクエストボディ**
 
@@ -150,7 +154,7 @@ POST /v2/entities
 }
 ```
 
-**keyValues 形式入力** (`options=keyValues`)
+**keyValues 形式の入力** (`options=keyValues`)
 
 ```json
 {
@@ -166,9 +170,14 @@ POST /v2/entities
 エンティティが存在しない場合は作成され (`201 Created`)、既に存在する場合はその属性が更新されます (`204 No Content`)。
 
 **レスポンス**
-- ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
-- ステータス: `409 AlreadyExists` 同じ ID のエンティティが既に存在する場合 (タイプに関わらず)
-- ヘッダー: `Location: /v2/entities/Room1?type=Room`> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID はテナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することはできず、`409 AlreadyExists` が返されます。これは、同じ ID で異なるタイプのエンティティを許可する NGSIv2 仕様とは異なります。詳細は [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension)を参照してください。
+
+* ステータス: `201 Created` (新規作成)、`204 No Content` (upsert による更新)
+  
+* ステータス: `409 AlreadyExists` 同じ ID を持つエンティティが既に存在する場合 (タイプに関係なく)
+  
+* ヘッダー: `Location: /v2/entities/Room1?type=Room`
+
+> **GeonicDB 拡張 — エンティティ ID の一意性**: エンティティ ID は、テナントとServicePathのスコープ内で一意です。同じ ID で異なるタイプのエンティティを作成することは許可されず、`409 AlreadyExists` が返されます。これは、異なるタイプの同じ ID のエンティティを許可する NGSIv2 仕様とは異なります。詳細については、[エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照してください。
 
 ### 単一エンティティの取得
 
@@ -178,11 +187,11 @@ GET /v2/entities/{entityId}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ (オプションのフィルタ; エンティティ ID は一意であるため、タイプの曖昧さ解消は不要 — [エンティティ ID の一意性](./endpoints.md#entity-id-uniqueness-geonicdb-extension) を参照) |
-| `attrs` | string | 取得する属性名 (カンマ区切り) |
-| `options` | string | `keyValues`、`values` |
+| Parameter | Type   | Description                                                                                                                                                                          |
+| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`    | string | Entity type (optional filter; type disambiguation is no longer needed as entity IDs are unique — see [Entity ID Uniqueness](./endpoints.md#entity-id-uniqueness-geonicdb-extension)) |
+| `attrs`   | string | Attribute names to retrieve (comma-separated)                                                                                                                                        |
+| `options` | string | `keyValues`, `values`                                                                                                                                                                |
 
 ### エンティティの更新 (PATCH)
 
@@ -194,9 +203,9 @@ PATCH /v2/entities/{entityId}/attrs
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
 **リクエストボディ**
 
@@ -209,38 +218,44 @@ PATCH /v2/entities/{entityId}/attrs
 }
 ```
 
-**レスポンス**: `204 No Content`### エンティティの更新 (PUT)
+**レスポンス**: `204 No Content`
+
+### エンティティの更新 (PUT)
 
 ```http
 PUT /v2/entities/{entityId}/attrs
 ```
 
-すべての属性を置き換えます (指定されていない属性は削除されます)。
+すべての属性を置き換えます(指定されていない属性は削除されます)。
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
-**レスポンス**: `204 No Content`### 属性の追加 (POST)
+**レスポンス**: `204 No Content`
+
+### 属性の追加 (POST)
 
 ```http
 POST /v2/entities/{entityId}/attrs
 ```
 
-新しい属性を追加します (既存の属性は上書きされます)。
+新しい属性を追加します(既存の属性は上書きされます)。
 
-`options=append` が指定された場合、既存の属性は上書きされず、新しい属性のみが追加されます (厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
+`options=append` が指定されている場合、既存の属性は上書きされず、新しい属性のみが追加されます(厳密な追加モード)。既に存在する属性名が含まれている場合、`422 Unprocessable Entity` エラーが返されます。
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
-| `options` | string | `append`: 既存の属性の上書きを禁止 (厳密な追加モード) |
+| Parameter | Type   | Description                                                             |
+| --------- | ------ | ----------------------------------------------------------------------- |
+| `type`    | string | Entity type                                                             |
+| `options` | string | `append`: Prohibit overwriting existing attributes (strict append mode) |
 
-**レスポンス**: `204 No Content`### エンティティの削除
+**レスポンス**: `204 No Content`
+
+### エンティティの削除
 
 ```http
 DELETE /v2/entities/{entityId}
@@ -248,15 +263,19 @@ DELETE /v2/entities/{entityId}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
-**レスポンス**: `204 No Content`---
+**レスポンス**: `204 No Content`
 
-## 属性の操作### エンティティの属性を取得
+***
 
-エンティティのすべての属性を取得します (`id` および `type` フィールドは含まれません)。
+## 属性の操作
+
+### エンティティの属性を取得
+
+エンティティのすべての属性を取得します(`id` と `type` フィールドは含まれません)。
 
 ```http
 GET /v2/entities/{entityId}/attrs
@@ -264,12 +283,12 @@ GET /v2/entities/{entityId}/attrs
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `type` | string | エンティティタイプ | - |
-| `attrs` | string | 取得する属性名 (カンマ区切り) | - |
-| `metadata` | string | メタデータ出力制御 (`on`、`off`) | `on` |
-| `options` | string | `keyValues`、`values`、`sysAttrs` | - |
+| Parameter  | Type   | Description                                   | Default |
+| ---------- | ------ | --------------------------------------------- | ------- |
+| `type`     | string | Entity type                                   | -       |
+| `attrs`    | string | Attribute names to retrieve (comma-separated) | -       |
+| `metadata` | string | Metadata output control (`on`, `off`)         | `on`    |
+| `options`  | string | `keyValues`, `values`, `sysAttrs`             | -       |
 
 **レスポンス例**
 
@@ -297,7 +316,7 @@ GET /v2/entities/{entityId}/attrs
 }
 ```
 
-> **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` および `type` フィールドが含まれません。属性のみが必要な場合に使用してください。
+> **注意**: `/v2/entities/{entityId}?attrs=...` とは異なり、このエンドポイントには `id` と `type` フィールドは含まれません。属性のみが必要な場合にこれを使用してください。
 
 ### 単一属性の取得
 
@@ -307,9 +326,9 @@ GET /v2/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
 **レスポンス例**
 
@@ -329,9 +348,9 @@ PUT /v2/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
 **リクエストボディ**
 
@@ -342,7 +361,9 @@ PUT /v2/entities/{entityId}/attrs/{attrName}
 }
 ```
 
-**レスポンス**: `204 No Content`### 単一属性の削除
+**レスポンス**: `204 No Content`
+
+### 単一属性の削除
 
 ```http
 DELETE /v2/entities/{entityId}/attrs/{attrName}
@@ -350,36 +371,38 @@ DELETE /v2/entities/{entityId}/attrs/{attrName}
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
-**レスポンス**: `204 No Content`### 属性値を直接取得
+**レスポンス**: `204 No Content`
+
+### 属性値の直接取得
 
 ```http
 GET /v2/entities/{entityId}/attrs/{attrName}/value
 ```
 
-属性の値のみを取得します (型とメタデータは含まれません)。
+属性の値のみを取得します(type と metadata は含まれません)。
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
 **レスポンス**
 
 値の型に応じて異なる Content-Type で返されます:
 
-| 値の型 | Content-Type | 例 |
-|------------|--------------|---------|
-| 文字列 | `text/plain` | `hello world` |
-| 数値 | `text/plain` | `23.5` |
-| 真偽値 | `text/plain` | `true` |
-| null | `text/plain` | `null` |
-| オブジェクト | `application/json` | `{"lat": 35.68, "lon": 139.76}` |
-| 配列 | `application/json` | `[1, 2, 3]` |
+| Value type | Content-Type       | Example                         |
+| ---------- | ------------------ | ------------------------------- |
+| String     | `text/plain`       | `hello world`                   |
+| Number     | `text/plain`       | `23.5`                          |
+| Boolean    | `text/plain`       | `true`                          |
+| null       | `text/plain`       | `null`                          |
+| Object     | `application/json` | `{"lat": 35.68, "lon": 139.76}` |
+| Array      | `application/json` | `[1, 2, 3]`                     |
 
 **使用例**
 
@@ -394,7 +417,8 @@ curl "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -H "Fiware-Service: smartcity"
 # Response: {"type":"Point","coordinates":[139.76,35.68]} (Content-Type: application/json)
 ```
-### 属性値の直接更新
+
+### 属性値を直接更新
 
 ```http
 PUT /v2/entities/{entityId}/attrs/{attrName}/value
@@ -404,18 +428,18 @@ PUT /v2/entities/{entityId}/attrs/{attrName}/value
 
 **クエリパラメータ**
 
-| パラメータ | 型 | 説明 |
-|-----------|------|-------------|
-| `type` | string | エンティティタイプ |
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| `type`    | string | Entity type |
 
 **リクエスト**
 
 値の解釈は Content-Type によって異なります:
 
-| Content-Type | 解釈 |
-|--------------|----------------|
-| `application/json` | JSON としてパース |
-| `text/plain` | プリミティブ値 (`null`、`true`、`false`、数値) または文字列 |
+| Content-Type       | Interpretation                                              |
+| ------------------ | ----------------------------------------------------------- |
+| `application/json` | Parsed as JSON                                              |
+| `text/plain`       | Primitive value (`null`, `true`, `false`, number) or string |
 
 **使用例**
 
@@ -433,13 +457,15 @@ curl -X PUT "http://localhost:3000/v2/entities/Car1/attrs/location/value" \
   -d '{"type":"Point","coordinates":[140.0,36.0]}'
 ```
 
-**レスポンス**: `204 No Content`**注**: この操作では、既存の属性の型やメタデータは変更されず、保持されます。
+**レスポンス**: `204 No Content`
 
----
+**注意**: この操作は既存の属性の型やメタデータを変更しません — それらは保持されます。
+
+***
 
 ## バッチ操作
 
-> **注**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます (デフォルト: 100、SAM パラメータ `MaxBatchSize` で最大 10,000 まで設定可能)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
+> **注意**: バッチ操作は 1 回のリクエストで最大 **`MAX_BATCH_SIZE`** 個のエンティティを処理できます(デフォルト: 100)。この制限を超えるリクエストは `400 Bad Request` エラーになります。
 
 ### バッチ更新
 
@@ -469,16 +495,19 @@ POST /v2/op/update
 
 **actionType の種類**
 
-| アクション | 説明 |
-|--------|-------------|
-| `append` | 既存エンティティの属性を追加/更新 |
-| `appendStrict` | 既存エンティティに新しい属性を追加 (既存属性が存在する場合はエラーを返す) |
-| `update` | 既存の属性のみを更新 (エンティティが存在しない場合はエラー) |
-| `replace` | すべての属性を置換 |
-| `delete` | エンティティまたは属性を削除 |
+| Action         | Description                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| `append`       | Add/update attributes of existing entities                                                    |
+| `appendStrict` | Add new attributes to existing entities (returns an error if existing attributes are present) |
+| `update`       | Update only existing attributes (error if entity does not exist)                              |
+| `replace`      | Replace all attributes                                                                        |
+| `delete`       | Delete entities or attributes                                                                 |
 
 **レスポンス**
-- すべて成功: `204 No Content`- 部分的成功/エラー: `200 OK` とエラー詳細
+
+* すべて成功: `204 No Content`
+  
+* 部分的な成功/エラー: `200 OK` とエラー詳細
 
 ```json
 {
@@ -522,13 +551,13 @@ POST /v2/op/query
 
 **レスポンス**: エンティティの配列
 
-### 通知の受信
+### 通知を受信
 
 ```http
 POST /v2/op/notify
 ```
 
-外部 Context Broker からの通知を受信し、append でエンティティを処理します (存在しない場合は作成、既に存在する場合は更新)。
+外部 Context Broker からの通知を受信し、append でエンティティを処理します(存在しない場合は作成、既に存在する場合は更新)。
 
 **リクエストボディ**
 
@@ -545,12 +574,18 @@ POST /v2/op/notify
 }
 ```
 
-- `subscriptionId`: 必須 - 通知をトリガーしたサブスクリプション ID
-- `data`: 必須 - NGSIv2 正規化形式のエンティティの配列
 
-**レスポンス**: `200 OK`---
+* `subscriptionId`: 必須 - 通知をトリガーしたサブスクリプション ID
+  
+* `data`: 必須 - NGSIv2 正規化形式のエンティティの配列
 
-## サブスクリプション### サブスクリプションの作成
+**レスポンス**: `200 OK`
+
+***
+
+## サブスクリプション
+
+### サブスクリプションの作成
 
 ```http
 POST /v2/subscriptions
@@ -609,25 +644,25 @@ POST /v2/subscriptions
 
 **httpCustom フィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `url` | string | ✓ | 通知送信先 URL |
-| `method` | string | - | HTTP メソッド(GET、POST、PUT、PATCH、DELETE)。デフォルト: POST |
-| `headers` | object | - | カスタム HTTP ヘッダー |
-| `qs` | object | - | クエリ文字列パラメータ(`${...}` マクロ置換をサポート) |
-| `payload` | string | - | リクエストボディテンプレート(`${...}` マクロ置換をサポート) |
+| Field     | Type   | Required | Description                                                    |
+| --------- | ------ | -------- | -------------------------------------------------------------- |
+| `url`     | string | ✓        | Notification destination URL                                   |
+| `method`  | string | -        | HTTP method (GET, POST, PUT, PATCH, DELETE). Default: POST     |
+| `headers` | object | -        | Custom HTTP headers                                            |
+| `qs`      | object | -        | Query string parameters (supports `${...}` macro substitution) |
+| `payload` | string | -        | Request body template (supports `${...}` macro substitution)   |
 
 **マクロ置換**
 
-`${...}` 構文を使用して `payload` および `qs` の値にエンティティデータを埋め込むことができます:
+`payload` と `qs` の値に `${...}` 構文を使用して、エンティティデータを埋め込むことができます:
 
-| マクロ | 置換値 |
-|-------|-------------------|
-| `${id}` | エンティティ ID |
-| `${type}` | エンティティタイプ |
-| `${attrName}` | 属性値(正規化された属性から `.value` を抽出) |
+| Macro         | Replacement value                                             |
+| ------------- | ------------------------------------------------------------- |
+| `${id}`       | Entity ID                                                     |
+| `${type}`     | Entity type                                                   |
+| `${attrName}` | Attribute value (extracts `.value` from normalized attribute) |
 
-存在しない属性は文字列 `null` に置き換えられます。マクロは attrs/exceptAttrs フィルターが適用される前の完全なエンティティに対して評価されます。
+存在しない属性は文字列 `null` に置き換えられます。マクロは attrs/exceptAttrs フィルタが適用される前の完全なエンティティに対して評価されます。
 
 **MQTT 通知の例**
 
@@ -658,14 +693,14 @@ POST /v2/subscriptions
 
 **MQTT 通知設定**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `url` | string | ✓ | MQTT ブローカー URL (`mqtt://` または `mqtts://`) |
-| `topic` | string | ✓ | 通知送信先トピック |
-| `qos` | integer | - | QoS レベル(0、1、2)。デフォルト: 0 |
-| `retain` | boolean | - | メッセージ保持フラグ。デフォルト: false |
-| `user` | string | - | 認証ユーザー名 |
-| `passwd` | string | - | 認証パスワード |
+| Field    | Type    | Required | Description                               |
+| -------- | ------- | -------- | ----------------------------------------- |
+| `url`    | string  | ✓        | MQTT broker URL (`mqtt://` or `mqtts://`) |
+| `topic`  | string  | ✓        | Notification destination topic            |
+| `qos`    | integer | -        | QoS level (0, 1, 2). Default: 0           |
+| `retain` | boolean | -        | Message retain flag. Default: false       |
+| `user`   | string  | -        | Authentication username                   |
+| `passwd` | string  | -        | Authentication password                   |
 
 **リクエストボディ**
 
@@ -697,21 +732,26 @@ POST /v2/subscriptions
 
 **attrsFormat タイプ**
 
-| フォーマット | 説明 |
-|--------|-------------|
-| `normalized` | 標準 NGSIv2 フォーマット(デフォルト) |
-| `keyValues` | 簡略化されたキーバリューフォーマット |
+| Format       | Description                      |
+| ------------ | -------------------------------- |
+| `normalized` | Standard NGSIv2 format (default) |
+| `keyValues`  | Simplified key-value format      |
 
-**通知属性のフィルタリング**
+**通知属性フィルタリング**
 
-| フィールド | タイプ | 説明 |
-|-------|------|-------------|
-| `attrs` | string[] | 通知に含める属性名のリスト |
-| `exceptAttrs` | string[] | 通知から除外する属性名のリスト |
-| `onlyChangedAttrs` | boolean | `true` の場合、実際に変更された属性のみが通知に含まれます。`attrs`/`exceptAttrs` と組み合わせることができます。 |
+| Field              | Type      | Description                                                                                                                    |
+| ------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `attrs`            | string\[] | List of attribute names to include in notifications                                                                            |
+| `exceptAttrs`      | string\[] | List of attribute names to exclude from notifications                                                                          |
+| `onlyChangedAttrs` | boolean   | If `true`, only attributes that actually changed are included in notifications. It can be combined with `attrs`/`exceptAttrs`. |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /v2/subscriptions/{subscriptionId}`### サブスクリプションの一覧取得
+
+* ステータス: `201 Created`
+  
+* ヘッダー: `Location: /v2/subscriptions/{subscriptionId}`
+
+### サブスクリプションの一覧取得
 
 ```http
 GET /v2/subscriptions
@@ -719,11 +759,11 @@ GET /v2/subscriptions
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
-| `status` | string | ステータスでフィルタリング(`active`、`inactive`) | - |
+| Parameter | Type    | Description                             | Default |
+| --------- | ------- | --------------------------------------- | ------- |
+| `limit`   | integer | Number of results to retrieve           | 20      |
+| `offset`  | integer | Offset                                  | 0       |
+| `status`  | string  | Filter by status (`active`, `inactive`) | -       |
 
 ### サブスクリプションの取得
 
@@ -746,23 +786,26 @@ PATCH /v2/subscriptions/{subscriptionId}
 ```
 
 **レスポンス**: `204 No Content`
+
 ### サブスクリプションの削除
 
 ```http
 DELETE /v2/subscriptions/{subscriptionId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権の検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`
 
-認証が有効になっている場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権の検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細については AUTH.md を参照してください。
+### 所有権検証 (GeonicDB 拡張)
 
----
+認証が有効な場合 (`AUTH_ENABLED=true`)、サブスクリプションの更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細は [AUTH.md](../reference/auth.md) を参照してください。
 
-## 登録
+***
 
-登録は外部コンテキストプロバイダを登録し、エンティティ情報のソースを管理します。
+## レジストレーション
 
-### 登録の作成
+レジストレーションは外部コンテキストプロバイダーを登録し、エンティティ情報のソースを管理します。
+
+### レジストレーションの作成
 
 ```http
 POST /v2/registrations
@@ -791,18 +834,23 @@ POST /v2/registrations
 
 **リクエストフィールド**
 
-| フィールド | タイプ | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `description` | string | - | 登録の説明 |
-| `dataProvided.entities` | array | ✓ | 対象エンティティ (id、idPattern、type) |
-| `dataProvided.attrs` | array | - | 提供する属性名 |
-| `provider.http.url` | string | ✓ | プロバイダ URL |
-| `expires` | string | - | 有効期限 (ISO 8601 形式) |
-| `status` | string | - | ステータス (`active` / `inactive`)。デフォルト: `active` |
-| `mode` | string | - | 転送モード (`inclusive` / `exclusive` / `redirect` / `auxiliary`)。NGSI-LD 互換拡張 |
+| Field                   | Type   | Required | Description                                                                                          |
+| ----------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------- |
+| `description`           | string | -        | Description of the registration                                                                      |
+| `dataProvided.entities` | array  | ✓        | Target entities (id, idPattern, type)                                                                |
+| `dataProvided.attrs`    | array  | -        | Attribute names to provide                                                                           |
+| `provider.http.url`     | string | ✓        | Provider URL                                                                                         |
+| `expires`               | string | -        | Expiration date (ISO 8601 format)                                                                    |
+| `status`                | string | -        | Status (`active` / `inactive`). Default: `active`                                                    |
+| `mode`                  | string | -        | Forwarding mode (`inclusive` / `exclusive` / `redirect` / `auxiliary`). NGSI-LD compatible extension |
 
 **レスポンス**
-- ステータス: `201 Created`- ヘッダー: `Location: /v2/registrations/{registrationId}`### 登録の一覧取得
+
+* ステータス: `201 Created`
+  
+* ヘッダー: `Location: /v2/registrations/{registrationId}`
+
+### レジストレーション一覧
 
 ```http
 GET /v2/registrations
@@ -810,10 +858,10 @@ GET /v2/registrations
 
 **クエリパラメータ**
 
-| パラメータ | タイプ | 説明 | デフォルト |
-|-----------|------|-------------|---------|
-| `limit` | integer | 取得する結果の数 | 20 |
-| `offset` | integer | オフセット | 0 |
+| Parameter | Type    | Description                   | Default |
+| --------- | ------- | ----------------------------- | ------- |
+| `limit`   | integer | Number of results to retrieve | 20      |
+| `offset`  | integer | Offset                        | 0       |
 
 **レスポンス例**
 
@@ -854,25 +902,29 @@ PATCH /v2/registrations/{registrationId}
 }
 ```
 
-**レスポンス**: `204 No Content`### 登録の削除
+**レスポンス**: `204 No Content`
+
+### 登録の削除
 
 ```http
 DELETE /v2/registrations/{registrationId}
 ```
 
-**レスポンス**: `204 No Content`### 所有権検証 (GeonicDB 拡張)
+**レスポンス**: `204 No Content`
 
-認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) と削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` と `tenant_admin` ロールはこの検証をバイパスできます。詳細は AUTH.md を参照してください。
+### 所有権検証 (GeonicDB 拡張)
 
----
+認証が有効な場合 (`AUTH_ENABLED=true`)、登録の更新 (PATCH) および削除 (DELETE) 操作は `createdBy` フィールドに基づいて所有権検証を実行します。作成者以外のユーザーがこれらの操作を試みた場合、`403 Forbidden` が返されます。`super_admin` および `tenant_admin` ロールはこの検証をバイパスできます。詳細は [AUTH.md](../reference/auth.md) を参照してください。
 
-## フェデレーション (クエリ転送 / 更新転送)
+***
 
-登録情報に基づいて、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合して返します。また、更新も転送します。
+## フェデレーション(クエリ転送 / 更新転送)
+
+登録(Registrations)に基づいて、GeonicDB は外部コンテキストプロバイダーにクエリを転送し、結果を統合し、更新を転送します。
 
 ### フェデレーションの仕組み
 
-エンティティをクエリする際、一致する登録情報が存在する場合、そのプロバイダーにも並行してクエリが送信され、結果がマージされて返されます。
+エンティティをクエリする際、一致する登録が存在する場合、そのプロバイダーにも並列でクエリが送信され、結果がマージされて返されます。
 
 ```text
 Client → Context Broker
@@ -886,16 +938,17 @@ Client → Context Broker
 
 ### 登録モード
 
-| モード | 動作 |
-|------|----------|
-| `inclusive` | ローカルとリモートの両方の結果を返します (デフォルト) |
-| `exclusive` | リモートの結果のみを返します (ローカルデータは無視されます) |
-| `redirect` | 303 リダイレクト URL を返します |
-| `auxiliary` | ローカルデータが優先され、リモートは不足データを補完します |
+| Mode        | Behavior                                                |
+| ----------- | ------------------------------------------------------- |
+| `inclusive` | Returns both local and remote results (default)         |
+| `exclusive` | Returns only remote results (local data is ignored)     |
+| `redirect`  | Returns a 303 redirect URL                              |
+| `auxiliary` | Local data takes priority; remote fills in missing data |
 
 ### フェデレーションの例
 
-1. 外部プロバイダーを登録します:
+
+1. 外部プロバイダーを登録:
 
 ```bash
 curl -X POST "http://localhost:3000/v2/registrations" \
@@ -913,7 +966,7 @@ curl -X POST "http://localhost:3000/v2/registrations" \
   }'
 ```
 
-2. クエリ時にフェデレーションが自動的に行われます:
+2\. クエリ時にフェデレーションが自動的に発生:
 
 ```bash
 curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
@@ -924,36 +977,36 @@ curl "http://localhost:3000/v2/entities?type=WeatherObserved" \
 
 ### 更新転送
 
-エンティティを更新または削除する際、一致する登録情報が存在する場合、更新もそのプロバイダーに並行して転送されます。
+エンティティを更新または削除する際、一致する登録が存在する場合、更新もそのプロバイダーに並列で転送されます。
 
-**サポートされる更新操作**
+**サポートされている更新操作**
 
-| 操作 | 説明 |
-|-----------|-------------|
-| エンティティ属性の更新 | `PATCH /v2/entities/{id}/attrs` |
-| エンティティ属性の追加 | `POST /v2/entities/{id}/attrs` |
-| エンティティ属性の置換 | `PUT /v2/entities/{id}/attrs` |
-| エンティティの削除 | `DELETE /v2/entities/{id}` |
-| 属性の削除 | `DELETE /v2/entities/{id}/attrs/{attr}` |
+| Operation                 | Description                             |
+| ------------------------- | --------------------------------------- |
+| Update entity attributes  | `PATCH /v2/entities/{id}/attrs`         |
+| Add entity attributes     | `POST /v2/entities/{id}/attrs`          |
+| Replace entity attributes | `PUT /v2/entities/{id}/attrs`           |
+| Delete entity             | `DELETE /v2/entities/{id}`              |
+| Delete attribute          | `DELETE /v2/entities/{id}/attrs/{attr}` |
 
 **モード別の更新動作**
 
-| モード | 動作 |
-|------|----------|
-| `inclusive` | ローカルとリモートの両方を更新します |
-| `exclusive` | リモートのみを更新します (ローカルは更新されません) |
-| `redirect` | 303 リダイレクト URL を返します (ローカルは更新されません) |
-| `auxiliary` | ローカルのみを更新します (リモートは読み取り専用) |
+| Mode        | Behavior                                          |
+| ----------- | ------------------------------------------------- |
+| `inclusive` | Updates both local and remote                     |
+| `exclusive` | Updates only remote (local is not updated)        |
+| `redirect`  | Returns a 303 redirect URL (local is not updated) |
+| `auxiliary` | Updates only local (remote is read-only)          |
 
 ### エラー処理
 
-| シナリオ | 動作 |
-|----------|----------|
-| プロバイダー接続失敗 | 警告をログに記録し、ローカル結果のみを返します |
-| プロバイダータイムアウト | 警告をログに記録し、ローカル結果のみを返します |
-| 排他モードですべてのプロバイダーが失敗 | 502 エラーを返します (オプション) |
+| Scenario                             | Behavior                                      |
+| ------------------------------------ | --------------------------------------------- |
+| Provider connection failure          | Logs a warning and returns only local results |
+| Provider timeout                     | Logs a warning and returns only local results |
+| All providers fail in exclusive mode | Returns a 502 error (optional)                |
 
----
+***
 
 ## エンティティタイプ
 
@@ -965,10 +1018,10 @@ GET /v2/types
 
 **クエリパラメータ**
 
-| パラメータ | 説明 |
-|-----------|-------------|
-| `options=count` | エンティティ数を含めます |
-| `options=values` | 属性の詳細を含めます |
+| Parameter        | Description               |
+| ---------------- | ------------------------- |
+| `options=count`  | Include entity count      |
+| `options=values` | Include attribute details |
 
 **レスポンス例**
 
@@ -985,7 +1038,7 @@ GET /v2/types
 ]
 ```
 
-### 特定タイプの取得
+### 特定のタイプを取得
 
 ```http
 GET /v2/types/{typeName}
@@ -1004,62 +1057,62 @@ GET /v2/types/{typeName}
 }
 ```
 
----
+***
 
-## HTTP キャッシュコントロール
+## HTTP キャッシュ制御
 
-GET エンドポイントは、エンドポイントのクラスごとにキャッシュ関連のヘッダーを返します:
+GET エンドポイントは、エンドポイントクラスごとにキャッシュ関連のヘッダーを返します:
 
-### データエンドポイント (エンティティ、サブスクリプション、登録) — 完全な RFC 7232 + RFC 7234 サポート
+### データエンドポイント(エンティティ、サブスクリプション、レジストレーション) — 完全な RFC 7232 + RFC 7234 サポート
 
-| ヘッダー | 値 | 目的 |
-|--------|-------|---------|
-| `ETag` | `W/"..."` | 弱いバリデーター。生成シードには `path + Accept + Fiware-Service + Fiware-ServicePath` が含まれるため、異なるエンドポイント / Accept / テナント / ServicePathは常に異なる ETag を生成します。リスト: `id + modifiedAt` のストリーミングダイジェストと総数およびスコープを混合。単一: `modifiedAt` のハッシュとスコープを混合。 |
-| `Last-Modified` | RFC 1123 HTTP-date | 結果セット内の最新の `modifiedAt` のタイムスタンプ。 |
-| `Cache-Control` | `private, no-cache` | `private` は共有 / 中間キャッシュストレージをブロック; `no-cache` はプライベートキャッシュからの再検証を強制。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | 共有キャッシュ向けのテナント + 認証 + コンテンツネゴシエーション分離。 |
+| Header          | Value                                                                  | Purpose                                                                                                                                                                                                                                                                                                              |
+| --------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ETag`          | `W/"..."`                                                              | Weak validator. Generation seeds include `path + Accept + Fiware-Service + Fiware-ServicePath` so distinct endpoints / Accept / tenants / service paths always produce distinct ETags. Lists: streaming digest of `id + modifiedAt` mixed with total count and scope. Single: hash of `modifiedAt` mixed with scope. |
+| `Last-Modified` | RFC 1123 HTTP-date                                                     | Timestamp of the latest `modifiedAt` in the result set.                                                                                                                                                                                                                                                              |
+| `Cache-Control` | `private, no-cache`                                                    | `private` blocks shared / intermediate cache storage; `no-cache` forces revalidation from the private cache.                                                                                                                                                                                                         |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | Tenant + auth + content-negotiation isolation for shared caches.                                                                                                                                                                                                                                                     |
 
 条件付きリクエストがサポートされています:
 
-| リクエストヘッダー | 動作 |
-|----------------|----------|
-| `If-None-Match: <ETag>` | 一致した場合、`304 Not Modified` (空のボディ) を返します。 |
-| `If-Modified-Since: <HTTP-date>` | リソースが変更されていない場合、`304` を返します。 |
-| `Cache-Control: no-store` | サーバーはレスポンスの `Cache-Control` を `no-store` にオーバーライドします。 |
+| Request Header                   | Behavior                                                 |
+| -------------------------------- | -------------------------------------------------------- |
+| `If-None-Match: <ETag>`          | Returns `304 Not Modified` (empty body) if matched.      |
+| `If-Modified-Since: <HTTP-date>` | Returns `304` if the resource is unchanged.              |
+| `Cache-Control: no-store`        | Server overrides response `Cache-Control` to `no-store`. |
 
-### メタエンドポイント (タイプ) — Cache-Control + Vary のみ (ETag なし / 304 なし)
+### メタエンドポイント(タイプ) — Cache-Control + Vary のみ(ETag なし / 304 なし)
 
-| ヘッダー | 値 | 目的 |
-|--------|-------|---------|
-| `Cache-Control` | `max-age=60, stale-while-revalidate=120` | バックグラウンド再検証を伴う短期キャッシング。 |
-| `Vary` | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | データエンドポイントと同じテナント / 認証分離。 |
+| Header          | Value                                                                  | Purpose                                          |
+| --------------- | ---------------------------------------------------------------------- | ------------------------------------------------ |
+| `Cache-Control` | `max-age=60, stale-while-revalidate=120`                               | Short-term caching with background revalidation. |
+| `Vary`          | `Fiware-Service, Fiware-ServicePath, Authorization, X-Api-Key, Accept` | Same tenant/auth isolation as data endpoints.    |
 
-メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしていません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
+メタエンドポイントは `ETag` / `Last-Modified` を返さず、`If-None-Match` / `If-Modified-Since` 条件付きリクエストをサポートしません。クライアントは代わりに `max-age` / `stale-while-revalidate` ディレクティブに依存する必要があります。
 
 完全なセマンティクスについては [API.md §HTTP Cache Control](./endpoints.md#http-cache-control-etag--conditional-requests) を参照してください。
 
----
+***
 
 ## HTTP エラーレスポンス
 
-| ステータスコード | エラーコード | 説明 |
-|-------------|------------|-------------|
-| 400 | BadRequest | 無効なリクエストパラメータまたはボディ |
-| 400 | InvalidModification | 無効な属性変更 (例: id や type の変更) |
-| 401 | Unauthorized | 認証が必要、またはトークンが無効 |
-| 403 | Forbidden | 権限不足 |
-| 404 | NotFound | エンティティ、サブスクリプションなどが見つかりません |
-| 405 | MethodNotAllowed | HTTP メソッドが許可されていません |
-| 409 | AlreadyExists | エンティティが既に存在します (POST 作成時) |
-| 409 | TooManyResults | 複数のエンティティが一致しました (type が指定されていない場合) |
-| 411 | ContentLengthRequired | Content-Length ヘッダーが必要です |
-| 413 | RequestEntityTooLarge | リクエストボディが大きすぎます |
-| 415 | UnsupportedMediaType | サポートされていない Content-Type |
-| 422 | Unprocessable | エンティティフォーマットが無効です |
-| 429 | TooManyRequests | レート制限を超過しました |
-| 500 | InternalError | 内部サーバーエラー |
+| Status Code | Error Code            | Description                                                |
+| ----------- | --------------------- | ---------------------------------------------------------- |
+| 400         | BadRequest            | Invalid request parameters or body                         |
+| 400         | InvalidModification   | Invalid attribute modification (e.g., changing id or type) |
+| 401         | Unauthorized          | Authentication required or token is invalid                |
+| 403         | Forbidden             | Insufficient permissions                                   |
+| 404         | NotFound              | Entity, subscription, etc. not found                       |
+| 405         | MethodNotAllowed      | HTTP method not allowed                                    |
+| 409         | AlreadyExists         | Entity already exists (during POST creation)               |
+| 409         | TooManyResults        | Multiple entities matched (when type is not specified)     |
+| 411         | ContentLengthRequired | Content-Length header is required                          |
+| 413         | RequestEntityTooLarge | Request body is too large                                  |
+| 415         | UnsupportedMediaType  | Unsupported Content-Type                                   |
+| 422         | Unprocessable         | Entity format is invalid                                   |
+| 429         | TooManyRequests       | Rate limit exceeded                                        |
+| 500         | InternalError         | Internal server error                                      |
 
-**エラーレスポンスフォーマット**
+**エラーレスポンス形式**
 
 ```json
 {
@@ -1068,69 +1121,74 @@ GET エンドポイントは、エンドポイントのクラスごとにキャ�
 }
 ```
 
----
+***
 
 ## エンドポイントリファレンス
 
-FIWARE NGSIv2 互換の Context Broker API です。
+FIWARE NGSIv2 互換 Context Broker API。
 
 ### 共通仕様
 
-- **Content-Type**: `application/json`- **認証**: `AUTH_ENABLED=true` の場合は必須
-- **テナント分離**: `Fiware-Service` ヘッダーによるテナント分離
-- **ページネーション**: `limit`/`offset` パラメータを使用。総数を取得するには `options=count` を使用
+
+* **Content-Type**: `application/json`
+  
+* **Authentication**: `AUTH_ENABLED=true` の場合は必須
+  
+* **Tenant isolation**: `Fiware-Service` ヘッダーによるテナント分離
+  
+* **Pagination**: `limit`/`offset` パラメータ; 合計カウントを取得するには `options=count` を使用
 
 ### エンティティ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/entities` | GET | エンティティ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/entities` | POST | エンティティの作成 | 201 | 400, 401, 409, 415 | - |
-| `/v2/entities/{entityId}` | GET | エンティティの取得 | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}` | DELETE | エンティティの削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | GET | 属性のみを取得 (id/type フィールドなし) | 200 | 400, 401, 404 | - |
-| `/v2/entities/{entityId}/attrs` | PATCH | 属性の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | POST | 属性の追加 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs` | PUT | 属性の置換 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | GET | 属性の取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | PUT | 属性の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}` | DELETE | 属性の削除 | 204 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET | 属性値の取得 | 200 | 401, 404 | - |
-| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT | 属性値の更新 | 204 | 400, 401, 404, 415 | - |
+| Endpoint                                         | Method | Description                             | Success | Error              | Pagination    |
+| ------------------------------------------------ | ------ | --------------------------------------- | ------- | ------------------ | ------------- |
+| `/v2/entities`                                   | GET    | List entities                           | 200     | 400, 401           | ✅ (max: 1000) |
+| `/v2/entities`                                   | POST   | Create entity                           | 201     | 400, 401, 409, 415 | -             |
+| `/v2/entities/{entityId}`                        | GET    | Get entity                              | 200     | 400, 401, 404      | -             |
+| `/v2/entities/{entityId}`                        | DELETE | Delete entity                           | 204     | 401, 404           | -             |
+| `/v2/entities/{entityId}/attrs`                  | GET    | Get attributes only (no id/type fields) | 200     | 400, 401, 404      | -             |
+| `/v2/entities/{entityId}/attrs`                  | PATCH  | Update attributes                       | 204     | 400, 401, 404, 415 | -             |
+| `/v2/entities/{entityId}/attrs`                  | POST   | Add attributes                          | 204     | 400, 401, 404, 415 | -             |
+| `/v2/entities/{entityId}/attrs`                  | PUT    | Replace attributes                      | 204     | 400, 401, 404, 415 | -             |
+| `/v2/entities/{entityId}/attrs/{attrName}`       | GET    | Get attribute                           | 200     | 401, 404           | -             |
+| `/v2/entities/{entityId}/attrs/{attrName}`       | PUT    | Update attribute                        | 204     | 400, 401, 404, 415 | -             |
+| `/v2/entities/{entityId}/attrs/{attrName}`       | DELETE | Delete attribute                        | 204     | 401, 404           | -             |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | GET    | Get attribute value                     | 200     | 401, 404           | -             |
+| `/v2/entities/{entityId}/attrs/{attrName}/value` | PUT    | Update attribute value                  | 204     | 400, 401, 404, 415 | -             |
 
 ### タイプ操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/types` | GET | タイプ一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/types/{typeName}` | GET | タイプ詳細の取得 | 200 | 401, 404 | - |
+| Endpoint               | Method | Description      | Success | Error    | Pagination    |
+| ---------------------- | ------ | ---------------- | ------- | -------- | ------------- |
+| `/v2/types`            | GET    | List types       | 200     | 400, 401 | ✅ (max: 1000) |
+| `/v2/types/{typeName}` | GET    | Get type details | 200     | 401, 404 | -             |
 
 ### サブスクリプション操作
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/subscriptions` | GET | サブスクリプション一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/subscriptions` | POST | サブスクリプションの作成 | 201 | 400, 401, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | GET | サブスクリプションの取得 | 200 | 401, 404 | - |
-| `/v2/subscriptions/{subscriptionId}` | PATCH | サブスクリプションの更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/subscriptions/{subscriptionId}` | DELETE | サブスクリプションの削除 | 204 | 401, 404 | - |
+| Endpoint                             | Method | Description         | Success | Error              | Pagination    |
+| ------------------------------------ | ------ | ------------------- | ------- | ------------------ | ------------- |
+| `/v2/subscriptions`                  | GET    | List subscriptions  | 200     | 400, 401           | ✅ (max: 1000) |
+| `/v2/subscriptions`                  | POST   | Create subscription | 201     | 400, 401, 415      | -             |
+| `/v2/subscriptions/{subscriptionId}` | GET    | Get subscription    | 200     | 401, 404           | -             |
+| `/v2/subscriptions/{subscriptionId}` | PATCH  | Update subscription | 204     | 400, 401, 404, 415 | -             |
+| `/v2/subscriptions/{subscriptionId}` | DELETE | Delete subscription | 204     | 401, 404           | -             |
 
-### 登録操作(フェデレーション)
+### レジストレーション操作 (フェデレーション)
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/registrations` | GET | 登録一覧の取得 | 200 | 400, 401 | ✅ (最大: 1000) |
-| `/v2/registrations` | POST | 登録の作成 | 201 | 400, 401, 415 | - |
-| `/v2/registrations/{registrationId}` | GET | 登録の取得 | 200 | 401, 404 | - |
-| `/v2/registrations/{registrationId}` | PATCH | 登録の更新 | 204 | 400, 401, 404, 415 | - |
-| `/v2/registrations/{registrationId}` | DELETE | 登録の削除 | 204 | 401, 404 | - |
+| Endpoint                             | Method | Description         | Success | Error              | Pagination    |
+| ------------------------------------ | ------ | ------------------- | ------- | ------------------ | ------------- |
+| `/v2/registrations`                  | GET    | List registrations  | 200     | 400, 401           | ✅ (max: 1000) |
+| `/v2/registrations`                  | POST   | Create registration | 201     | 400, 401, 415      | -             |
+| `/v2/registrations/{registrationId}` | GET    | Get registration    | 200     | 401, 404           | -             |
+| `/v2/registrations/{registrationId}` | PATCH  | Update registration | 204     | 400, 401, 404, 415 | -             |
+| `/v2/registrations/{registrationId}` | DELETE | Delete registration | 204     | 401, 404           | -             |
 
 ### バッチ操作
 
-> **注意**: バッチ操作(クエリを除く)は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています(デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
+> **Note**: バッチ操作 (クエリを除く) は、1 リクエストあたり **`MAX_BATCH_SIZE`** エンティティに制限されています (デフォルト: 100)。この制限を超えると `400 Bad Request` が返されます。
 
-| エンドポイント | メソッド | 説明 | 成功 | エラー | ページネーション |
-|----------|--------|-------------|---------|-------|------------|
-| `/v2/op/update` | POST | バッチ更新(最大: `MAX_BATCH_SIZE`) | 204 | 400, 401, 415 | - |
-| `/v2/op/query` | POST | バッチクエリ | 200 | 400, 401, 415 | ✅ (最大: 1000) |
-| `/v2/op/notify` | POST | 通知の受信 | 200 | 400, 401, 415 | - |
+| Endpoint        | Method | Description                          | Success | Error         | Pagination    |
+| --------------- | ------ | ------------------------------------ | ------- | ------------- | ------------- |
+| `/v2/op/update` | POST   | Batch update (max: `MAX_BATCH_SIZE`) | 204     | 400, 401, 415 | -             |
+| `/v2/op/query`  | POST   | Batch query                          | 200     | 400, 401, 415 | ✅ (max: 1000) |
+| `/v2/op/notify` | POST   | Receive notification                 | 200     | 400, 401, 415 | -             |

--- a/docs/ja/changelog/0.3.x.md
+++ b/docs/ja/changelog/0.3.x.md
@@ -163,7 +163,7 @@ outline: deep
   - `permissions` 未指定時は既存動作と同一（デフォルト Deny）
 - **Feature**: XACML resource 属性に `servicePath` を追加 (#750)
   - `Fiware-ServicePath` ヘッダーの値をポリシー評価に使用可能に
-  - glob パターン（例: `/opendata/**`）でサービスパス階層のアクセス制御が可能
+  - glob パターン（例: `/opendata/**`）でServicePath階層のアクセス制御が可能
   - 正規表現マッチ（`string-regexp`）にも対応
 - **Feature**: XACML 認可一元化 — 5層の認可ロジックを統合 (#748)
   - ロールごとのデフォルトフォールバックポリシーを追加: user (readonly), api_key (全Deny), anonymous (全Deny)

--- a/docs/ja/changelog/unreleased.md
+++ b/docs/ja/changelog/unreleased.md
@@ -3,4 +3,12 @@ title: "Unreleased"
 description: "GeonicDB Unreleased changelog"
 outline: deep
 ---
-## [Unreleased]
+## \[未リリース]
+
+### 2026-05-08
+
+*変更履歴エントリーは日本語で文書化されています。英語翻訳は今後のアップデートで追加される予定です。*
+
+[unreleased]: https://github.com/geolonia/geonicdb/compare/v0.1.0...HEAD
+
+[0.1.0]: https://github.com/geolonia/geonicdb/releases/tag/v0.1.0

--- a/docs/ja/faq.md
+++ b/docs/ja/faq.md
@@ -5,125 +5,131 @@ outline: deep
 ---
 # よくある質問 (FAQ)
 
-GeonicDB に関するよくある質問と回答のコレクションです。
+GeonicDB についてよくある質問と回答の集まりです。
 
 ## 目次
 
-- [データ量とパフォーマンス](#データ量とパフォーマンス)
-- [FIWARE Orion との違い](#fiware-orion-との違い)
-- [デプロイメントと運用](#デプロイと運用)
-- [API の使い方](#api-の使い方)
-- [地理空間拡張](#地理空間拡張)
-- [セキュリティ](#セキュリティ)
 
----
+* [データ量とパフォーマンス](#データ量とパフォーマンス)
+  
+* [FIWARE Orion との違い](#fiware-orion-との違い)
+  
+* [デプロイと運用](#デプロイと運用)
+  
+* [API の使い方](#api-の使い方)
+  
+* [地理空間拡張](#geospatial-extensions)
+  
+* [セキュリティ](#セキュリティ)
+
+***
 
 ## データ量とパフォーマンス
 
-### Q: データ量の制限はありますか?
+### Q: データ量の上限はありますか?
 
-**A:** GeonicDB 自体には明示的なデータ量の制限はありません。MongoDB のスケーリング能力に依存します。
+**A:** GeonicDB 自体には明確なデータ量の上限はありません。MongoDB のスケーリング機能に依存します。
 
-#
+#### ハード制限(システム制約)
 
-### ハード制限(システム制約)
+| Constraint                | Value      | Description                                                  |
+| ------------------------- | ---------- | ------------------------------------------------------------ |
+| Maximum items per request | 1,000      | `limit` upper bound for pagination (FIWARE Orion compatible) |
+| Admin API maximum items   | 100        | Pagination upper bound for admin APIs                        |
+| API Gateway timeout       | 29 seconds | AWS-side limit                                               |
+| Lambda timeout            | 15 minutes | For Lambda functions such as batch processing                |
 
-| 制約 | 値 | 説明 |
-|------|-----|------|
-| リクエストあたりの最大アイテム数 | 1,000 | ページネーションの上限値 `limit` (FIWARE Orion 互換) |
-| 管理 API の最大アイテム数 | 100 | 管理 API のページネーション上限値 |
-| API Gateway タイムアウト | 29 秒 | AWS 側の制限 |
-| Lambda タイムアウト | 15 分 | バッチ処理などの Lambda 関数用 |
+#### 本番環境のための実用的なガイドライン
 
-#
-
-### 本番環境での実用的なガイドライン
-
-| データ規模 | 推奨環境 |
-|-----------|---------|
-| エンティティ 100,000 件まで | MongoDB Atlas M10–M30 |
-| エンティティ 1,000,000 件まで | MongoDB Atlas M30–M50 |
-| エンティティ 1,000,000 件超 | MongoDB Atlas M50+ でシャーディングを検討 |
+| Data Scale               | Recommended Environment                        |
+| ------------------------ | ---------------------------------------------- |
+| Up to 100,000 entities   | MongoDB Atlas M10–M30                          |
+| Up to 1,000,000 entities | MongoDB Atlas M30–M50                          |
+| Over 1,000,000 entities  | MongoDB Atlas M50+ with sharding consideration |
 
 ### Q: クエリが遅くなるケースはありますか?
 
-**A:** 以下のケースではクエリパフォーマンスが低下する可能性があります。
+**A:** 以下のケースではクエリのパフォーマンスが低下する可能性があります。
 
-#
+#### インデックスを活用するクエリ(高速)
 
-### インデックスを活用するクエリ(高速)
 
-- エンティティ ID による検索
-- エンティティタイプによるフィルタリング
-- Geo クエリ (`georel`、`geometry`、`coordinates`)
-- 最終更新日時によるソート (`modifiedAt`)
-- `observedAt` による時系列データ検索
+* エンティティ ID による検索
+  
+* エンティティタイプによるフィルタリング
+  
+* Geo クエリ(`georel`、`geometry`、`coordinates`)
+  
+* 最終更新日時(`modifiedAt`)によるソート
+  
+* `observedAt` による時系列データ検索
 
-#
+#### 注意が必要なクエリ(遅くなる可能性あり)
 
-### 注意が必要なクエリ(遅くなる可能性)
+| Query Pattern                            | Reason                    | Mitigation                       |
+| ---------------------------------------- | ------------------------- | -------------------------------- |
+| Partial match search on attribute values | Indexes are not effective | Use exact matches where possible |
+| Complex combinations of `q` filters      | May result in full scan   | Narrow down filter conditions    |
+| Wide-range Geo searches                  | Too many candidates       | Limit the search area            |
+| Retrieving all records without `limit`   | High memory consumption   | Always use pagination            |
 
-| クエリパターン | 理由 | 対策 |
-|--------------|------|------|
-| 属性値の部分一致検索 | インデックスが効かない | 可能な限り完全一致を使用 |
-| `q` フィルタの複雑な組み合わせ | フルスキャンになる可能性 | フィルタ条件を絞り込む |
-| 広範囲の Geo 検索 | 候補が多すぎる | 検索エリアを制限 |
-| `limit` なしで全レコード取得 | メモリ消費が大きい | 必ずページネーションを使用 |
+### Q: 時系列(Temporal)データで注意すべきことは?
 
-### Q: 時系列(Temporal)データで注意すべき点は?
+**A:** 時系列データの量は、エンティティ数 x 属性数 x 時間間隔で急速に増加します。
 
-**A:** 時系列データのボリュームは、エンティティ数 x 属性数 x 時間間隔で急速に増大します。
-
-#
-
-### 推奨設定
+#### 推奨設定
 
 ```bash
 # Configure automatic deletion of old data (TTL)
 # expireAfterSeconds can be set in MongoDB Atlas collection settings
 ```
 
-#
-
-### データ量の見積もり例
+#### データ量の推定例
 
 ```text
 1,000 entities x 10 attributes x 1-minute interval x 24 hours x 30 days
 = approximately 430 million records/month
 ```
 
-大量の時系列データを扱う場合は、専用の時系列データベース (TimescaleDB、InfluxDB) との統合を検討してください。
+大量の時系列データを扱う場合は、専用の時系列データベース(TimescaleDB、InfluxDB)との連携を検討してください。
 
----
+***
 
 ## FIWARE Orion との違い
 
-### Q: FIWARE Orion との互換性は？
+### Q: FIWARE Orion との互換性はどうですか?
 
-**A:** NGSIv2 API は高い互換性を持っています。詳細は [FIWARE Orion 比較ドキュメント](./migration/compatibility-matrix.md) を参照してください。
+**A:** NGSIv2 API は高い互換性があります。詳細は [FIWARE Orion 比較ドキュメント](./migration/compatibility-matrix.md) を参照してください。
 
-#
+#### 互換性のある機能
 
-### 互換性のある機能
 
-- NGSIv2 エンティティの CRUD 操作
-- サブスクリプション (通知)
-- 地理空間クエリ
-- バッチ操作
-- 登録 (Context Provider)
+* NGSIv2 エンティティ CRUD 操作
+  
+* サブスクリプション(通知)
+  
+* 地理空間クエリ
+  
+* バッチ操作
+  
+* レジストレーション(Context Provider)
 
-#
+#### GeonicDB 独自の機能
 
-### GeonicDB 独自の機能
 
-- NGSI-LD API サポート
-- JWT 認証と認可
-- マルチテナンシー
-- AI ツール統合 (MCP)
-- ベクタータイル出力
-- スナップショット機能
+* NGSI-LD API サポート
+  
+* JWT 認証と認可
+  
+* マルチテナンシー
+  
+* AI ツール統合(MCP)
+  
+* ベクタータイル出力
+  
+* スナップショット機能
 
-### Q: Orion から移行できますか？
+### Q: Orion から移行できますか?
 
 **A:** 基本的なエンティティデータは移行可能です。
 
@@ -139,63 +145,64 @@ curl -X POST "https://api.example.com/v2/op/update" \
   -d '{"actionType": "append", "entities": '"$(cat entities.json)"'}'
 ```
 
----
+***
 
 ## デプロイと運用
 
-### Q: どこにデプロイできますか？
+### Q: どこにデプロイできますか?
 
 **A:** 以下の環境で動作します。
 
-| 環境 | 説明 |
-|------|------|
-| AWS Lambda + API Gateway | 推奨。サーバーレスで自動スケーリング |
-| ローカル (`npm start`) | 開発とテスト用。インメモリ MongoDB を使用 |
-| Docker | あらゆるコンテナ環境で実行可能 |
+| Environment              | Description                                         |
+| ------------------------ | --------------------------------------------------- |
+| AWS Lambda + API Gateway | Recommended. Serverless with automatic scaling      |
+| Local (`npm start`)      | For development and testing. Uses in-memory MongoDB |
+| Docker                   | Can run in any container environment                |
 
-### Q: どの MongoDB を使うべきですか？
+### Q: どの MongoDB を使用すればよいですか?
 
-**A:** 以下のいずれかを推奨します。
+**A:** 以下のいずれかが推奨されます。
 
-| サービス | 特徴 |
-|---------|------|
-| MongoDB Atlas | 推奨。フルマネージドで自動スケーリング |
-| セルフホスト MongoDB | 完全な制御が可能だが、運用負荷が高い |
+| Service             | Features                                      |
+| ------------------- | --------------------------------------------- |
+| MongoDB Atlas       | Recommended. Fully managed, automatic scaling |
+| Self-hosted MongoDB | Full control, but high operational overhead   |
 
-> **注意**: MongoDB 8.0 以上が必要です (Time Series Collection サポートのため)。Amazon DocumentDB は Time Series Collection をサポートしていないため非対応です。
+> **注意**: MongoDB 8.0 以上が必要です(Time Series Collection サポートのため)。Amazon DocumentDB は Time Series Collection をサポートしていないため、サポートされていません。
 
-### Q: 推定コストは？
+### Q: 推定コストはどのくらいですか?
 
-**A:** サーバーレスアーキテクチャのため、使用した分だけ課金されます。
+**A:** サーバーレスアーキテクチャであるため、使用した分だけ課金されます。
 
-| コンポーネント | 小規模 (10 万リクエスト/月) | 中規模 (100 万リクエスト/月) |
-|--------------|---------------------------|----------------------------|
-| Lambda | ~$5 | ~$20 |
-| API Gateway | ~$4 | ~$35 |
-| MongoDB Atlas (M10) | ~$60 | ~$60 |
-| **合計** | **~$70/月** | **~$115/月** |
+| Component           | Small scale (100,000 requests/month) | Medium scale (1,000,000 requests/month) |
+| ------------------- | ------------------------------------ | --------------------------------------- |
+| Lambda              | \~$5                                 | \~$20                                   |
+| API Gateway         | \~$4                                 | \~$35                                   |
+| MongoDB Atlas (M10) | \~$60                                | \~$60                                   |
+| **Total**           | **\~$70/month**                      | **\~$115/month**                        |
+
 
 * 実際のコストは、リージョン、データ量、リクエストパターンによって異なります。
 
----
+***
 
 ## API の使い方
 
 ### Q: NGSIv2 と NGSI-LD のどちらを使うべきですか?
 
-**A:** 用途に応じて選択してください。
+**A:** ユースケースに基づいて選択してください。
 
-| 観点 | NGSIv2 | NGSI-LD |
-|------|--------|---------|
-| 学習コスト | 低い | やや高い (JSON-LD の理解が必要) |
-| FIWARE エコシステム | 多くのツールが利用可能 | 対応ツールが増加中 |
-| 時系列データ | 非対応 (別途実装が必要) | Temporal API による標準サポート |
-| データの相互運用性 | 限定的 | JSON-LD により高い |
-| 推奨される用途 | 既存の FIWARE システムとの統合 | 新規開発、データ相互運用性重視 |
+| Perspective           | NGSIv2                                           | NGSI-LD                                           |
+| --------------------- | ------------------------------------------------ | ------------------------------------------------- |
+| Learning curve        | Low                                              | Somewhat high (requires understanding of JSON-LD) |
+| FIWARE ecosystem      | Many tools available                             | Number of compatible tools is growing             |
+| Time-series data      | Not supported (requires separate implementation) | Standard support via Temporal API                 |
+| Data interoperability | Limited                                          | High via JSON-LD                                  |
+| Recommended use       | Integration with existing FIWARE systems         | New development, data interoperability focus      |
 
-### Q: 認証なしで使えますか?
+### Q: 認証なしで使用できますか?
 
-**A:** 開発環境では、デフォルトで認証なしで使用できます。本番環境では JWT 認証の有効化を強く推奨します。
+**A:** 開発環境では、デフォルトで認証なしで使用できます。本番環境では JWT 認証を有効にすることを強く推奨します。
 
 ```bash
 # Without authentication (development environment)
@@ -208,58 +215,50 @@ curl -X GET "https://api.example.com/v2/entities" \
   -H "Authorization: Bearer <access_token>"
 ```
 
-### Q: テナント (Fiware-Service) は必須ですか?
+### Q: テナント (Fiware-Service) は必要ですか?
 
-**A:** 必須ではありませんが、未指定の場合は `default` テナントが使用されます。本番環境では明示的にテナントを指定することを推奨します。
+**A:** 必須ではありませんが、指定しない場合は `default` テナントが使用されます。本番環境では明示的にテナントを指定することを推奨します。
 
----
+***
 
-## 地理空間拡張
+## 地理空間拡張機能
 
-### Q: 地理空間拡張とは何ですか?
+### Q: 地理空間拡張機能とは何ですか?
 
-**A:** NGSI 標準の Geo クエリに加えて、GeonicDB が独自に提供する地理空間機能です。これらを総称して「地理空間拡張」と呼びます。
+**A:** NGSI 標準の Geo クエリに加えて、GeonicDB が独自に提供する地理空間機能です。これらを総称して「地理空間拡張機能」と呼びます。
 
-#
+#### 機能一覧
 
-### 機能一覧
-
-| 機能 | 説明 | 対応 API |
-|------|------|---------|
-| Geo クエリ | NGSI 標準の地理空間検索 | NGSIv2、NGSI-LD |
-| ベクタータイル | 地図表示用の GeoJSON タイル出力 | NGSIv2、NGSI-LD |
-| 空間 ID | 日本デジタル庁 3D 空間 ID 対応 | NGSIv2、NGSI-LD |
+| Feature      | Description                                | Supported APIs  |
+| ------------ | ------------------------------------------ | --------------- |
+| Geo queries  | NGSI standard geospatial search            | NGSIv2, NGSI-LD |
+| Vector tiles | GeoJSON tile output for map display        | NGSIv2, NGSI-LD |
+| Spatial ID   | Japan Digital Agency 3D Spatial ID support | NGSIv2, NGSI-LD |
 
 ### Q: Geo クエリで何ができますか?
 
-**A:** 位置情報を持つエンティティを地理的条件で検索できます。
+**A:** 地理的条件を使用して、位置情報を持つエンティティを検索できます。
 
-#
+#### サポートされているジオメトリタイプ
 
-### サポートされるジオメトリタイプ
+| Type       | Description                  | Examples                               |
+| ---------- | ---------------------------- | -------------------------------------- |
+| Point      | A point (latitude/longitude) | Sensor location, store location        |
+| Polygon    | A polygon                    | Building area, administrative boundary |
+| LineString | A line                       | Road, river                            |
 
-| タイプ | 説明 | 例 |
-|--------|------|-----|
-| Point | 点 (緯度/経度) | センサーの位置、店舗の場所 |
-| Polygon | 多角形 | 建物の面積、行政区域 |
-| LineString | 線 | 道路、河川 |
+#### サポートされている空間関係 (georel)
 
-#
+| Relationship | Description                     | Usage Example                            |
+| ------------ | ------------------------------- | ---------------------------------------- |
+| `near`       | Distance from a specified point | "Sensors within 1km of current location" |
+| `within`     | Contained within a range        | "Buildings within this district"         |
+| `contains`   | Contains a range                | "Areas that contain this point"          |
+| `intersects` | Intersects with                 | "Areas that intersect with this road"    |
+| `disjoint`   | Separated from                  | "Entities outside this district"         |
+| `equals`     | Matches exactly                 | "Entities at the same location"          |
 
-### サポートされる空間関係 (georel)
-
-| 関係 | 説明 | 使用例 |
-|------|------|--------|
-| `near` | 指定地点からの距離 | 「現在地から 1km 以内のセンサー」 |
-| `within` | 範囲内に含まれる | 「この地区内の建物」 |
-| `contains` | 範囲を含む | 「この点を含むエリア」 |
-| `intersects` | 交差する | 「この道路と交差するエリア」 |
-| `disjoint` | 分離している | 「この地区外のエンティティ」 |
-| `equals` | 完全に一致 | 「同じ場所にあるエンティティ」 |
-
-#
-
-### 使用例
+#### 使用例
 
 ```bash
 # Search for sensors within 1km of Tokyo Station (139.7671, 35.6812)
@@ -271,21 +270,20 @@ curl -X GET "http://localhost:3000/v2/entities?georel=within&geometry=polygon&co
   -H "Fiware-Service: default"
 ```
 
-### Q: ベクタータイルとは何ですか?
+### Q: ベクトルタイルとは何ですか?
 
-**A:** エンティティの位置情報を GeoJSON タイル形式で出力し、地図アプリケーション向けに提供する機能です。
+**A:** 地図アプリケーション向けに、エンティティの位置情報を GeoJSON タイル形式で出力する機能です。
 
-#
+#### 機能
 
-### 特徴
 
-- **タイル座標系**: Web メルカトル (z/x/y 形式)
-- **クラスタリング**: ズームレベルに応じて自動的にポイントを集約
-- **TileJSON 対応**: MapLibre GL JS などの地図ライブラリと統合可能
+* **タイル座標系**: Web Mercator (z/x/y 形式)
+  
+* **クラスタリング**: ズームレベルに基づいてポイントを自動的に集約
+  
+* **TileJSON サポート**: MapLibre GL JS などの地図ライブラリと統合可能
 
-#
-
-### エンドポイント
+#### エンドポイント
 
 ```bash
 # Get TileJSON metadata
@@ -297,9 +295,7 @@ curl -X GET "http://localhost:3000/v2/tiles/14/14552/6451.geojson" \
   -H "Fiware-Service: default"
 ```
 
-#
-
-### MapLibre GL JS での使用例
+#### MapLibre GL JS での使用例
 
 ```javascript
 map.addSource('entities', {
@@ -317,13 +313,12 @@ map.addLayer({
   }
 });
 ```
-### Q: Spatial ID とは何ですか？
 
-**A:** 日本のデジタル庁/IPA が策定した「3 次元空間 ID」仕様をサポートする機能です。緯度・経度に加えて高度（階層）を含む 3 次元空間を一意に識別できるようにします。
+### Q: Spatial ID とは何ですか?
 
-#
+**A:** 日本のデジタル庁/IPA が策定した「3次元空間識別子」仕様をサポートする機能です。緯度・経度に加えて高度(階層)を含む 3D 空間の一意識別を可能にします。
 
-### Spatial ID の形式
+#### Spatial ID 形式
 
 ```text
 z/f/x/y
@@ -334,9 +329,7 @@ x: X tile coordinate
 y: Y tile coordinate
 ```
 
-#
-
-### 使用例
+#### 使用例
 
 ```text
 25/0/29805582/13235296  → A specific point on the ground floor
@@ -344,32 +337,30 @@ y: Y tile coordinate
 25/-1/29805582/13235296 → Underground at the same point
 ```
 
-#
+#### 機能
 
-### 機能
+| Operation                            | Description                                                 |
+| ------------------------------------ | ----------------------------------------------------------- |
+| Coordinates to Spatial ID conversion | Calculate Spatial ID from latitude, longitude, and altitude |
+| Spatial ID to bounding box           | Get the 3D extent represented by a Spatial ID               |
+| Spatial ID expansion                 | Enumerate child Spatial IDs from a parent Spatial ID        |
 
-| 操作 | 説明 |
-|------|------|
-| 座標から Spatial ID への変換 | 緯度、経度、高度から Spatial ID を計算 |
-| Spatial ID から境界ボックスへ | Spatial ID が表す 3 次元の範囲を取得 |
-| Spatial ID の展開 | 親 Spatial ID から子 Spatial ID を列挙 |
+#### 使用事例
 
-#
 
-### ユースケース
+* 屋内測位(建物内のフロア識別)
+  
+* ドローン飛行経路管理
+  
+* 3D 都市モデルとの統合
+  
+* 地下施設管理
 
-- 屋内測位（建物内のフロア識別）
-- ドローンの飛行経路管理
-- 3D 都市モデルとの統合
-- 地下施設の管理
-
-### Q: GeoProperty の設定方法は？
+### Q: GeoProperty を設定するにはどうすればよいですか?
 
 **A:** エンティティに位置情報を保存するには、`location` 属性に GeoJSON 形式で座標を設定します。
 
-#
-
-### NGSIv2 形式
+#### NGSIv2 形式
 
 ```json
 {
@@ -385,9 +376,7 @@ y: Y tile coordinate
 }
 ```
 
-#
-
-### NGSI-LD 形式
+#### NGSI-LD 形式
 
 ```json
 {
@@ -403,44 +392,48 @@ y: Y tile coordinate
 }
 ```
 
-**注意**: 座標は `[longitude, latitude]` の順序です（GeoJSON 標準）。
+**注意**: 座標は `[longitude, latitude]` の順序です (GeoJSON 標準)。
 
----
+***
 
 ## セキュリティ
 
-### Q: サポートされている認証方法は？
+### Q: どのような認証方法がサポートされていますか?
 
 **A:** 以下の認証方法がサポートされています。
 
-| 方法 | 説明 |
-|------|------|
-| JWT Bearer Token | 推奨。ユーザー認証とロールベースのアクセス制御 |
-| IP ホワイトリスト | テナントごとに許可される IP を制限 |
-| API Key (X-Api-Key) | IoT デバイスやサードパーティ統合向けの軽量認証 |
+| Method              | Description                                                             |
+| ------------------- | ----------------------------------------------------------------------- |
+| JWT Bearer Token    | Recommended. User authentication and role-based access control          |
+| IP whitelist        | Restrict allowed IPs per tenant                                         |
+| API Key (X-Api-Key) | Lightweight authentication for IoT devices and third-party integrations |
 
-### Q: ロール（権限）の種類は？
+### Q: ロール (権限) にはどのような種類がありますか?
 
-**A:** 4 種類のロールがあります。
+**A:** ロールには 4 つの種類があります。
 
-| ロール | 権限 |
-|--------|------|
-| `super_admin` | プラットフォーム管理のみ（`/admin/*`、`/auth/*`）。データ API にはアクセスできません（403 を返す） |
-| `tenant_admin` | 割り当てられたテナントの管理、ユーザー管理 |
-| `user` | エンティティの読み取り/書き込み（ポリシーで制限可能） |
-| `api_key` | X-Api-Key ヘッダー経由のスコープベースアクセス（オリジン/エンティティタイプ制限） |
+| Role           | Permissions                                                                             |
+| -------------- | --------------------------------------------------------------------------------------- |
+| `super_admin`  | Platform management only (`/admin/*`, `/auth/*`). Cannot access data APIs (returns 403) |
+| `tenant_admin` | Management of assigned tenants, user management                                         |
+| `user`         | Read/write entities (can be restricted by policy)                                       |
+| `api_key`      | Scope-based access via X-Api-Key header (origin/entity-type restrictions)               |
 
-詳細は認証と認可を参照してください。
+詳細は [認証と認可](./reference/auth.md) を参照してください。
 
-### Q: HTTPS は必須ですか？
+### Q: HTTPS は必須ですか?
 
 **A:** 本番環境では必須です。AWS にデプロイする場合、API Gateway が自動的に HTTPS を提供します。
 
----
+***
 
 ## 関連ドキュメント
 
-- [API 仕様](./api-reference/endpoints.md)
-- [FIWARE Orion との比較](./migration/compatibility-matrix.md)
-- 開発とデプロイガイド
-- 認証と認可
+
+* [API 仕様](./api-reference/endpoints.md)
+  
+* [FIWARE Orion 比較](./migration/compatibility-matrix.md)
+  
+* 開発とデプロイメントガイド
+  
+* [認証と認可](./reference/auth.md)

--- a/docs/ja/features/ngsi-subscriptions.md
+++ b/docs/ja/features/ngsi-subscriptions.md
@@ -1,11 +1,684 @@
 ---
-title: "NGSI サブスクリプション"
-description: "エンティティ変更通知のための HTTP Webhook サブスクリプション"
+title: "NGSI Subscriptions"
+description: "HTTP Webhook subscriptions for entity change notifications"
 outline: deep
 ---
+# サブスクリプション
 
-# NGSI サブスクリプション
+GeonicDB のサブスクリプション機能により、エンティティの変更をリアルタイムで監視し、外部システムに自動的に通知することができます。
 
-::: info 準備中
-このページは GeonicDB 上流ドキュメントから同期されます。次回ドキュメント同期後に全コンテンツが利用可能になります。
-:::
+## 目次
+
+
+* [概要](#概要)
+  
+* [サブスクリプションの仕組み](#サブスクリプションの仕組み)
+  
+* [通知方法](#通知方法)
+  
+* [条件とフィルタリング](#条件とフィルタリング)
+  
+* [実用例](#実用例)
+  
+* [ベストプラクティス](#ベストプラクティス)
+  
+* [アクセス制御と所有権 (GeonicDB 拡張)](#アクセス制御と所有権-geonicdb-拡張)
+  
+* [トラブルシューティング](#トラブルシューティング)
+
+***
+
+## 概要
+
+サブスクリプションは、エンティティの作成、更新、削除を監視し、定義された条件が満たされたときに指定されたエンドポイントに通知を送信します。
+
+### 主なユースケース
+
+
+* **センサーデータの監視**: 温度、湿度などの閾値超過を検出
+  
+* **位置追跡**: 車両やデバイスの位置変化を追跡
+  
+* **イベント駆動アーキテクチャ**: エンティティの変更によってトリガーされる自動処理
+  
+* **データ統合**: 他システムへのリアルタイムデータ配信
+
+### サポートされる API
+
+| API     | Endpoint                    | Support |
+| ------- | --------------------------- | ------- |
+| NGSIv2  | `/v2/subscriptions`         | ✅       |
+| NGSI-LD | `/ngsi-ld/v1/subscriptions` | ✅       |
+
+***
+
+## サブスクリプションの仕組み
+
+```text
+1. Entity creation/update
+   ↓
+2. MongoDB Change Stream detects the event
+   ↓
+3. Event is sent to EventBridge
+   ↓
+4. SubscriptionMatcher searches for subscriptions matching the conditions
+   ↓
+5. Notification message is sent to the SQS queue
+   ↓
+6. NotificationSender sends an HTTP/MQTT notification to the external endpoint
+```
+
+**レイテンシ**: エンティティの変更から通知配信まで約 1 分 (Change Stream のポーリング間隔に依存)。
+
+***
+
+## 通知方法
+
+### HTTP Webhook
+
+標準的な HTTP POST リクエストとして通知を送信します。
+
+**サブスクリプション作成の例:**
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{
+    "description": "Room temperature monitoring",
+    "subject": {
+      "entities": [{ "idPattern": ".*", "type": "Room" }],
+      "condition": {
+        "attrs": ["temperature"],
+        "expression": { "q": "temperature>25" }
+      }
+    },
+    "notification": {
+      "http": { "url": "https://webhook.example.com/notify" },
+      "attrs": ["temperature", "pressure"]
+    },
+    "expires": "2030-12-31T23:59:59.000Z",
+    "throttling": 5
+  }'
+```
+
+**通知ペイロードの例:**
+
+```json
+{
+  "subscriptionId": "sub123",
+  "data": [
+    {
+      "id": "Room1",
+      "type": "Room",
+      "temperature": {
+        "type": "Number",
+        "value": 26.5,
+        "metadata": {}
+      },
+      "pressure": {
+        "type": "Number",
+        "value": 1013.25,
+        "metadata": {}
+      }
+    }
+  ]
+}
+```
+
+### httpCustom (カスタムテンプレート)
+
+HTTP メソッド、ヘッダー、ペイロードのカスタマイズを可能にします。
+
+**サブスクリプション作成の例:**
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{
+    "description": "Custom notification template",
+    "subject": {
+      "entities": [{ "type": "Room" }],
+      "condition": { "attrs": ["temperature"] }
+    },
+    "notification": {
+      "httpCustom": {
+        "url": "https://api.example.com/events",
+        "method": "PUT",
+        "headers": {
+          "X-Api-Key": "secret-key",
+          "Content-Type": "application/json"
+        },
+        "qs": {
+          "entityId": "${id}",
+          "temp": "${temperature}"
+        },
+        "payload": "{\"room\": \"${id}\", \"temp\": ${temperature}, \"timestamp\": \"${timestamp}\"}"
+      }
+    }
+  }'
+```
+
+**マクロ置換:**
+
+| Macro            | Substituted value                                              |
+| ---------------- | -------------------------------------------------------------- |
+| `${id}`          | Entity ID                                                      |
+| `${type}`        | Entity type                                                    |
+| `${temperature}` | Attribute value (extracts `.value` from normalized attributes) |
+
+存在しない属性は文字列 `null` に置き換えられます。
+
+### MQTT
+
+MQTT ブローカーにメッセージを公開します。
+
+**サブスクリプション作成の例:**
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{
+    "description": "MQTT notification",
+    "subject": {
+      "entities": [{ "type": "Sensor" }],
+      "condition": { "attrs": ["value"] }
+    },
+    "notification": {
+      "mqtt": {
+        "url": "mqtt://broker.example.com:1883",
+        "topic": "sensors/room/temperature",
+        "qos": 1,
+        "user": "username",
+        "passwd": "password"
+      },
+      "attrs": ["value"]
+    }
+  }'
+```
+
+**MQTT 設定:**
+
+| Field    | Description                               | Default |
+| -------- | ----------------------------------------- | ------- |
+| `url`    | MQTT broker URL (`mqtt://` or `mqtts://`) | -       |
+| `topic`  | Topic to publish to                       | -       |
+| `qos`    | QoS level (0, 1, 2)                       | 0       |
+| `retain` | Message retain flag                       | false   |
+| `user`   | Authentication username                   | -       |
+| `passwd` | Authentication password                   | -       |
+
+***
+
+## 条件とフィルタリング
+
+### エンティティの指定
+
+**特定の ID:**
+
+```json
+{
+  "subject": {
+    "entities": [
+      { "id": "Room1", "type": "Room" }
+    ]
+  }
+}
+```
+
+**ID パターン (正規表現):**
+
+```json
+{
+  "subject": {
+    "entities": [
+      { "idPattern": "Room.*", "type": "Room" }
+    ]
+  }
+}
+```
+
+**すべてのエンティティ:**
+
+```json
+{
+  "subject": {
+    "entities": [
+      { "idPattern": ".*" }
+    ]
+  }
+}
+```
+
+### 条件式 (q パラメータ)
+
+**比較演算子:**
+
+| Operator | Description              | Example            |
+| -------- | ------------------------ | ------------------ |
+| `>`      | Greater than             | `temperature>25`   |
+| `<`      | Less than                | `temperature<10`   |
+| `>=`     | Greater than or equal to | `temperature>=20`  |
+| `<=`     | Less than or equal to    | `temperature<=30`  |
+| `==`     | Equal to                 | `status==active`   |
+| `!=`     | Not equal to             | `status!=inactive` |
+
+**論理演算子:**
+
+| Operator | Description | Example                      |
+| -------- | ----------- | ---------------------------- |
+| `;`      | AND         | `temperature>20;humidity<80` |
+| `,`      | OR          | `type==Room,type==Building`  |
+
+**例:**
+
+```json
+{
+  "subject": {
+    "condition": {
+      "attrs": ["temperature"],
+      "expression": {
+        "q": "temperature>25;temperature<40"
+      }
+    }
+  }
+}
+```
+
+### 通知属性フィルタリング
+
+**特定の属性のみを通知:**
+
+```json
+{
+  "notification": {
+    "attrs": ["temperature", "humidity"]
+  }
+}
+```
+
+**特定の属性を除外:**
+
+```json
+{
+  "notification": {
+    "exceptAttrs": ["metadata", "internalId"]
+  }
+}
+```
+
+**変更された属性のみを通知:**
+
+```json
+{
+  "notification": {
+    "onlyChangedAttrs": true
+  }
+}
+```
+
+***
+
+## 実用例
+
+### 例 1: 温度閾値監視
+
+高温アラートを送信するサブスクリプション:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "description": "High temperature alert",
+    "subject": {
+      "entities": [{ "type": "TemperatureSensor" }],
+      "condition": {
+        "attrs": ["temperature"],
+        "expression": { "q": "temperature>35" }
+      }
+    },
+    "notification": {
+      "http": { "url": "https://alerts.example.com/high-temp" },
+      "attrs": ["temperature", "location"]
+    }
+  }'
+```
+
+### 例 2: 車両位置追跡
+
+車両位置の変化を追跡:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: fleet" \
+  -d '{
+    "description": "Vehicle location tracking",
+    "subject": {
+      "entities": [{ "idPattern": "Vehicle.*", "type": "Vehicle" }],
+      "condition": { "attrs": ["location"] }
+    },
+    "notification": {
+      "http": { "url": "https://tracking.example.com/update" },
+      "attrs": ["location", "speed", "status"],
+      "attrsFormat": "keyValues"
+    }
+  }'
+```
+
+### 例 3: カスタムペイロード (Slack 通知)
+
+Slack Webhook にカスタム形式の通知を送信:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "description": "Slack notification for alerts",
+    "subject": {
+      "entities": [{ "type": "Alert" }],
+      "condition": { "attrs": ["severity"] }
+    },
+    "notification": {
+      "httpCustom": {
+        "url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+        "method": "POST",
+        "headers": { "Content-Type": "application/json" },
+        "payload": "{\"text\": \"⚠️ Alert: ${id} - Severity: ${severity}\"}"
+      }
+    }
+  }'
+```
+
+### 例 4: MQTT センサーデータ配信
+
+MQTT ブローカーにセンサーデータを配信:
+
+```bash
+curl -X POST http://localhost:3000/v2/subscriptions \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: iot" \
+  -d '{
+    "description": "Sensor data to MQTT",
+    "subject": {
+      "entities": [{ "type": "Sensor" }],
+      "condition": { "attrs": ["value"] }
+    },
+    "notification": {
+      "mqtt": {
+        "url": "mqtts://broker.hivemq.com:8883",
+        "topic": "sensors/${type}/${id}",
+        "qos": 1
+      },
+      "attrsFormat": "keyValues"
+    }
+  }'
+```
+
+***
+
+## ベストプラクティス
+
+### 1. 条件を適切に設定する
+
+**❌ 悪い例:すべてのエンティティを監視**
+
+```json
+{
+  "subject": {
+    "entities": [{ "idPattern": ".*" }],
+    "condition": { "attrs": [] }
+  }
+}
+```
+
+通知の量が過剰になり、システムに負荷がかかります。
+
+**✅ 良い例:特定のタイプと条件で絞り込む**
+
+```json
+{
+  "subject": {
+    "entities": [{ "type": "Sensor" }],
+    "condition": {
+      "attrs": ["temperature"],
+      "expression": { "q": "temperature>25" }
+    }
+  }
+}
+```
+
+### 2. スロットリングを設定する
+
+`throttling`(秒単位)を設定して、過剰な通知を防ぎます:
+
+```json
+{
+  "throttling": 60
+}
+```
+
+これにより、同じエンティティの変更通知が 60 秒に 1 回に制限されます。
+
+### 3. 有効期限を設定する
+
+テストサブスクリプションには`expires`を設定します:
+
+```json
+{
+  "expires": "2026-12-31T23:59:59.000Z"
+}
+```
+
+### 4. 変更された属性のみを通知する
+
+不要な通知を減らします:
+
+```json
+{
+  "notification": {
+    "onlyChangedAttrs": true
+  }
+}
+```
+
+### 5. ステータス管理
+
+`inactive`に設定して、一時的に通知を停止します:
+
+```bash
+curl -X PATCH http://localhost:3000/v2/subscriptions/{id} \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{ "status": "inactive" }'
+```
+
+### 6. エラーハンドリング
+
+通知先エンドポイントで以下を実装します:
+
+* **2xx ステータスコードを返す**:成功を示すため
+  
+* **リトライロジック**:一時的な障害に対処するため
+  
+* **タイムアウト設定**:長時間のハングを防ぐため
+
+***
+
+## アクセス制御と所有権 (GeonicDB 拡張)
+
+> **注意**: `super_admin` はサブスクリプションエンドポイント (`/v2/subscriptions`、`/ngsi-ld/v1/subscriptions`) にアクセスできません。これらはデータ API であるためです。代わりに `tenant_admin` または `user` ロールを使用してください。
+
+認証が有効な環境では、サブスクリプションに対して所有権ベースのアクセス制御が適用されます。
+
+### 動作
+
+
+* サブスクリプションが作成されると、認証されたユーザーの ID が `createdBy` フィールドに記録されます。
+  
+* **更新 (PATCH) と削除 (DELETE)** は、次のいずれかの条件を満たすユーザーのみが実行できます:
+  
+  * サブスクリプションの作成者 (`createdBy` が一致)
+    
+  * `tenant_admin` ロール
+    
+* 上記の条件が満たされない場合、**403 Forbidden** が返されます。
+  
+* **取得 (GET) と一覧表示 (LIST)** は、同じテナント内の認証されたユーザーであれば制限はありません。
+
+> **注意**: 同じ所有権検証が登録 (`/v2/registrations`、`/ngsi-ld/v1/csourceRegistrations`) にも適用されます。
+
+### サブスクリプション作成時の XACML 属性ベース制御 (NGSI-LD、#1104)
+
+`POST /ngsi-ld/v1/subscriptions` の場合、XACML PIP はサブスクリプション対象の属性を `AuthzRequest.resource` に注入し、きめ細かなポリシー制御を可能にします:
+
+| Resource attribute     | Source field                | Example use                                                                                                 |
+| ---------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `entityType`           | `entities[].type`           | "Anonymous can subscribe only to `ActivityLog`"                                                             |
+| `entityId`             | `entities[].id`             | Restrict to specific entity IDs                                                                             |
+| `entityIdPattern`      | `entities[].idPattern`      | Restrict by id pattern                                                                                      |
+| `notificationEndpoint` | `notification.endpoint.uri` | "Notifications may only be posted to `https://*.example.com/**`" — defence against SSRF / data exfiltration |
+
+`entities[]` に複数の要素が含まれる場合、サブスクリプション作成を成功させるには**すべての要素が Permit でなければなりません**(全 Permit セマンティクス)。単一の不一致なタイプまたは id パターンがあると、リクエスト全体が `403 Forbidden` で拒否されます。
+
+> リテラル `body.type === "Subscription"` は `entityType` に伝播**されません**。ポリシーは `entities[].type` を対象とする必要があり、ラッパーオブジェクトのタイプではありません。
+
+認証と認可の詳細については、[AUTH.md § Subscription PIP attributes](../reference/auth.md#subscription-pip-attributes) を参照してください。
+
+***
+
+## トラブルシューティング
+
+### 1. 通知が配信されない
+
+**原因:**
+
+* 条件式が一致しない
+  
+* 通知先 URL に到達できない
+  
+* サブスクリプションが `inactive` または期限切れ
+
+**確認方法:**
+
+```bash
+# Check subscription details
+curl http://localhost:3000/v2/subscriptions/{id} \
+  -H "Fiware-Service: demo"
+
+# Check status, expires, and lastNotification
+```
+
+**解決方法:**
+
+* 条件式をテストする: 手動でエンティティを更新し、条件が満たされることを確認
+  
+* 通知 URL をテストする: `curl` で直接到達可能か確認
+  
+* ステータスを `active` に変更
+
+### 2. 通知が重複する
+
+**原因:**
+
+* `throttling` が設定されていない
+  
+* 複数のサブスクリプションが同じエンティティを監視している
+
+**解決方法:**
+
+```bash
+# Configure throttling
+curl -X PATCH http://localhost:3000/v2/subscriptions/{id} \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: demo" \
+  -d '{ "throttling": 30 }'
+
+# Check the subscription list
+curl http://localhost:3000/v2/subscriptions \
+  -H "Fiware-Service: demo"
+```
+
+### 3. Notification Payload Is Not as Expected
+
+**原因:**
+
+* `attrs` フィルターが正しく設定されていない
+  
+* `attrsFormat` が適切でない
+  
+* `httpCustom` マクロ構文が正しくない
+
+**確認方法:**
+
+```bash
+# Check subscription configuration
+curl http://localhost:3000/v2/subscriptions/{id} \
+  -H "Fiware-Service: demo" | jq '.notification'
+```
+
+**解決策:**
+
+* 必要な属性を含むように `attrs` を更新する
+  
+* `attrsFormat` を `normalized` または `keyValues` に変更する
+  
+* `httpCustom` マクロ構文を検証する(`${attrName}` は属性名と一致する必要がある)
+
+### 4. MQTT Notifications Are Not Being Sent
+
+**原因:**
+
+* MQTT ブローカーに接続できない
+  
+* 認証情報が正しくない
+  
+* トピック名が無効
+
+**確認方法:**
+
+```bash
+# Test the connection to the MQTT broker (using mosquitto_sub)
+mosquitto_sub -h broker.example.com -p 1883 -t "sensors/#" -u username -P password
+```
+
+**解決策:**
+
+* MQTT ブローカーの URL、ポート、および認証情報を確認する
+  
+* トピック名に特殊文字が含まれていないことを確認する
+  
+* QoS レベルを 0 に下げてみる
+
+### 5. Subscription Automatically Becomes inactive
+
+**原因:**
+
+* 通知の送信先が継続的にエラーを返している(5xx、タイムアウト)
+  
+* GeonicDB がサブスクリプションを自動的に無効にした
+
+**解決策:**
+
+* 通知の送信先エンドポイントのログを確認する
+  
+* エンドポイントが正しく応答するように修正する
+  
+* サブスクリプションを `active` に戻す
+
+***
+
+## 関連ドキュメント
+
+
+* [API Common Specification](../api-reference/endpoints.md) - REST API ドキュメント
+  
+* [API\_NGSIV2.md](../api-reference/ngsiv2.md) - NGSIv2 Subscriptions API リファレンス
+  
+* [API\_NGSILD.md](../api-reference/ngsild.md) - NGSI-LD Subscriptions API リファレンス
+  
+* [EVENT\_STREAMING.md](./subscriptions.md) - WebSocket イベントストリーミング

--- a/docs/ja/features/reactivcore-rules.md
+++ b/docs/ja/features/reactivcore-rules.md
@@ -1,11 +1,2321 @@
 ---
-title: "ReactiveCore ルール"
-description: "エンティティ変更に基づくリアクティブ自動化ルール"
+title: "ReactiveCore Rules"
+description: "Reactive automation rules based on entity changes"
 outline: deep
 ---
+# ReactiveCore Rules
 
-# ReactiveCore ルール
+GeonicDB の **ReactiveCore Rules** は、エンティティの変更を自動的に検出し、定義されたルールに基づいてアクションを実行するリアクティブ自動化機能です。Change Streams を介して MongoDB の変更をリアルタイムで監視し、ルール条件が一致したときに自動処理を実行します。
 
-::: info 準備中
-このページは GeonicDB 上流ドキュメントから同期されます。次回ドキュメント同期後に全コンテンツが利用可能になります。
-:::
+## 目次
+
+
+* [概要](#overview)
+  
+  * [主要機能](#主要機能)
+    
+  * [有効化](#有効化)
+    
+  * [ローカル開発環境でのテスト](#ローカル開発環境でのテスト)
+    
+  * [ユースケース](#ユースケース)
+    
+* [アーキテクチャ](#アーキテクチャ)
+  
+* [ルール構造](#ルール構造)
+  
+* [条件](#条件)
+  
+* [アクション](#アクション)
+  
+* [テンプレート変数](#template-variables)
+  
+* [Rules API](#rules-api)
+  
+* [例](#examples)
+  
+* [制限事項](#limitations)
+  
+* [トラブルシューティング](#トラブルシューティング)
+
+***
+
+## 概要
+
+### 主要機能
+
+
+* **自動エンティティ処理**: エンティティの作成、更新、削除を検出し、自動的にアクションを実行
+  
+* **柔軟な条件設定**: 属性値、パターンマッチング、変更検出、時間範囲、エンティティタイプに基づいた条件を指定
+  
+* **複数のアクションサポート**: 派生エンティティの作成、属性の更新、属性の削除、通知の送信、Webhook の呼び出し
+  
+* **テンプレート変数**: `${entity.id}`、`${attribute.temperature.value}` などを使用して値を動的に参照
+  
+* **優先度制御**: 複数のルールが一致した場合、優先度の昇順で実行
+  
+* **テナント分離**: テナントごとに独立したルール管理
+
+### 有効化
+
+環境変数を介して ReactiveCore Rules を有効化します(デフォルトでは無効)。
+
+```bash
+export RULES_ENABLED=true
+```
+
+### ローカル開発環境でのテスト
+
+ローカル開発環境で ReactiveCore Rules を試すには、以下の手順に従ってください。
+
+#### 1. ローカルサーバーを起動する
+
+ローカルサーバーを起動します。MongoDB は自動的にレプリカセットモードで起動し、Change Stream Watcher も自動的に有効になります。
+
+```bash
+npm start
+```
+
+起動時には、以下のような出力が表示されます。
+
+```text
+━━━ ReactiveCore Rules - Change Stream Started ━━━
+Watching for entity changes...
+```
+
+エンティティの変更が自動的に監視され、ルールが実行準備完了になります。
+
+#### 2. ルールを作成する
+
+Rules API を使用してルールを作成します。
+
+```bash
+# Rule to create a warning entity when a temperature sensor exceeds 30 degrees
+curl -X POST "http://localhost:3000/rules" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <accessToken>" \
+  -d '{
+    "name": "High Temperature Alert",
+    "description": "Automatically create a warning entity when temperature exceeds 30 degrees",
+    "conditions": [
+      {
+        "type": "entityType",
+        "entityTypes": ["TemperatureSensor"]
+      },
+      {
+        "type": "value",
+        "attributeName": "temperature",
+        "operator": ">",
+        "value": 30
+      }
+    ],
+    "actions": [
+      {
+        "type": "createEntity",
+        "entityId": "urn:ngsi-ld:Alert:${entity.id}",
+        "entityType": "Alert",
+        "attributes": {
+          "severity": "high",
+          "message": "Temperature exceeded 30°C",
+          "sourceEntity": "${entity.id}"
+        }
+      }
+    ],
+    "priority": 10
+  }'
+```
+
+#### 3. ルールをトリガーするエンティティを作成または更新する
+
+Entity API を使用してエンティティを作成します。
+
+```bash
+# Create a sensor with a temperature of 31 degrees (rule will be triggered)
+curl -X POST "http://localhost:3000/v2/entities" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: test" \
+  -d '{
+    "id": "urn:ngsi-ld:TemperatureSensor:001",
+    "type": "TemperatureSensor",
+    "temperature": {
+      "value": 31,
+      "type": "Number"
+    }
+  }'
+```
+
+#### 4. Change Stream の出力を確認する
+
+`npm start` を実行しているターミナルには、以下のような出力が表示されます。
+
+```text
+━━━ Entity Change Detected ━━━
+Event: entity.created
+Entity: urn:ngsi-ld:TemperatureSensor:001 (TemperatureSensor)
+Changed attributes: temperature
+Executing ReactiveCore Rules...
+✓ Rules processed successfully
+```
+
+#### 5. 派生エンティティが作成されたことを確認する
+
+```bash
+# Verify that the alert entity was automatically created
+curl -X GET "http://localhost:3000/v2/entities?type=Alert" \
+  -H "Fiware-Service: test"
+```
+
+応答例:
+
+```json
+[
+  {
+    "id": "urn:ngsi-ld:Alert:urn:ngsi-ld:TemperatureSensor:001",
+    "type": "Alert",
+    "severity": {
+      "type": "Property",
+      "value": "high",
+      "metadata": {}
+    },
+    "message": {
+      "type": "Property",
+      "value": "Temperature exceeded 30°C",
+      "metadata": {}
+    },
+    "sourceEntity": {
+      "type": "Relationship",
+      "object": "urn:ngsi-ld:TemperatureSensor:001",
+      "metadata": {}
+    }
+  }
+]
+```
+
+#### 注意事項
+
+
+* **自動起動**: `npm start` を実行するだけで、MongoDB (レプリカセットモード) と Change Stream Watcher が自動的に起動します。
+  
+* **レプリカセットモード**: Change Streams には レプリカセットモードが必要なため、MongoDB はレプリカセットモードで起動します (Change Streams はスタンドアロン MongoDB モードでは動作しません)。
+  
+* **Resume Token**: サーバーが停止して再起動しても、Change Stream の処理は中断したところから再開されます (resume token は MongoDB に保存されます)。
+  
+* **リアルタイム処理**: エンティティが作成または更新されると、Change Stream が即座にルールを実行します。
+  
+* **バックグラウンド実行**: Change Stream は HTTP サーバーと並行してバックグラウンドで実行されます。
+
+### ユースケース
+
+
+1. **派生エンティティの自動生成**: センサーデータから集約エンティティを自動的に作成
+   
+2. **属性の自動計算**: 温度と湿度から不快指数を自動的に計算して追加
+   
+3. **閾値監視**: 温度が 30 度を超えた場合に警告属性を自動的に追加
+   
+4. **時間ベースの処理**: 営業時間外にステータス属性を自動的に更新
+   
+5. **Webhook 統合**: エンティティの変更を外部システムに自動的に通知
+
+***
+
+## アーキテクチャ
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                    Entity Change Event                       │
+│          (EntityCreated, EntityUpdated, EntityDeleted)       │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+                            │ EntityService publishes to EventBridge
+                            │ (#1119: Rule firing migrated from
+                            │  scheduled change-stream to EventBridge)
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│              Rule Processor Handler (Lambda)                 │
+│              src/handlers/rules/processor.ts                 │
+│                                                              │
+│  - Consumes EventBridgeRule for                              │
+│    EntityCreated / EntityUpdated / EntityDeleted             │
+│  - Forwards EntityChangeEvent to RuleEngineService           │
+│                                                              │
+│  Local / standalone:                                         │
+│    local-server.ts watches the MongoDB Change Stream and     │
+│    invokes RuleEngineService directly. The E2E suite reuses  │
+│    the production handler via `@rules-auto-fire` hook for    │
+│    parity between local and Lambda paths.                    │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│                   RuleEngineService                          │
+│            src/core/rules/rule-engine.service.ts             │
+│                                                              │
+│  1. Retrieves active rules for the tenant                    │
+│  2. Evaluates conditions for each rule                       │
+│     - evaluateCondition() (recursive)                       │
+│     - value, pattern, change, time, entityType              │
+│     - and, or, not (logical operators)                      │
+│  3. Sorts matched rules by priority                          │
+│  4. Executes actions for each rule sequentially              │
+│     - executeAction()                                       │
+│     - createEntity, updateAttribute, deleteAttribute        │
+│     - sendNotification, webhook, appendToTemporal           │
+└───────────────────────────┬─────────────────────────────────┘
+                            │
+┌───────────────────────────▼─────────────────────────────────┐
+│                  Action Execution                            │
+│                                                              │
+│  - EntityService: entity operations                          │
+│  - TemporalService: time-series data recording              │
+│  - HTTP Client: Webhook invocation                           │
+│  - EventBridge: subscription notification delivery           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 処理フロー
+
+
+1. **エンティティ変更検出**
+   
+   * Lambda 上:`EntityService` は `EntityCreated/Updated/Deleted` を EventBridge に直接パブリッシュします。`RuleProcessorFunction` は EventBridgeRule によって呼び出され、`EntityChangeEvent` を構築します
+     
+   * ローカル / スタンドアロン上:`local-server.ts` は MongoDB Change Stream を追跡し、同じ `EntityChangeEvent` をプロセス内で構築します
+     
+   * レガシーの `ChangeStreamProcessorFunction` は依然として `publishEntityChangeEvent()` を呼び出して、変更ストリーム由来のイベントを同じ EventBridge ファンアウトに再パブリッシュするため、`RuleProcessorFunction`、`SubscriptionMatcherFunction`、`WsBroadcastFunction` はすべてこれらの再生イベントを受信して処理します(ルールとサブスクリプションは再評価されます)。これはもはや `RuleEngineService` を直接呼び出さないため、ルールパスは単一の EventBridge コンシューマーに統合されます (#1119)
+
+2\. **ルール評価**
+
+* テナントと servicePath のアクティブなルールを取得します
+  
+* 各ルールの条件(AND 結合)を評価します
+  
+* マッチしたルールを優先順位順にソートします
+
+3\. **アクション実行**
+
+* 各ルールのアクションを順次実行します
+  
+* テンプレート変数を実際の値で置換します
+  
+* エラーが発生しても、他のアクションは実行を継続します
+
+***
+
+## ルール構造
+
+### ルールインターフェース
+
+```typescript
+interface Rule {
+  ruleId: string;           // Unique identifier for the rule
+  name: string;             // Rule name
+  description?: string;     // Description
+  tenantId: string | null;  // Tenant ID (null = applies to all tenants)
+  servicePath: string;      // Service path (e.g., "/sensors")
+  conditions: RuleConditionUnion[];  // Array of conditions (AND-joined)
+  actions: RuleActionUnion[];        // Array of actions (executed sequentially)
+  isActive: boolean;        // Enabled/disabled
+  priority: number;         // Priority (lower value = higher priority)
+  cooldownSeconds?: number; // Cooldown period (seconds) - prevents infinite loops
+  createdAt: Date;
+  updatedAt: Date;
+}
+```
+
+### 基本的なルールの例
+
+```json
+{
+  "name": "High Temperature Warning",
+  "description": "Add a warning attribute when temperature exceeds 30 degrees",
+  "servicePath": "/sensors",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alert",
+      "value": "HIGH_TEMPERATURE"
+    }
+  ],
+  "isActive": true,
+  "priority": 10
+}
+```
+
+***
+
+## 条件
+
+条件は、ルールが一致するかどうかを決定します。複数の条件は AND で結合されます。
+
+### 条件タイプ
+
+| Type            | Description                                   | Use Case                                         |
+| --------------- | --------------------------------------------- | ------------------------------------------------ |
+| `value`         | Attribute value comparison                    | `temperature > 30`                               |
+| `pattern`       | Regular expression match                      | `name matches "Sensor.*"`                        |
+| `change`        | Whether an attribute has changed              | `temperature was updated`                        |
+| `time`          | Time range check                              | `09:00 to 18:00`                                 |
+| `entityType`    | Entity type                                   | `["Sensor", "Actuator"]`                         |
+| `eventType`     | Trigger event type (CREATE / UPDATE / DELETE) | `["create"]`, `["create", "delete"]`             |
+| `celExpression` | CEL expression                                | Complex calculations, multi-attribute evaluation |
+| `and`           | Logical AND                                   | All conditions are true                          |
+| `or`            | Logical OR                                    | At least one condition is true                   |
+| `not`           | Logical NOT                                   | Condition is false                               |
+
+### 1. Value Condition
+
+属性の値を比較します。エンティティ属性名に加えて、エンティティレベルのフィールド `"id"` および `"type"` も `attributeName` に指定できます。
+
+```typescript
+interface ValueCondition {
+  type: 'value';
+  attributeName: string;  // Attribute name, or "id" / "type"
+  operator: '==' | '!=' | '>' | '<' | '>=' | '<=';
+  value: string | number | boolean;
+}
+```
+
+**例**:
+
+```json
+{
+  "type": "value",
+  "attributeName": "temperature",
+  "operator": ">",
+  "value": 30
+}
+```
+
+エンティティ ID でフィルタリングする例:
+
+```json
+{
+  "type": "value",
+  "attributeName": "id",
+  "operator": "==",
+  "value": "urn:ngsi-ld:Sensor:001"
+}
+```
+
+### 2. Pattern Condition
+
+属性値を正規表現と照合します。エンティティ属性名に加えて、エンティティレベルのフィールド `"id"` および `"type"` も `attributeName` に指定できます。
+
+```typescript
+interface PatternCondition {
+  type: 'pattern';
+  attributeName: string;  // Attribute name, or "id" / "type"
+  pattern: string;  // Regular expression pattern
+}
+```
+
+**例**:
+
+```json
+{
+  "type": "pattern",
+  "attributeName": "name",
+  "pattern": "^Sensor.*"
+}
+```
+
+パターンでエンティティ ID をフィルタリングする例:
+
+```json
+{
+  "type": "pattern",
+  "attributeName": "id",
+  "pattern": "urn:ngsi-ld:WaterLevelSensor:.*"
+}
+```
+
+### 3. Change Condition
+
+特定の属性が変更されたかどうかをチェックします。
+
+```typescript
+interface ChangeCondition {
+  type: 'change';
+  attributeName: string;
+}
+```
+
+**例**:
+
+```json
+{
+  "type": "change",
+  "attributeName": "status"
+}
+```
+
+### 4. Time Condition
+
+現在の時刻が指定された範囲内にあるかどうかをチェックします。
+
+```typescript
+interface TimeCondition {
+  type: 'time';
+  startTime?: string;  // "HH:mm" format
+  endTime?: string;    // "HH:mm" format
+  timezone?: string;   // IANA timezone (e.g., "Asia/Tokyo")
+}
+```
+
+**例**:
+
+```json
+{
+  "type": "time",
+  "startTime": "09:00",
+  "endTime": "18:00",
+  "timezone": "Asia/Tokyo"
+}
+```
+
+### 5. Entity Type Condition
+
+エンティティタイプをチェックします。
+
+```typescript
+interface EntityTypeCondition {
+  type: 'entityType';
+  entityTypes: string[];  // List of matching types
+}
+```
+
+**例**:
+
+```json
+{
+  "type": "entityType",
+  "entityTypes": ["TemperatureSensor", "HumiditySensor"]
+}
+```
+
+### 6. Event Type Condition
+
+変更を生成したトリガーイベントでフィルタリングします。内部イベント名 (`EntityCreated` / `EntityUpdated` / `EntityDeleted`) を小文字のトークン `create` / `update` / `delete` にマップします。
+
+```typescript
+interface EventTypeCondition {
+  type: 'eventType';
+  eventTypes: Array<'create' | 'update' | 'delete'>;
+}
+```
+
+**ユースケース**:
+
+
+* エンティティ作成時のみアクションを実行する (例: `GeoJSON` が作成されたときにのみ `ActivityLog` を書き込む)
+  
+* 削除時のみクリーンアップを実行する
+  
+* 更新によって引き起こされるカスケード書き込みをスキップする
+
+**例**:
+
+作成のみ:
+
+```json
+{
+  "type": "eventType",
+  "eventTypes": ["create"]
+}
+```
+
+作成または削除 (更新を除外):
+
+```json
+{
+  "type": "eventType",
+  "eventTypes": ["create", "delete"]
+}
+```
+
+`entityType` と組み合わせて特定のタイプにスコープを設定:
+
+```json
+{
+  "type": "and",
+  "conditions": [
+    { "type": "eventType",  "eventTypes": ["create"] },
+    { "type": "entityType", "entityTypes": ["GeoJSON"] }
+  ]
+}
+```
+
+> **注**: UPDATE イベントの属性レベルフィルタリングには、`change` と組み合わせて使用します (例: `{type: "change", attributeName: "status"}`)。CREATE / DELETE では、`changedAttributes` が undefined であるため、`change` は常に false と評価されます。
+
+### 7. CEL Expression Condition
+
+[Common Expression Language (CEL)](https://github.com/google/cel-spec) を使用した柔軟な条件式です。複雑な計算、文字列操作、および複数の属性の組み合わせ評価をサポートします。
+
+```typescript
+interface CelExpressionCondition {
+  type: 'celExpression';
+  expression: string;  // CEL expression (max 1000 characters)
+}
+```
+
+#### CEL コンテキスト変数
+
+| Variable                          | Description                | Example                                            |
+| --------------------------------- | -------------------------- | -------------------------------------------------- |
+| `entity.id`                       | Entity ID                  | `"urn:ngsi-ld:Device:001"`                         |
+| `entity.type`                     | Entity type                | `"Device"`                                         |
+| `attribute.<name>.value`          | Current attribute value    | `attribute.temperature.value` → `35`               |
+| `attribute.<name>.type`           | Current attribute type     | `attribute.temperature.type` → `"Number"`          |
+| `previous.attribute.<name>.value` | Pre-change attribute value | `previous.attribute.temperature.value` → `25`      |
+| `previous.attribute.<name>.type`  | Pre-change attribute type  | `previous.attribute.temperature.type` → `"Number"` |
+
+イベントタイプ別の `previous` セマンティクス:
+
+| Event           | `previous.attribute`             |
+| --------------- | -------------------------------- |
+| `EntityCreated` | Empty object — no previous state |
+| `EntityUpdated` | Pre-update attributes snapshot   |
+| `EntityDeleted` | Final attributes before deletion |
+
+> **ヒント — `has()` でガードする**: 属性が以前の状態に存在しない可能性がある場合(例: `EntityCreated` の場合、または新しく追加された属性の場合)、アクセスを `has()` でラップします:
+>
+> ```text
+> has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30
+> ```
+>
+> 欠損キーに対して `has()` なしで直接アクセスすると評価エラーが発生し、これはキャッチされて `false` として扱われます。
+
+#### 例
+
+**属性値の比較:**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "attribute.temperature.value > 30"
+}
+```
+
+**複数の属性の組み合わせ:**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "attribute.temperature.value > 30 && attribute.status.value == \"active\""
+}
+```
+
+**不快指数の計算:**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 75"
+}
+```
+
+**エンティティ ID/タイプ条件:**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "entity.type == \"Device\" && entity.id.startsWith(\"urn:ngsi-ld:Device:\")"
+}
+```
+
+**しきい値の交差(値がしきい値を超えた瞬間のみ発火):**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "has(previous.attribute.temperature) && previous.attribute.temperature.value <= 30 && attribute.temperature.value > 30"
+}
+```
+
+冪等更新(同じ値の再書き込み)は、`previous.attribute.temperature.value` が既に > 30 であるため発火しません。
+
+**状態遷移(例: `draft` → `published`):**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "has(previous.attribute.status) && previous.attribute.status.value == \"draft\" && attribute.status.value == \"published\""
+}
+```
+
+**新しく追加された属性の検出:**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "!has(previous.attribute.description) && has(attribute.description)"
+}
+```
+
+**型変更の検出 (例: Text → Number):**
+
+```json
+{
+  "type": "celExpression",
+  "expression": "has(previous.attribute.reading) && previous.attribute.reading.type == \"Text\" && attribute.reading.type == \"Number\""
+}
+```
+
+#### カスタム関数
+
+以下のカスタム関数は CEL 式で使用できます。これらは IoT およびスマートシティのユースケースで一般的に必要とされる地理空間計算および時間ベースの条件評価をサポートします。
+
+##### `distance(location1, location2)` — 2 点間の距離 (メートル単位)
+
+Haversine 公式を使用した大圏距離の計算。入力は GeoJSON Point オブジェクト、出力はメートル (Number) です。
+
+```json
+{
+  "type": "celExpression",
+  "expression": "distance(attribute.location.value, {\"type\": \"Point\", \"coordinates\": [139.6503, 35.6762]}) < 1000"
+}
+```
+
+##### `within(location, polygon)` — ポイントインポリゴンチェック
+
+Ray casting アルゴリズムを使用したポイントインポリゴン判定。入力は GeoJSON Point と GeoJSON Polygon、出力は Boolean です。外側のリングのみがサポートされます (穴/内側のリングはサポートされていません)。外側のリングは閉じている必要があります (開始座標と終了座標が同じである必要があります)。
+
+```json
+{
+  "type": "celExpression",
+  "expression": "within(attribute.location.value, {\"type\": \"Polygon\", \"coordinates\": [[[139.6, 35.6], [139.8, 35.6], [139.8, 35.8], [139.6, 35.8], [139.6, 35.6]]]})"
+}
+```
+
+ジオフェンス退出を検出するには否定演算子を使用します:
+
+```json
+{
+  "type": "celExpression",
+  "expression": "!within(attribute.location.value, {\"type\": \"Polygon\", \"coordinates\": [[[139.6, 35.6], [139.8, 35.6], [139.8, 35.8], [139.6, 35.8], [139.6, 35.6]]]})"
+}
+```
+
+##### `now()` — 現在時刻 (ISO 8601 文字列)
+
+現在の UTC 時刻を ISO 8601 文字列として返します。
+
+```json
+{
+  "type": "celExpression",
+  "expression": "now() > attribute.createdAt.value"
+}
+```
+
+##### `dayOfWeek()` — 現在の曜日 (0-6、Sunday=0)
+
+UTC ベースの曜日を数値として返します (0=Sunday、1=Monday、...、6=Saturday)。
+
+```json
+{
+  "type": "celExpression",
+  "expression": "dayOfWeek() >= 1 && dayOfWeek() <= 5 && attribute.temperature.value > 30"
+}
+```
+
+##### 関数の組み合わせ
+
+カスタム関数は他の CEL 演算子やコンテキスト変数と自由に組み合わせることができます:
+
+```json
+{
+  "type": "celExpression",
+  "expression": "distance(attribute.location.value, {\"type\": \"Point\", \"coordinates\": [139.7671, 35.6812]}) < 5000 && dayOfWeek() >= 1 && dayOfWeek() <= 5"
+}
+```
+
+#### 制限事項
+
+
+* 式の最大長: 1000 文字
+  
+* CEL はチューリング不完全です (ループや再帰はありません) ため、無限ループのリスクはありません
+  
+* 式はブール値を返す必要があります (ブール値以外の結果は false として扱われます)
+  
+* 評価エラーが発生した場合、条件は false として扱われます (例外はスローされません)
+  
+* カスタム関数は既存の CEL 評価タイムアウト (100ms) 内で実行されます
+  
+* カスタム関数への無効な入力 (例: 無効な GeoJSON) はエラーとなり、条件は false として扱われます
+
+### 8. Logical Conditions
+
+#### AND 条件
+
+すべての子条件が真である場合に真となります。
+
+```json
+{
+  "type": "and",
+  "conditions": [
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    },
+    {
+      "type": "value",
+      "attributeName": "humidity",
+      "operator": "<",
+      "value": 40
+    }
+  ]
+}
+```
+
+#### OR 条件
+
+少なくとも 1 つの子条件が真である場合に真となります。
+
+```json
+{
+  "type": "or",
+  "conditions": [
+    {
+      "type": "value",
+      "attributeName": "status",
+      "operator": "==",
+      "value": "critical"
+    },
+    {
+      "type": "value",
+      "attributeName": "status",
+      "operator": "==",
+      "value": "error"
+    }
+  ]
+}
+```
+
+#### NOT 条件
+
+子条件が偽である場合に真となります。
+
+```json
+{
+  "type": "not",
+  "condition": {
+    "type": "value",
+    "attributeName": "enabled",
+    "operator": "==",
+    "value": false
+  }
+}
+```
+
+***
+
+## アクション
+
+条件が一致したときに実行される操作です。
+
+### アクションタイプ
+
+| Type               | Description                | Use Case                              |
+| ------------------ | -------------------------- | ------------------------------------- |
+| `createEntity`     | Create a new entity        | Generate derived entities             |
+| `updateAttribute`  | Update an attribute        | Add calculated results                |
+| `deleteAttribute`  | Delete an attribute        | Remove unnecessary attributes         |
+| `sendNotification` | Send a notification        | Notify via subscription               |
+| `webhook`          | Invoke a Webhook           | Integrate with external systems       |
+| `appendToTemporal` | Append to the Temporal API | Automatically record time-series data |
+
+### 1. Create Entity Action
+
+新しいエンティティを作成します。
+
+```typescript
+interface CreateEntityAction {
+  type: 'createEntity';
+  entityId: string;               // Supports template variables
+  entityType: string;             // Supports template variables
+  attributes: Record<string, unknown>;  // Supports template variables
+  protocol?: 'ngsiv2' | 'ngsild';  // Target protocol (default: inherit from trigger)
+  servicePath?: string;              // Target servicePath for ngsiv2 (supports template variables)
+  scope?: string[];                  // Target scope for ngsild (supports template variables)
+}
+```
+
+**例**: 温度センサーデータから集約エンティティを作成
+
+```json
+{
+  "type": "createEntity",
+  "entityId": "summary-${entity.id}",
+  "entityType": "TemperatureSummary",
+  "attributes": {
+    "sensorId": "${entity.id}",
+    "currentTemperature": "${attribute.temperature.value}",
+    "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+  }
+}
+```
+
+**例**: クロスプロトコル — NGSIv2 センサーから NGSI-LD アラートを作成
+
+```json
+{
+  "type": "createEntity",
+  "entityId": "urn:ngsi-ld:Alert:${entity.id}",
+  "entityType": "Alert",
+  "protocol": "ngsild",
+  "scope": ["${trigger.servicePath}"],
+  "attributes": {
+    "severity": { "type": "Property", "value": "high" },
+    "source": { "type": "Relationship", "value": "${entity.id}" }
+  }
+}
+```
+
+### 2. Update Attribute Action
+
+既存のエンティティの属性を更新します。
+
+```typescript
+interface UpdateAttributeAction {
+  type: 'updateAttribute';
+  entityId: string;        // Supports template variables
+  attributeName: string;
+  value: unknown;          // Supports template variables
+  protocol?: 'ngsiv2' | 'ngsild';  // Target protocol (default: inherit from trigger)
+}
+```
+
+**例**: 高温警告フラグを追加
+
+```json
+{
+  "type": "updateAttribute",
+  "entityId": "${entity.id}",
+  "attributeName": "highTemperatureAlert",
+  "value": true
+}
+```
+
+### 3. Delete Attribute Action
+
+エンティティから属性を削除します。
+
+```typescript
+interface DeleteAttributeAction {
+  type: 'deleteAttribute';
+  entityId: string;        // Supports template variables
+  attributeName: string;
+  protocol?: 'ngsiv2' | 'ngsild';  // Target protocol (default: inherit from trigger)
+}
+```
+
+**例**: 警告フラグを削除
+
+```json
+{
+  "type": "deleteAttribute",
+  "entityId": "${entity.id}",
+  "attributeName": "highTemperatureAlert"
+}
+```
+
+### 4. Send Notification Action
+
+サブスクリプション経由で通知を送信します。指定されたサブスクリプションの通知エンドポイントにカスタムデータを送信できます。
+
+#### インターフェース
+
+```typescript
+interface SendNotificationAction {
+  type: 'sendNotification';
+  subscriptionId?: string;        // Single subscription ID
+  subscriptionIds?: string[];     // Multiple subscription IDs
+  message?: string;               // Optional message
+  notificationData?: Record<string, unknown>;  // Custom data
+}
+```
+
+**注:** `subscriptionId` または `subscriptionIds` の少なくとも一方を指定する必要があります。
+
+#### 例
+
+**単一のサブスクリプションへの通知:**
+
+```json
+{
+  "type": "sendNotification",
+  "subscriptionId": "urn:ngsi-ld:Subscription:sub001",
+  "message": "High temperature detected"
+}
+```
+
+**複数のサブスクリプションへの通知:**
+
+```json
+{
+  "type": "sendNotification",
+  "subscriptionIds": ["urn:ngsi-ld:Subscription:sub001", "urn:ngsi-ld:Subscription:sub002"],
+  "notificationData": {
+    "alertLevel": "high",
+    "sensorId": "${entity.id}",
+    "temperature": "${attribute.temperature.value}"
+  }
+}
+```
+
+#### テンプレート変数
+
+`notificationData` では以下のテンプレート変数を使用できます:
+
+* `${entity.id}` - Entity ID
+  
+* `${entity.type}` - Entity タイプ
+  
+* `${attribute.<name>.value}` - 属性値
+  
+* `${attribute.<name>.metadata.<metaName>.value}` - 属性メタデータ値
+
+#### 制限事項
+
+
+* カスタムデータのサイズは 200 KB 以下である必要があります (EventBridge の制限)
+  
+* 指定されたサブスクリプション ID は同じテナント内に存在する必要があります
+  
+* 存在しないサブスクリプション ID は警告ログと共にスキップされます
+
+### 5. Webhook Action
+
+外部 HTTP エンドポイントを呼び出します。
+
+```typescript
+interface WebhookAction {
+  type: 'webhook';
+  url: string;                        // Supports template variables
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  headers?: Record<string, string>;   // Supports template variables
+  body?: unknown;                     // Supports template variables
+}
+```
+
+**例**: 温度データを外部 API に送信
+
+```json
+{
+  "type": "webhook",
+  "url": "https://api.example.com/temperature-alerts",
+  "method": "POST",
+  "headers": {
+    "Authorization": "Bearer token123",
+    "Content-Type": "application/json"
+  },
+  "body": {
+    "sensorId": "${entity.id}",
+    "temperature": "${attribute.temperature.value}",
+    "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+  }
+}
+```
+
+### 6. Append to Temporal Action
+
+エンティティ属性データを Temporal API (時系列データベース) に自動的に追加します。内部的には `TemporalService.recordEntityChange()` を呼び出して、Time Series Collection にデータを記録します。
+
+#### インターフェース
+
+```typescript
+interface AppendToTemporalAction {
+  type: 'appendToTemporal';
+  attributes?: string[];  // List of attribute names to record (defaults to changedAttributes if omitted)
+}
+```
+
+#### 例
+
+**特定の属性のみを記録:**
+
+```json
+{
+  "type": "appendToTemporal",
+  "attributes": ["temperature", "humidity"]
+}
+```
+
+**変更された属性を自動的に記録 (attributes を省略):**
+
+```json
+{
+  "type": "appendToTemporal"
+}
+```
+
+#### 動作の詳細
+
+
+* `attributes` が指定されている場合:指定された属性のみが Temporal API に記録されます
+  
+* `attributes` が省略されている場合:エンティティ変更イベントからの `changedAttributes` (変更された属性) が記録されます
+  
+* 属性に `observedAt` メタデータがある場合、その値がタイムスタンプとして使用されます。それ以外の場合は現在時刻が使用されます
+  
+* データは Time Series Collection に追加されます (既存のデータは保持されます)
+
+#### 使用例
+
+
+1. **IoT センサーデータの自動アーカイブ**:温度と湿度のセンサー値が更新されるたびに、時系列データとして自動的に記録します
+   
+2. **閾値違反時のスナップショット記録**:特定の条件が満たされた場合にのみ時系列データを記録します (条件との組み合わせで使用)
+   
+3. **選択的な属性記録**:すべての属性ではなく、特定の属性のみを効率的に記録します
+
+***
+
+## プロトコル間エンティティ作成
+
+ルールエンジンは、プロトコル境界を越えたエンティティの作成をサポートします。例えば、NGSIv2 センサーの変更が NGSI-LD エンティティの作成をトリガーしたり、その逆も可能です。
+
+### 概要
+
+GeonicDB はプロトコルの分離を強制します。NGSIv2 エンティティは NGSIv2 API 経由でのみアクセス可能で、NGSI-LD エンティティは NGSI-LD API 経由でアクセス可能です。ルールエンジンは、アクションがトリガーエンティティのプロトコルとは異なるターゲット `protocol` を指定できるようにすることで、このギャップを埋めます。
+
+### プロトコル間のアクションフィールド
+
+| Field         | Actions                                        | Type                         | Default                  |
+| ------------- | ---------------------------------------------- | ---------------------------- | ------------------------ |
+| `protocol`    | createEntity, updateAttribute, deleteAttribute | `'ngsiv2' \| 'ngsild'` | Inherited from trigger   |
+| `servicePath` | createEntity                                   | `string`                     | Inherited or auto-mapped |
+| `scope`       | createEntity                                   | `string[]`                   | Inherited or auto-mapped |
+
+### 自動 servicePath ↔ scope マッピング
+
+プロトコルを越える際、階層システムは自動的にマッピングされます:
+
+| Direction              | Condition            | Mapping                  |
+| ---------------------- | -------------------- | ------------------------ |
+| NGSIv2 → NGSI-LD       | `servicePath != '/'` | `scope = [servicePath]`  |
+| NGSI-LD → NGSIv2       | `scope` has elements | `servicePath = scope[0]` |
+| Root servicePath `'/'` | (always)             | No scope generated       |
+
+アクションで明示的に `servicePath` または `scope` を指定すると、自動マッピングが上書きされます。テンプレート変数(`${trigger.servicePath}`、`${trigger.scope}`)は、カスタムマッピングロジックに使用できます。
+
+### 例: NGSIv2 センサー → NGSI-LD アラート
+
+```json
+{
+  "name": "Cross-protocol temperature alert",
+  "conditions": [
+    { "type": "entityType", "entityTypes": ["TemperatureSensor"] },
+    { "type": "value", "attributeName": "temperature", "operator": ">", "value": 35 }
+  ],
+  "actions": [{
+    "type": "createEntity",
+    "protocol": "ngsild",
+    "entityId": "urn:ngsi-ld:Alert:heat-${entity.id}",
+    "entityType": "Alert",
+    "scope": ["${trigger.servicePath}"],
+    "attributes": {
+      "severity": { "type": "Property", "value": "high" },
+      "source": { "type": "Relationship", "value": "${entity.id}" },
+      "temperature": { "type": "Property", "value": "${attribute.temperature.value}" }
+    }
+  }]
+}
+```
+
+### 例: NGSI-LD エンティティ → NGSIv2 ミラー
+
+```json
+{
+  "name": "NGSI-LD to NGSIv2 mirror",
+  "conditions": [
+    { "type": "entityType", "entityTypes": ["Device"] }
+  ],
+  "actions": [{
+    "type": "createEntity",
+    "protocol": "ngsiv2",
+    "entityId": "v2-${entity.id}",
+    "entityType": "DeviceMirror",
+    "attributes": {
+      "source": "${entity.id}",
+      "status": "mirrored"
+    }
+  }]
+}
+```
+
+### 制限事項
+
+
+* **複数のスコープ**: scope → servicePath のマッピング時には、servicePath が単一の文字列であるため、最初の要素(`scope[0]`)のみが使用されます
+  
+* **ルート servicePath**: `'/'` は scope にマッピングされません(NGSI-LD では意味的な意味を持ちません)
+  
+* **後方互換性**: `protocol` が省略された場合、アクションはトリガーエンティティのプロトコルを継承します(既存の動作)
+
+***
+
+## テンプレート変数
+
+動的変数をアクション値に埋め込むことができます。
+
+### 構文
+
+`${path.to.value}` の形式で記述します。
+
+### 利用可能なパス
+
+| Path                                       | Description                         | Example                                                      |
+| ------------------------------------------ | ----------------------------------- | ------------------------------------------------------------ |
+| `${entity.id}`                             | Entity ID                           | `"Sensor001"`                                                |
+| `${entity.type}`                           | Entity type                         | `"TemperatureSensor"`                                        |
+| `${attribute.<name>.value}`                | Attribute value                     | `${attribute.temperature.value}` → `25.5`                    |
+| `${attribute.<name>.type}`                 | Attribute type                      | `${attribute.temperature.type}` → `"Number"`                 |
+| `${attribute.<name>.metadata.<key>.value}` | Metadata value                      | `${attribute.temperature.metadata.unit.value}` → `"Celsius"` |
+| `${trigger.protocol}`                      | Trigger entity's protocol           | `"ngsiv2"` or `"ngsild"`                                     |
+| `${trigger.servicePath}`                   | Trigger entity's servicePath        | `"/Madrid/Sensors"`                                          |
+| `${trigger.scope}`                         | Trigger entity's scope array (JSON) | `["/Madrid/Sensors"]`                                        |
+| `${trigger.service}`                       | Trigger entity's tenant service     | `"smartcity"`                                                |
+
+### 例
+
+#### 派生エンティティ ID の生成
+
+```json
+{
+  "entityId": "summary-${entity.id}"
+}
+```
+
+`entity.id` が `"Sensor001"` の場合、これは `"summary-Sensor001"` になります。
+
+#### 属性値のコピー
+
+```json
+{
+  "attributes": {
+    "originalTemperature": "${attribute.temperature.value}",
+    "sensor": "${entity.id}"
+  }
+}
+```
+
+#### 動的 Webhook URL
+
+```json
+{
+  "url": "https://api.example.com/sensors/${entity.id}/alerts"
+}
+```
+
+### テンプレート関数
+
+パス解決に加えて、アクションテンプレートは `${name(args)}` の形式で純粋関数の小さなホワイトリストを呼び出すことができます。サーバーのウォールクロック時刻をスタンプしたり、派生エンティティで一意の ID を生成したりするのに便利です(例:追記専用の `ActivityLog` レコード)。
+
+| Function                     | Returns                                | Example                                  |
+| ---------------------------- | -------------------------------------- | ---------------------------------------- |
+| `${now()}` / `${now('iso')}` | ISO 8601 timestamp (ms precision, UTC) | `"2026-05-02T01:23:45.678Z"`             |
+| `${now('unix')}`             | UNIX timestamp in seconds              | `"1746148225"`                           |
+| `${now('unix-ms')}`          | UNIX timestamp in milliseconds         | `"1746148225678"`                        |
+| `${uuid()}`                  | RFC 4122 v4 UUID                       | `"6f1c43b8-7c5e-4f12-9a2b-2d3a4f5c6e7d"` |
+
+**注意事項**
+
+
+* 関数は**ルール発火ごと**に評価されます — すべてのイベントが新しい値を作成するため、`${uuid()}` は派生エンティティごとに本当に一意であり、`${now()}` はルール登録時ではなく評価の瞬間を反映します。
+  
+* 引数パーサーは、単純なカンマ区切りのリテラル文字列(`'iso'`、`"unix"`)のみを処理します。ネストされた式、数値演算、および `${now(entity.id)}` などの参照はサポートされていません — それらは代わりに CEL `celExpression` 条件で計算し、結果をエンティティ属性として公開してください。
+  
+* 不明な関数名とサポートされていない引数値は、プレースホルダーテキストをそのまま残します(例:`${notAFunction()}` はリテラルのまま)。ルール作成者がタイプミスを修正できるように警告がログに記録されます。
+  
+* パス解決と関数呼び出しは共存します:`https://example.com/log?id=${uuid()}&entity=${entity.id}` は期待通りに動作します。
+
+#### 追記専用 ActivityLog の例
+
+```json
+{
+  "type": "createEntity",
+  "entityId": "urn:ngsi-ld:ActivityLog:${uuid()}",
+  "entityType": "ActivityLog",
+  "attributes": {
+    "target": "${entity.id}",
+    "action": "create",
+    "createdAt": "${now()}"
+  }
+}
+```
+
+すべてのエンティティ作成イベントは新しい `ActivityLog` インスタンスを生成します — entityId の衝突やクールダウンの競合はありません。
+
+***
+
+## Rules API
+
+### ルール一覧
+
+```http
+GET /rules
+Authorization: Bearer <accessToken>
+```
+
+**認可**: XACML ポリシーベース (`tenant_admin` ロールが必要。`AUTH_ENABLED=true` の場合、`super_admin` は `/rules*` エンドポイントにアクセスできません)
+
+**クエリパラメータ**
+
+| Parameter     | Description                                           |
+| ------------- | ----------------------------------------------------- |
+| `limit`       | Number of results to retrieve (default: 20, max: 100) |
+| `offset`      | Offset (default: 0)                                   |
+| `servicePath` | Filter by service path                                |
+| `isActive`    | Filter by enabled/disabled (`true` / `false`)         |
+
+**レスポンス**: `200 OK`
+
+```json
+[
+  {
+    "ruleId": "high-temperature-alert",
+    "name": "High Temperature Warning",
+    "description": "Add a warning attribute when temperature exceeds 30 degrees",
+    "tenantId": "smartcity",
+    "servicePath": "/sensors",
+    "conditions": [...],
+    "actions": [...],
+    "isActive": true,
+    "priority": 10,
+    "createdAt": "2026-02-10T00:00:00.000Z",
+    "updatedAt": "2026-02-10T00:00:00.000Z"
+  }
+]
+```
+
+**レスポンスヘッダー**
+
+
+* `X-Total-Count`: 結果の総数
+  
+* `Link`: ページネーションリンク
+
+### ルール作成
+
+```http
+POST /rules
+Authorization: Bearer <accessToken>
+Content-Type: application/json
+```
+
+**リクエストボディ**
+
+```json
+{
+  "ruleId": "high-temperature-alert",
+  "name": "High Temperature Warning",
+  "description": "Add a warning attribute when temperature exceeds 30 degrees",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alert",
+      "value": "HIGH_TEMPERATURE"
+    }
+  ],
+  "priority": 10
+}
+```
+
+**レスポンス**: `201 Created`
+
+### ルール取得
+
+```http
+GET /rules/:ruleId
+Authorization: Bearer <accessToken>
+```
+
+**レスポンス**: `200 OK` / `404 Not Found`
+
+### ルールの更新
+
+```http
+PATCH /rules/:ruleId
+Authorization: Bearer <accessToken>
+Content-Type: application/json
+```
+
+**リクエストボディ**
+
+```json
+{
+  "name": "Updated rule name",
+  "description": "Updated description",
+  "conditions": [...],
+  "actions": [...],
+  "priority": 5
+}
+```
+
+**レスポンス**: `204 No Content` / `404 Not Found`
+
+### ルールの削除
+
+```http
+DELETE /rules/:ruleId
+Authorization: Bearer <accessToken>
+```
+
+**レスポンス**: `204 No Content` / `404 Not Found`
+
+### ルールの有効化/無効化
+
+```http
+POST /rules/:ruleId/activate
+POST /rules/:ruleId/deactivate
+Authorization: Bearer <accessToken>
+```
+
+**レスポンス**: `200 OK` / `404 Not Found`
+
+***
+
+## 例
+
+### 例 1: 高温アラート
+
+温度が 30 度を超えた場合、自動的に警告属性を追加します。
+
+```json
+{
+  "ruleId": "high-temperature-alert",
+  "name": "High Temperature Alert",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alert",
+      "value": "HIGH_TEMPERATURE"
+    },
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "alertTimestamp",
+      "value": "${attribute.temperature.metadata.timestamp.value}"
+    }
+  ],
+  "priority": 10
+}
+```
+
+### 例 2: 営業時間外の自動ステータス更新
+
+営業時間外(18:00 から 09:00)に自動的にステータスを "closed" に設定します。
+
+```json
+{
+  "ruleId": "after-hours-status",
+  "name": "After-Hours Status",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["Store"]
+    },
+    {
+      "type": "or",
+      "conditions": [
+        {
+          "type": "time",
+          "startTime": "18:00",
+          "endTime": "23:59",
+          "timezone": "Asia/Tokyo"
+        },
+        {
+          "type": "time",
+          "startTime": "00:00",
+          "endTime": "09:00",
+          "timezone": "Asia/Tokyo"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "status",
+      "value": "closed"
+    }
+  ],
+  "priority": 5
+}
+```
+
+### 例 3: 派生エンティティの自動生成
+
+センサーデータから日次サマリーエンティティを自動的に生成します。
+
+```json
+{
+  "ruleId": "daily-summary",
+  "name": "Daily Summary Generation",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "change",
+      "attributeName": "temperature"
+    }
+  ],
+  "actions": [
+    {
+      "type": "createEntity",
+      "entityId": "summary-${entity.id}",
+      "entityType": "DailySummary",
+      "attributes": {
+        "sensorId": "${entity.id}",
+        "sensorType": "${entity.type}",
+        "currentTemperature": "${attribute.temperature.value}",
+        "unit": "${attribute.temperature.metadata.unit.value}",
+        "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+      }
+    }
+  ],
+  "priority": 20
+}
+```
+
+### 例 4: 外部 API への Webhook 通知
+
+温度変化を外部監視システムに通知します。
+
+```json
+{
+  "ruleId": "external-monitoring",
+  "name": "External Monitoring Notification",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "change",
+      "attributeName": "temperature"
+    }
+  ],
+  "actions": [
+    {
+      "type": "webhook",
+      "url": "https://monitoring.example.com/api/sensors/${entity.id}/events",
+      "method": "POST",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_TOKEN",
+        "X-Sensor-Type": "${entity.type}"
+      },
+      "body": {
+        "event": "temperature_change",
+        "sensorId": "${entity.id}",
+        "temperature": "${attribute.temperature.value}",
+        "unit": "celsius",
+        "timestamp": "${attribute.temperature.metadata.timestamp.value}"
+      }
+    }
+  ],
+  "priority": 15
+}
+```
+
+### 例 5: 複雑な条件 (AND + OR)
+
+温度が 30 度以上で、かつ湿度が 80% 以上、または時間が 12:00 から 15:00 の間である場合に警告を発行します。
+
+```json
+{
+  "ruleId": "complex-alert",
+  "name": "Complex Condition Alert",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["WeatherStation"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">=",
+      "value": 30
+    },
+    {
+      "type": "or",
+      "conditions": [
+        {
+          "type": "value",
+          "attributeName": "humidity",
+          "operator": ">=",
+          "value": 80
+        },
+        {
+          "type": "time",
+          "startTime": "12:00",
+          "endTime": "15:00",
+          "timezone": "Asia/Tokyo"
+        }
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "heatIndexAlert",
+      "value": "EXTREME"
+    }
+  ],
+  "priority": 5
+}
+```
+
+### 例 6: 不快指数による熱中症アラート通知 (CEL 式 + 通知)
+
+温度と湿度から **不快指数** をリアルタイムで評価し、閾値を超えた際にサブスクリプション経由で通知を送信する実用的な例です。
+
+**不快指数の計算式:**
+
+```text
+DI = 0.81 × T + 0.01 × H × (0.99 × T − 14.3) + 46.3
+```
+
+
+* T: 温度 (°C)
+  
+* H: 相対湿度 (%)
+
+**不快指数の参考レベル:**
+
+| Discomfort Index | Perceived sensation                |
+| ---------------- | ---------------------------------- |
+| \~55             | Cold                               |
+| 55\~60           | Chilly                             |
+| 60\~65           | No particular sensation            |
+| 65\~70           | Comfortable                        |
+| 70\~75           | Not hot                            |
+| **75\~80**       | **Somewhat hot** ← Alert threshold |
+| 80\~85           | Hot with perspiration              |
+| 85\~             | Unbearably hot                     |
+
+#### ステップ 1: 通知サブスクリプションを作成する
+
+まず、アラート通知を受信するためのサブスクリプションを作成します。
+
+```bash
+# Create an NGSIv2 subscription
+curl -X POST "http://localhost:3000/v2/subscriptions" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -H "Authorization: Bearer <accessToken>" \
+  -d '{
+    "description": "Discomfort index alert notification",
+    "subject": {
+      "entities": [
+        { "idPattern": ".*", "type": "WeatherStation" }
+      ],
+      "condition": {
+        "attrs": ["temperature", "humidity"]
+      }
+    },
+    "notification": {
+      "http": {
+        "url": "https://alerts.example.com/discomfort-index"
+      },
+      "attrs": ["temperature", "humidity", "discomfortLevel"]
+    }
+  }'
+```
+
+レスポンスの `Location` ヘッダーからサブスクリプション ID を取得します (例: `urn:ngsi-ld:Subscription:abc123`)。
+
+#### ステップ 2: 不快指数アラートルールを作成する
+
+CEL 式を使用して不快指数を計算し、75 を超えた際にアクションを実行するルールを作成します。
+
+```bash
+curl -X POST "http://localhost:3000/rules" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -H "Authorization: Bearer <accessToken>" \
+  -d '{
+    "ruleId": "discomfort-index-alert",
+    "name": "Discomfort Index Alert",
+    "description": "Set a warning level and send a notification when the discomfort index exceeds 75",
+    "conditions": [
+      {
+        "type": "entityType",
+        "entityTypes": ["WeatherStation"]
+      },
+      {
+        "type": "or",
+        "conditions": [
+          { "type": "change", "attributeName": "temperature" },
+          { "type": "change", "attributeName": "humidity" }
+        ]
+      },
+      {
+        "type": "celExpression",
+        "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 75"
+      }
+    ],
+    "actions": [
+      {
+        "type": "updateAttribute",
+        "entityId": "${entity.id}",
+        "attributeName": "discomfortLevel",
+        "value": "WARNING"
+      },
+      {
+        "type": "sendNotification",
+        "subscriptionId": "urn:ngsi-ld:Subscription:abc123",
+        "message": "Discomfort index has exceeded the threshold",
+        "notificationData": {
+          "alertType": "DISCOMFORT_INDEX",
+          "stationId": "${entity.id}",
+          "temperature": "${attribute.temperature.value}",
+          "humidity": "${attribute.humidity.value}",
+          "level": "WARNING"
+        }
+      }
+    ],
+    "priority": 10,
+    "cooldownSeconds": 600
+  }'
+```
+
+**このルールの要点:**
+
+
+* **条件 1 (entityType)**: `WeatherStation` 型のエンティティのみを対象とする
+  
+* **条件 2 (or + change)**: `temperature` または `humidity` が変更されたときのみ評価する(不要な再評価を回避)
+  
+* **条件 3 (celExpression)**: 不快指数の計算式を CEL で直接記述し、75 を超えるかどうかをチェックする
+  
+* **アクション 1 (updateAttribute)**: エンティティに `discomfortLevel` 属性を追加する
+  
+* **アクション 2 (sendNotification)**: サブスクリプション経由でアラート通知を送信する
+  
+* **cooldownSeconds: 600**: 10 分間のクールダウンにより、過剰な通知配信を防止する
+
+#### ステップ 3: 危険レベル (DI > 80) の Webhook 通知ルールを追加する
+
+不快指数がさらに高い場合に Webhook 経由で緊急通知を送信する追加のルールを作成します。
+
+```json
+{
+  "ruleId": "discomfort-index-danger",
+  "name": "Discomfort Index Danger Alert",
+  "description": "Send an emergency notification when the discomfort index exceeds 80",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["WeatherStation"]
+    },
+    {
+      "type": "celExpression",
+      "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 80"
+    }
+  ],
+  "actions": [
+    {
+      "type": "updateAttribute",
+      "entityId": "${entity.id}",
+      "attributeName": "discomfortLevel",
+      "value": "DANGER"
+    },
+    {
+      "type": "webhook",
+      "url": "https://api.example.com/emergency/heatstroke-alert",
+      "method": "POST",
+      "headers": {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer YOUR_API_TOKEN"
+      },
+      "body": {
+        "severity": "DANGER",
+        "stationId": "${entity.id}",
+        "stationType": "${entity.type}",
+        "temperature": "${attribute.temperature.value}",
+        "humidity": "${attribute.humidity.value}",
+        "message": "Heat stroke danger level: Temperature ${attribute.temperature.value}°C, Humidity ${attribute.humidity.value}%"
+      }
+    }
+  ],
+  "priority": 5,
+  "cooldownSeconds": 300
+}
+```
+
+**注意:** このルールは `priority: 5` を持ち、Example 6 の `priority: 10` より高い優先度です。したがって、DI > 80 の場合、まず `DANGER` が設定され、その後の `WARNING` 更新で上書きされないように注意する必要があります。同じエンティティに対して両方のルールが一致する場合、優先度の昇順で実行されるため、順序は `DANGER` → `WARNING` となります。これを回避するには、WARNING ルールの CEL 式に上限条件を追加します:
+
+```json
+{
+  "type": "celExpression",
+  "expression": "0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 > 75 && 0.81 * attribute.temperature.value + 0.01 * attribute.humidity.value * (0.99 * attribute.temperature.value - 14.3) + 46.3 <= 80"
+}
+```
+
+#### ステップ 4: 動作を確認する
+
+```bash
+# Temperature 27°C, Humidity 75% → Discomfort index ≈ 77.5 (WARNING)
+curl -X POST "http://localhost:3000/v2/entities" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "id": "urn:ngsi-ld:WeatherStation:shibuya-001",
+    "type": "WeatherStation",
+    "temperature": { "value": 27, "type": "Number" },
+    "humidity": { "value": 75, "type": "Number" },
+    "location": { "value": "35.6595,139.7004", "type": "Text" }
+  }'
+
+# Verify that discomfortLevel was automatically added
+curl -s "http://localhost:3000/v2/entities/urn:ngsi-ld:WeatherStation:shibuya-001" \
+  -H "Fiware-Service: smartcity" | jq '.discomfortLevel'
+# → { "type": "Text", "value": "WARNING", "metadata": {} }
+
+# Update temperature to 33°C → Discomfort index ≈ 86.8 (DANGER)
+curl -X PATCH "http://localhost:3000/v2/entities/urn:ngsi-ld:WeatherStation:shibuya-001/attrs" \
+  -H "Content-Type: application/json" \
+  -H "Fiware-Service: smartcity" \
+  -d '{
+    "temperature": { "value": 33, "type": "Number" }
+  }'
+
+# Verify that discomfortLevel was updated to DANGER
+curl -s "http://localhost:3000/v2/entities/urn:ngsi-ld:WeatherStation:shibuya-001" \
+  -H "Fiware-Service: smartcity" | jq '.discomfortLevel'
+# → { "type": "Text", "value": "DANGER", "metadata": {} }
+```
+
+***
+
+## 無限ループの防止
+
+ReactiveCore Rules は、ルールが無限ループに陥るのを防ぐために、複数の保護メカニズムを実装しています。
+
+### 1. Action Entity Type Exclusion (Self-Trigger Prevention)
+
+**制限**: ルールのアクションによって作成されるエンティティタイプは、同じルールのトリガーターゲットから**自動的に除外**されます。
+
+**動作**:
+
+* ルールのアクション(`createEntity`)によって作成されるエンティティタイプを抽出
+  
+* 変更イベント内のエンティティタイプがアクションで指定されたタイプと一致する場合、そのルールの実行がブロックされます
+
+**例**:
+
+```json
+{
+  "ruleId": "sensor-alert-rule",
+  "name": "Temperature Sensor Warning",
+  "conditions": [
+    {
+      "type": "entityType",
+      "entityTypes": ["TemperatureSensor"]
+    },
+    {
+      "type": "value",
+      "attributeName": "temperature",
+      "operator": ">",
+      "value": 30
+    }
+  ],
+  "actions": [
+    {
+      "type": "createEntity",
+      "entityId": "Alert:${entity.id}",
+      "entityType": "Alert",  // ← Creates an Alert entity
+      "attributes": {
+        "severity": "high"
+      }
+    }
+  ]
+}
+```
+
+このルール:
+
+* ✅ `TemperatureSensor` エンティティの変更時に実行される
+  
+* ❌ `Alert` エンティティの変更時には実行されない(自己トリガー防止)
+
+**利点**:
+
+* ルールが作成したエンティティによってルール自身が再トリガーされることを防止
+  
+* 意図しない連鎖反応を自動的に防止
+  
+* 明示的な条件設定なしでループを回避
+
+### 2. Execution Counter (Per Entity, Per Time Window)
+
+**制限**: 単一のエンティティに対して、単一のルールは**1分間に最大 10回**まで実行できます。
+
+```typescript
+// Default configuration (src/config/defaults.ts)
+RULE_ENGINE.MAX_EXECUTIONS_PER_WINDOW = 10;  // Maximum executions
+RULE_ENGINE.EXECUTION_WINDOW_SECONDS = 60;   // Time window (seconds)
+```
+
+**動作**:
+
+* ルール毎、エンティティ毎の実行回数を追跡
+  
+* 時間ウィンドウ内で最大値に達した場合、それ以降の実行をブロック
+  
+* カウンターは時間ウィンドウの期限が切れると自動的にリセットされます
+
+### 3. Loop Detection (Circular Rule Chains)
+
+**制限**: ルール実行チェーンの深さは最大**5レベル**に制限されています。
+
+```typescript
+// Default configuration (src/config/defaults.ts)
+RULE_ENGINE.MAX_CHAIN_DEPTH = 5;
+```
+
+**動作**:
+
+* ルール A → エンティティ更新 → ルール B → エンティティ更新 → ルール C のようなチェーンを追跡
+  
+* 実行チェーン内で同じルールが 2回出現する場合(循環)、実行がブロックされます
+  
+* チェーンの深さが最大値を超えた場合、実行がブロックされます
+
+**例**:
+
+```text
+Rule A (temperature sensor) → creates Alert entity
+  → Rule B (Alert) → creates notification entity
+    → Rule C (notification) → creates log entity
+      → Rule D (log) → ... (OK: up to depth 5)
+        → Rule E (Alert) → triggers Rule B (NG: circular detected)
+```
+
+### 4. Cooldown Period
+
+各ルールに対して **最小実行間隔** を設定できます。
+
+```json
+{
+  "ruleId": "temperature-alert",
+  "name": "Temperature Alert",
+  "conditions": [ ... ],
+  "actions": [ ... ],
+  "cooldownSeconds": 300  // 5-minute cooldown
+}
+```
+
+**デフォルト値**: `cooldownSeconds` が指定されていない場合、デフォルトのクールダウンとして **60 秒** が適用されます。
+
+```typescript
+// Default configuration (src/config/defaults.ts)
+RULE_ENGINE.DEFAULT_COOLDOWN_SECONDS = 60;
+```
+
+**動作**:
+
+* ルールごとにエンティティごとの最終実行時刻を追跡
+  
+* クールダウン期間内の場合は実行をブロック
+  
+* クールダウン期間が経過すると再び実行が可能になります
+
+**使用例**:
+
+* 頻繁に変化するセンサーデータのアラート通知の制御
+  
+* 過度な Webhook 呼び出しの防止
+  
+* 外部システムへの負荷の軽減
+
+### ループ防止のベストプラクティス
+
+
+1. **エンティティタイプを明確に区別する**: アクションエンティティタイプ除外機能が自動的に適用されます
+
+   ```json
+   // Rule 1: Sensor → creates Alert entity
+   {
+     "conditions": [{"type": "entityType", "entityTypes": ["Sensor"]}],
+     "actions": [{"type": "createEntity", "entityType": "Alert", ...}]
+   }
+   // Changes to Alert entities will not trigger this rule (automatically excluded)
+   ```
+
+2\. **Change 条件を使用する**: 属性が実際に変更された場合にのみトリガーします
+
+```json
+{
+  "type": "change",
+  "attributeName": "temperature"
+}
+```
+
+3\. **cooldownSeconds を設定する**: 高頻度の実行が予想される場合は適切なクールダウンを設定します
+
+```json
+{
+  "cooldownSeconds": 300  // 5 minutes
+}
+```
+
+4\. **ルールの優先順位を適切に設定する**: 意図しない連鎖を防ぐために実行順序を制御します
+
+***
+
+## 制限事項
+
+### 現在の制限事項
+
+
+1. **トランザクションなし**: 複数のアクションの実行中にエラーが発生した場合、ロールバックは実行されません
+   
+2. **条件評価のパフォーマンス**: ルール数が多い場合、評価に時間がかかる可能性があります
+   
+3. **テンプレート変数の型チェックなし**: 実行時エラーが発生する可能性があります
+
+### パフォーマンスに関する考慮事項
+
+
+* ルール数が多い場合、エンティティ変更ごとの処理時間が増加します
+  
+* 不要なルールを無効化します(`isActive: false`)
+  
+* 実行順序を最適化するために優先度を適切に設定します
+  
+* 高頻度で変更されるエンティティに対してルールを設定する際は注意が必要です
+  
+* **ループ防止**: アクションエンティティタイプの除外、実行カウンター、ループ検出、クールダウン期間のメカニズムにより、無限ループは自動的に防止されます
+
+***
+
+## トラブルシューティング
+
+### ルールが実行されない
+
+**チェックリスト**:
+
+
+1. `RULES_ENABLED=true` が設定されていますか?
+   
+2. ルールが有効になっていますか (`isActive: true`)?
+   
+3. 条件が正しくマッチしていますか (特にエンティティタイプ)?
+   
+4. servicePath がマッチしていますか?
+   
+5. Change Stream Handler は実行されていますか?
+
+**デバッグ**:
+
+ログを確認してください。
+
+```bash
+# Search for RuleEngineService logs
+grep "RuleEngineService" /var/log/lambda.log
+```
+
+### テンプレート変数が展開されない
+
+**チェックリスト**:
+
+
+1. 変数のパスは正しいですか (例: `${entity.id}`、`${attribute.temperature.value}`)?
+   
+2. 参照している属性は存在しますか?
+   
+3. 大文字と小文字の違いに注意してください
+
+**例**:
+
+
+* ❌ `${Entity.ID}` → ✅ `${entity.id}`
+  
+* ❌ `${temperature.value}` → ✅ `${attribute.temperature.value}`
+
+### Webhook の失敗
+
+**チェックリスト**:
+
+
+1. URL は正しいですか?
+   
+2. 外部 API に到達可能ですか (ネットワーク、ファイアウォール)?
+   
+3. Authorization ヘッダーは正しいですか?
+   
+4. Content-Type は正しいですか?
+   
+5. リクエストボディのフォーマットは正しいですか?
+
+**デバッグ**:
+
+エラーメッセージのログを確認してください。
+
+```bash
+# Search for Webhook errors
+grep "Webhook execution failed" /var/log/lambda.log
+```
+
+### 無限ループ
+
+あるルールのアクションが別のルールの条件にマッチすると、無限ループが発生する可能性があります。
+
+**対策**:
+
+
+1. ルールの条件を慎重に設計する
+   
+2. `change` 条件を使用して、特定の属性の変更時のみトリガーする
+   
+3. エンティティタイプを分離する (例: 派生エンティティには異なるタイプを使用する)
+
+### アクション実行エラー
+
+**チェックリスト**:
+
+
+1. エンティティ ID は存在しますか (updateAttribute、deleteAttribute の場合)?
+   
+2. 属性名は正しいですか?
+   
+3. 値の型は正しいですか (例: 数値属性に文字列値を設定していないか)?
+   
+4. テナントと servicePath は正しいですか?
+
+***
+
+## 技術仕様 (GeonicDB Rule Specification v1.0)
+
+**ステータス**: ドラフト
+**バージョン**: 1.0.0
+**最終更新日**: 2026-02-10
+**著者**: GeonicDB Development Team
+
+### 概要
+
+本文書は、NGSI ベースのコンテキストブローカーにおけるエンティティ変更を処理するための GeonicDB Rule Engine フォーマットを規定します。本仕様は、Event-Condition-Action (ECA) パターンに従った JSON ベースのルールフォーマットを定義し、IoT およびスマートシティアプリケーション向けに最適化されています。
+
+### 1. はじめに
+
+#### 1.1 目的
+
+GeonicDB Rule Engine は、FIWARE 互換コンテキストブローカーにおけるエンティティ変更の自動処理を可能にします。ルールは、エンティティが作成、更新、または削除されたときにアクションをトリガーする条件を定義します。
+
+#### 1.2 設計原則
+
+
+* **JSON Format**: すべてのルールは標準 JSON を使用して定義されます
+  
+* **ECA Pattern**: リアクティブ処理のための Event-Condition-Action アーキテクチャ
+  
+* **NGSI-Aware**: NGSI エンティティ属性とメタデータのネイティブサポート
+  
+* **Composable**: 任意のネストを持つ論理演算子 (AND、OR、NOT) をサポートする条件
+  
+* **Type-Safe**: 条件とアクションのための判別共用体型
+  
+* **Template-Driven**: `${...}` 構文を使用した動的な値の置換
+
+#### 1.3 用語
+
+
+* **Rule**: 条件とアクションから成る完全な定義
+  
+* **Condition**: エンティティに対して真または偽に評価される述語
+  
+* **Action**: すべてのルール条件が満たされたときに実行される操作
+  
+* **Entity Change Event**: エンティティの作成、更新、または削除の通知
+  
+* **Template Variable**: 実行時のエンティティ値に解決されるプレースホルダー
+
+### 2. 適合性
+
+#### 2.1 適合性レベル
+
+実装は、REQUIRED とマークされたすべての機能を実装している場合、**適合** とみなされます。
+
+OPTIONAL とマークされた機能は、実装者の裁量で実装してもかまいません。
+
+#### 2.2 必須機能
+
+適合実装は、次のことを満たさなければなりません (MUST):
+
+
+1. セクション 4 で定義されたすべての条件タイプをサポートする
+   
+2. セクション 5 で定義されたすべてのアクションタイプをサポートする
+   
+3. セクション 6 で定義されたテンプレート変数の置換をサポートする
+   
+4. セクション 7 で定義されたループ防止メカニズムを実装する
+   
+5. ネストされた論理演算子の条件を再帰的に評価する
+   
+6. 指定された順序でアクションを順次実行する
+   
+7. セクション 8 の JSON Schema に対してルールを検証する
+
+#### 2.3 オプション機能
+
+適合実装は、次のことを行ってもかまいません (MAY):
+
+
+1. 追加のカスタム条件タイプをサポートする
+   
+2. 追加のカスタムアクションタイプをサポートする
+   
+3. 拡張されたテンプレート変数パスを提供する
+   
+4. カスタムループ防止戦略を実装する
+
+### 3. JSON Schema
+
+GeonicDB Rule Specification v1.0 の完全な JSON Schema は仕様書に記載されています。すべてのルールはこのスキーマに対して検証される必要があります (MUST)。
+
+主要な検証ルール:
+
+* `ruleId`、`name`、`tenantId`、`servicePath`、`conditions`、`actions`、`isActive`、および `priority` は必須フィールドです (REQUIRED)
+  
+* `conditions` 配列は少なくとも 1 つの条件を含む必要があります (MUST)
+  
+* `actions` 配列は少なくとも 1 つのアクションを含む必要があります (MUST)
+  
+* `cooldownSeconds` は指定する場合、正の整数である必要があります (MUST)
+  
+* `servicePath` は `/` で始まる必要があります (MUST)
+
+完全な JSON Schema 定義については、正式仕様書のセクション 8 を参照してください。
+
+### 4. Versioning
+
+#### 4.1 バージョン形式
+
+本仕様は Semantic Versioning 2.0.0 (<https://semver.org/>) に準拠します:
+
+
+* **MAJOR**: 互換性のない変更 (例: 条件/アクションタイプの削除)
+  
+* **MINOR**: 後方互換性のある追加 (例: 新しい条件/アクションタイプ)
+  
+* **PATCH**: 後方互換性のある修正 (例: 明確化、誤字修正)
+
+現在のバージョン: **1.0.0**
+
+#### 4.2 互換性
+
+ルールは `specVersion` フィールドを使用して準拠する仕様バージョンを宣言することができます (MAY):
+
+```json
+{
+  "specVersion": "1.0.0",
+  "ruleId": "...",
+  ...
+}
+```
+
+#### 4.3 非推奨ポリシー
+
+機能が非推奨となる場合:
+
+1. 機能はドキュメントで非推奨 (DEPRECATED) としてマークされます
+   
+2. 機能は少なくとも 1 つの MAJOR バージョンの間、動作し続けます
+   
+3. 非推奨警告はログに記録されるべきです (SHOULD)
+   
+4. 移行ガイドは提供される必要があります (MUST)
+
+### 参考文献
+
+
+* **FIWARE NGSI-v2 Specification**: <https://fiware.github.io/specifications/ngsiv2/stable/>
+  
+* **FIWARE NGSI-LD Specification**: <https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/>
+  
+* **JSON Schema Draft 7**: <http://json-schema.org/draft-07/schema#>
+  
+* **Semantic Versioning 2.0.0**: <https://semver.org/>
+  
+* **IANA Time Zone Database**: <https://www.iana.org/time-zones>
+  
+* **ECMAScript Regular Expressions**: <https://tc39.es/ecma262/#sec-regexp-regular-expression-objects>
+
+### 謝辞
+
+本仕様は Geolonia Inc. の GeonicDB チームによって開発されました。以下からインスピレーションを得ています:
+
+* FIWARE Complex Event Processing (Proton CEP)
+  
+* json-rules-engine (CacheControl)
+  
+* AWS EventBridge Rules
+  
+* Common Expression Language (CEL)
+
+**ライセンス**: GNU Affero General Public License v3.0 (AGPL-3.0)
+**著作権**: © 2026 Geolonia Inc.
+
+***
+
+## 関連ドキュメント
+
+
+* [API Common Specification](../api-reference/endpoints.md) - 一般的な API 仕様
+  
+* [Authentication & Authorization](../reference/auth.md) - 管理 API と認証要件の詳細
+  
+* [API Specification](../api-reference/endpoints.md) - すべてのエンドポイントの一覧
+  
+* Development Guide - HTTP ステータスコードの詳細

--- a/docs/ja/features/subscriptions.md
+++ b/docs/ja/features/subscriptions.md
@@ -5,20 +5,28 @@ outline: deep
 ---
 # WebSocket イベントストリーミング
 
-GeonicDB は WebSocket によるリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムで購読し、Web アプリケーションやダッシュボードに即座に反映できます。
+GeonicDB は WebSocket によるリアルタイムイベントストリーミングをサポートしています。エンティティの変更をリアルタイムでサブスクリプションライブし、Web アプリケーションやダッシュボードに即座に反映することができます。
 
 ## 目次
 
-- [概要](#概要)
-- [アーキテクチャと有効化](#アーキテクチャと有効化)
-- [接続](#接続)
-- [メッセージ形式とフィルタリング](#メッセージ形式とフィルタリング)
-- [クライアント実装](#クライアント実装)
-- [ベストプラクティス](#ベストプラクティス)
-- [トラブルシューティング](#トラブルシューティング)
-- [制約](#制約)
 
----
+* [概要](#概要)
+  
+* [アーキテクチャと有効化](#アーキテクチャと有効化)
+  
+* [接続](#接続)
+  
+* [メッセージフォーマットとフィルタリング](#message-format-and-filtering)
+  
+* [クライアント実装](#クライアント実装)
+  
+* [ベストプラクティス](#ベストプラクティス)
+  
+* [トラブルシューティング](#トラブルシューティング)
+  
+* [制約](#制約)
+
+***
 
 ## 概要
 
@@ -26,13 +34,13 @@ GeonicDB は WebSocket によるリアルタイムイベントストリーミン
 
 ### 通知チャネルの比較
 
-| チャネル | 方向 | フィルタリング | レイテンシ |
-|---------|-----------|-----------|---------|
-| HTTP Webhook (既存) | Push | サブスクリプション条件 | 約 1 分 |
-| MQTT (既存) | Push | サブスクリプション条件 | 約 1 分 |
-| WebSocket (本機能) | Push | テナント + エンティティタイプ/ID パターン | 約 1 分 |
+| Channel                  | Direction | Filtering                       | Latency |
+| ------------------------ | --------- | ------------------------------- | ------- |
+| HTTP Webhook (existing)  | Push      | Subscription conditions         | \~1 min |
+| MQTT (existing)          | Push      | Subscription conditions         | \~1 min |
+| WebSocket (this feature) | Push      | Tenant + entity type/ID pattern | \~1 min |
 
----
+***
 
 ## アーキテクチャと有効化
 
@@ -43,9 +51,12 @@ EventBridge ─┬─> SubscriptionMatcher -> SQS -> HTTP/MQTT  [existing]
              └─> WsBroadcastFunction -> API GW WebSocket -> client  [new]
 ```
 
-- **接続状態**: DynamoDB (PAY_PER_REQUEST、自動 TTL クリーンアップ)
-- **接続管理**: 3 つの Lambda 関数 (connect、disconnect、default)
-- **ブロードキャスト**: EventBridge から直接トリガーされる Lambda 関数
+
+* **接続状態**: DynamoDB (PAY\_PER\_REQUEST、自動 TTL クリーンアップ)
+  
+* **接続管理**: 3 つの Lambda 関数 (connect、disconnect、default)
+  
+* **ブロードキャスト**: EventBridge から直接トリガーされる Lambda 関数
 
 ### 有効化
 
@@ -53,13 +64,13 @@ GeonicDB SaaS ではイベントストリーミングは既定で有効です。
 
 ### 環境変数
 
-| 変数 | 説明 |
-|----------|-------------|
-| `EVENT_STREAMING_ENABLED` | `true` に設定して有効化 |
-| `WS_CONNECTIONS_TABLE` | DynamoDB 接続テーブル名 (自動設定) |
-| `WS_API_ENDPOINT` | WebSocket API エンドポイント (自動設定) |
+| Variable                  | Description                                       |
+| ------------------------- | ------------------------------------------------- |
+| `EVENT_STREAMING_ENABLED` | Enable by setting to `true`                       |
+| `WS_CONNECTIONS_TABLE`    | DynamoDB connections table name (auto-configured) |
+| `WS_API_ENDPOINT`         | WebSocket API endpoint (auto-configured)          |
 
----
+***
 
 ## 接続
 
@@ -77,44 +88,55 @@ ws://localhost:3000?tenant={tenantName}
 
 ### クエリパラメータ
 
-| パラメータ | 必須 | 説明 |
-|-----------|------|------|
-| `tenant` | ✅ | テナント名 (`Fiware-Service` ヘッダーと同等) |
+| Parameter | Required | Description                                             |
+| --------- | -------- | ------------------------------------------------------- |
+| `tenant`  | ✅        | Tenant name (equivalent to the `Fiware-Service` header) |
 
 ### 認証
 
-`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは次の優先順位で抽出されます:
+`AUTH_ENABLED=true` の場合、WebSocket 接続を確立するには認証トークンが必要です。トークンは以下の優先順位で抽出されます:
+
 
 1. **`Authorization` ヘッダー (推奨)**: `Authorization: Bearer <token>` — 最も安全な方法
-2. **`Sec-WebSocket-Protocol` ヘッダー (ブラウザ向け)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合に使用
+   
+2. **`Sec-WebSocket-Protocol` ヘッダー (ブラウザ用)**: `Sec-WebSocket-Protocol: access_token, <token>` — ブラウザクライアントが `Authorization` ヘッダーを設定できない場合はこれを使用します
 
-> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。これまで URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
+> **破壊的変更 (#1072)**: `?token=<token>` クエリパラメータは受け付けられなくなりました。URL はリバースプロキシ / WAF / ロードバランサーのアクセスログ、ブラウザ履歴、`Referer` ヘッダーに漏洩します。以前に URL 経由でトークンを渡していたクライアントは、上記の 2 つのヘッダー方式のいずれかに切り替える必要があります。
 
-- REST API `/auth/login` エンドポイントから取得した `accessToken` をトークンとして直接使用してください。
-- `super_admin` ロールは、WebSocket ストリーミングのために任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API (`/v2/*`、`/ngsi-ld/*`) にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
-- `tenant_admin` / `user` ロールは自分のテナントにのみ接続できます。
 
-| 条件 | 結果 |
-|------|------|
-| `AUTH_ENABLED=false`、トークンなし | ✅ 接続許可 |
-| `AUTH_ENABLED=true`、トークンなし | ❌ 接続拒否 (1008) |
-| `AUTH_ENABLED=true`、無効なトークン | ❌ 接続拒否 (1008) |
-| `AUTH_ENABLED=true`、有効なトークン、自分のテナント | ✅ 接続許可 |
-| `AUTH_ENABLED=true`、有効なトークン、他のテナント | ❌ 接続拒否 (1008) |
-| `AUTH_ENABLED=true`、super_admin、任意のテナント | ✅ 接続許可 |
+* REST API `/auth/login` エンドポイントから取得した `accessToken` をトークンとして直接使用します。
+  
+* `super_admin` ロールは、WebSocket ストリーミング用に任意のテナントに接続できます。注意: `super_admin` は REST 経由でデータ API (`/v2/*`, `/ngsi-ld/*`) にアクセスできませんが、運用監視目的での WebSocket イベントストリーミングは許可されています。
+  
+* `tenant_admin` / `user` ロールは自分のテナントにのみ接続できます。
+
+| Condition                                      | Result                       |
+| ---------------------------------------------- | ---------------------------- |
+| `AUTH_ENABLED=false`, no token                 | ✅ Connection allowed         |
+| `AUTH_ENABLED=true`, no token                  | ❌ Connection rejected (1008) |
+| `AUTH_ENABLED=true`, invalid token             | ❌ Connection rejected (1008) |
+| `AUTH_ENABLED=true`, valid token, own tenant   | ✅ Connection allowed         |
+| `AUTH_ENABLED=true`, valid token, other tenant | ❌ Connection rejected (1008) |
+| `AUTH_ENABLED=true`, super\_admin, any tenant  | ✅ Connection allowed         |
 
 ### 接続フロー
 
-1. クライアントが WebSocket URL に接続 (`tenant` クエリパラメータは必須; 認証が有効な場合はトークンも必須)
-2. サーバーがトークンを検証し、テナントアクセス権限を確認 (認証が有効な場合)
-3. トークンに `cnf.jkt` クレーム (DPoP バインドトークン) が含まれている場合、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります (下記の [DPoP バインディング](#dpop-binding-for-websocket) を参照)
-4. サーバーが DynamoDB に接続を記録 (TTL: 2 時間)
-5. オプション: `subscribe` メッセージでフィルター条件を設定
-6. エンティティが変更されると、サーバーがクライアントにイベントをプッシュ
 
----
+1. クライアントが WebSocket URL に接続します (`tenant` クエリパラメータは必須です。認証が有効な場合はトークンも必要です)
+   
+2. サーバーがトークンを検証し、テナントアクセス権を確認します (認証が有効な場合)
+   
+3. トークンに `cnf.jkt` クレーム (DPoP バインドトークン) が含まれている場合、接続は `pending_dpop` 状態になります — クライアントは 5 秒以内に `dpop_bind` メッセージを送信する必要があります (下記の [DPoP Binding](#dpop-binding-for-websocket) を参照)
+   
+4. サーバーが DynamoDB に接続を記録します (TTL: 2 時間)
+   
+5. オプション: `subscribe` メッセージを介してフィルター条件を設定します
+   
+6. エンティティが変更されると、サーバーがクライアントにイベントをプッシュします
 
-## メッセージフォーマットとフィルタリング
+***
+
+## メッセージ形式とフィルタリング
 
 ### クライアント → サーバー
 
@@ -128,13 +150,13 @@ ws://localhost:3000?tenant={tenantName}
 }
 ```
 
-| フィールド | 型 | 説明 |
-|-------|------|-------------|
-| `action` | string | `subscribe` |
-| `entityTypes` | string[] | フィルタリングするエンティティタイプ |
-| `idPattern` | string | エンティティ ID の正規表現パターン |
+| Field         | Type      | Description                               |
+| ------------- | --------- | ----------------------------------------- |
+| `action`      | string    | `subscribe`                               |
+| `entityTypes` | string\[] | Entity types to filter                    |
+| `idPattern`   | string    | Regular expression pattern for entity IDs |
 
-#### dpop_bind (DPoP 証明検証)
+#### dpop\_bind (DPoP proof 検証)
 
 ```json
 {
@@ -143,9 +165,9 @@ ws://localhost:3000?tenant={tenantName}
 }
 ```
 
-DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する場合に必要です。接続後 5 秒以内に送信する必要があります。サーバーは証明の JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` で応答します。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否されます。
+DPoP バインドトークン (`cnf.jkt` を含む JWT) で接続する際に必要です。接続から 5 秒以内に送信する必要があります。サーバーは proof の JWK Thumbprint がトークンの `cnf.jkt` クレームと一致することを検証し、`{"type": "dpop_verified"}` を返します。検証されるまで、他のすべてのメッセージは `{"type": "error", "message": "DPoP proof required"}` で拒否されます。
 
-詳細は AUTH.md — DPoP Token Binding を参照してください。
+詳細は [AUTH.md — DPoP Token Binding](../reference/auth.md#dpop-token-binding-rfc-9449) を参照してください。
 
 #### ping (キープアライブ)
 
@@ -176,48 +198,53 @@ DPoP バインドされたトークン (`cnf.jkt` を含む JWT) で接続する
 }
 ```
 
-| フィールド | 型 | 説明 |
-|-------|------|-------------|
-| `type` | string | `entityCreated`、`entityUpdated`、`entityDeleted` |
-| `tenant` | string | テナント名 |
-| `servicePath` | string | ServicePath |
-| `entityId` | string | エンティティ ID |
-| `entityType` | string | エンティティタイプ |
-| `data` | object | エンティティ属性データ |
-| `changedAttributes` | string[] | 変更された属性の名前 (更新時のみ) |
-| `timestamp` | string | イベントタイムスタンプ (ISO 8601) |
+| Field               | Type      | Description                                       |
+| ------------------- | --------- | ------------------------------------------------- |
+| `type`              | string    | `entityCreated`, `entityUpdated`, `entityDeleted` |
+| `tenant`            | string    | Tenant name                                       |
+| `servicePath`       | string    | Service path                                      |
+| `entityId`          | string    | Entity ID                                         |
+| `entityType`        | string    | Entity type                                       |
+| `data`              | object    | Entity attribute data                             |
+| `changedAttributes` | string\[] | Names of changed attributes (on update only)      |
+| `timestamp`         | string    | Event timestamp (ISO 8601)                        |
 
 ### フィルタリング
 
-フィルタリングは次の順序で 3 つの層で適用されます:
+フィルタリングは以下の順序で 3 つのレイヤーで適用されます:
 
-1. **テナントフィルタ (必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
-2. **接続側の `subscribe` フィルタ (オプション)** — クライアントが受信したい内容を絞り込みます:
-   - `entityTypes`: 受信するエンティティタイプの配列
-   - `idPattern`: `entityId` に対してマッチングされる正規表現
-3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターはアクティブな XACML ポリシーを実行します。サブジェクトがイベントに対して `Permit` された接続のみに配信されます。
 
-#### XACML で利用可能なイベントごとのリソース属性 (#1107)
+1. **テナントフィルタ(必須)** — 接続時に `tenant` クエリパラメータを介して自動的に適用されます。
+   
+2. **接続側の `subscribe` フィルタ(オプション)** — クライアントが受信したいものを絞り込みます:
+   
+   * `entityTypes`: 受信するエンティティタイプの配列
+     
+   * `idPattern`: `entityId` に対してマッチする正規表現
+     
+3. **XACML 認可フィルタ** — 上記を通過した各接続に対して、ブロードキャスターはアクティブな XACML ポリシーを実行します。イベントに対してサブジェクトが `Permit` された接続のみに配信されます。
 
-ブロードキャスターが配信を認可する際、以下のエンティティごとのリソース属性を AuthzRequest に注入します:
+#### XACML で利用可能なイベントごとのリソース属性(#1107)
 
-| attributeId | ソース |
-|-------------|--------|
-| `entityType` | イベントのエンティティタイプ |
-| `entityId` | イベントのエンティティ ID |
-| `entityOwner` | イベントエンティティの `createdBy` (元々エンティティを `POST` したユーザー) |
+ブロードキャスターが配信を認可する際、これらのエンティティごとのリソース属性を AuthzRequest に注入します:
 
-これにより、`${subject.userId}` テンプレート展開と `entityOwner` を使用して、単一の XACML ポリシーで「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった**ユーザーごとの配信フィルタ**を記述できます。完全なポリシー例については `docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性 を参照してください。
+| attributeId   | Source                                                                   |
+| ------------- | ------------------------------------------------------------------------ |
+| `entityType`  | event's entity type                                                      |
+| `entityId`    | event's entity ID                                                        |
+| `entityOwner` | event entity's `createdBy` (the user who originally `POST`ed the entity) |
 
-> 認証なしで書き込まれたエンティティ (または `createdBy` を設定しないレガシー / バッチパス経由) は、`owner` 属性のないイベントを発行します — 所有者ベースのルールはこれらのイベントにマッチしないため、このフォールバックを考慮してポリシーを設計してください。
+これにより、`entityOwner` に対する `${subject.userId}` テンプレート展開を使用した単一の XACML ポリシーで「各ユーザーは自分が作成したエンティティのイベントのみを受信する」といった**ユーザーごとの配信フィルタ**を記述できます。完全なポリシーの例については、[`docs/AUTH.md` — ブロードキャスト時のエンティティごとの属性](../reference/auth.md#per-entity-attributes-at-broadcast-time-1107)を参照してください。
 
----
+> 認証なしで書き込まれたエンティティ(または `createdBy` を設定しないレガシー/バッチパス経由)は、`owner` 属性のないイベントを発行します — オーナーベースのルールはこれらのイベントにマッチしないため、そのフォールバックを念頭に置いてポリシーを設計してください。
+
+***
 
 ## クライアント実装
 
-### JavaScript SDK (推奨)
+### JavaScript SDK(推奨)
 
-GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンの更新、DPoP バインディング、再接続を自動的に処理します。
+GeonicDB JavaScript SDK は、WebSocket イベントストリーミングを使用する最もシンプルな方法を提供します。認証、トークンのリフレッシュ、DPoP バインディング、再接続を自動的に処理します。
 
 ```bash
 npm install @geolonia/geonicdb-sdk
@@ -257,7 +284,7 @@ db.on('connected', function() {
 // db.reconnect();
 ```
 
-Bearer JWT 認証の場合(例: ログインフロー後)、`setCredentials()` で認証情報を注入します:
+Bearer JWT 認証の場合(例:ログインフロー後)、`setCredentials()` で認証情報を注入します:
 
 ```javascript
 import GeonicDB from '@geolonia/geonicdb-sdk';
@@ -448,7 +475,7 @@ function RoomMonitor() {
 }
 ```
 
-### JavaScript (認証あり)
+### JavaScript (認証付き)
 
 ```javascript
 // Obtain a token
@@ -555,11 +582,11 @@ wscat -c "wss://{api-id}.execute-api.{region}.amazonaws.com/{stage}?tenant=smart
 > {"action": "ping"}
 ```
 
----
+***
 
-## WebSocket の DPoP バインディング {#dpop-binding-for-websocket}
+## WebSocket 用の DPoP バインディング
 
-DPoP バインドトークンを使用する WebSocket 接続には、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
+DPoP バインドトークンを使用した WebSocket 接続では、接続後の証明検証ステップが必要です。WebSocket プロトコルは初期ハンドシェイク後のカスタムヘッダーをサポートしていないため、DPoP 証明は接続確立後にメッセージとして送信されます。
 
 ### フロー
 
@@ -582,22 +609,22 @@ Client                               Server
 
 ### 状態
 
-| 状態 | 説明 | 許可されるメッセージ |
-|-------|-------------|------------------|
-| `pending_dpop` | 接続後に DPoP 証明を待機中 | `dpop_bind` のみ |
-| `verified` | DPoP 証明が正常に検証された | `subscribe`、`ping` など |
+| State          | Description                          | Allowed Messages          |
+| -------------- | ------------------------------------ | ------------------------- |
+| `pending_dpop` | Awaiting DPoP proof after connection | `dpop_bind` only          |
+| `verified`     | DPoP proof verified successfully     | `subscribe`, `ping`, etc. |
 
 `dpop_bind` メッセージが 5 秒以内に受信されない場合、接続は終了されます。
 
----
+***
 
 ## ベストプラクティス
 
-### 1. 再接続ロジック
+### 1. Reconnection Logic
 
-> **注意**: JavaScript SDK を使用している場合、指数バックオフを使用した再接続が組み込まれています。`db.reconnect()` を使用して強制的に再接続するか、`reconnecting` イベントをリッスンして再接続試行を追跡できます。以下の例は、raw WebSocket 実装向けです。
+> **注**: JavaScript SDK を使用している場合、指数バックオフによる再接続が組み込まれています。強制的に再接続するには `db.reconnect()` を使用するか、`reconnecting` イベントをリッスンして再接続試行を追跡してください。以下の例は、生の WebSocket 実装用です。
 
-指数バックオフを使用した堅牢な再接続を実装します:
+指数バックオフによる堅牢な再接続を実装します:
 
 ```javascript
 class GeonicDBWebSocket {
@@ -645,9 +672,9 @@ setInterval(() => {
 }, 5 * 60 * 1000);
 ```
 
-### 3. イベント処理の最適化
+### 3. Optimizing Event Processing
 
-大量のイベントを受信する場合、デバウンシングで UI 更新を最適化します:
+大量のイベントを受信する場合、デバウンスを使用して UI の更新を最適化します:
 
 ```javascript
 import { debounce } from 'lodash';
@@ -662,7 +689,7 @@ ws.onmessage = (event) => {
 };
 ```
 
-### 4. セキュリティ
+### 4. Security
 
 **安全なトークン管理:**
 
@@ -695,7 +722,7 @@ function isTokenExpired(token, bufferSeconds = 60) {
 }
 ```
 
-### 5. メモリ管理
+### 5. Memory Management
 
 メモリリークを防ぐために、イベント履歴に制限を設定します:
 
@@ -712,18 +739,21 @@ onUnmounted(() => {
 });
 ```
 
----
+***
 
 ## トラブルシューティング
 
-### 1. 接続が拒否される (1008 エラー)
+### 1. Connection Rejected (1008 Error)
 
 **原因:**
-- トークンが無効または期限切れ
-- テナントへのアクセス権限がない
-- `AUTH_ENABLED=true` にもかかわらずトークンが提供されていない
 
-**解決方法:**
+* トークンが無効または期限切れ
+  
+* テナントへのアクセス権限がない
+  
+* `AUTH_ENABLED=true` にもかかわらずトークンが提供されていない
+
+**解決策:**
 
 ```javascript
 ws.onclose = (event) => {
@@ -735,11 +765,11 @@ ws.onclose = (event) => {
 };
 ```
 
-### 2. 10 分後に接続が切断される
+### 2. Connection Drops After 10 Minutes
 
-**原因:** Keep-alive (ping) メッセージが送信されていない。
+**原因:** Keep-alive (ping) メッセージが送信されていません。
 
-**解決方法:**
+**解決策:**
 
 ```javascript
 // Send a ping every 5 minutes
@@ -750,14 +780,17 @@ setInterval(() => {
 }, 5 * 60 * 1000);
 ```
 
-### 3. イベントを受信できない
+### 3. Not Receiving Events
 
 **原因:**
-- フィルタが厳しすぎる
-- テナントが間違っている
-- エンティティの作成/更新が実際に発生していない
 
-**解決方法:**
+* フィルターの制限が厳しすぎる
+  
+* テナントが間違っている
+  
+* エンティティの作成/更新が実際に発生していない
+
+**解決策:**
 
 ```javascript
 // Debug: log all messages
@@ -774,13 +807,15 @@ ws.send(JSON.stringify({
 }));
 ```
 
-### 4. ローカル開発環境で接続できない
+### 4. Cannot Connect in Local Development
 
 **原因:**
-- ローカルサーバーが起動していない
-- WebSocket URL が間違っている
 
-**解決方法:**
+* ローカルサーバーが起動していない
+  
+* WebSocket URL が間違っている
+
+**解決策:**
 
 ```bash
 # Start the local server
@@ -790,9 +825,9 @@ npm start
 const wsUrl = 'ws://localhost:3000?tenant=demo';
 ```
 
-### 5. デバッグ
+### 5. Debugging
 
-ブラウザの開発者ツールの Network タブで、WebSocket 接続と送受信されたメッセージを確認できます。
+ブラウザの開発者ツールの Network タブで、WebSocket 接続と送受信されたメッセージを検査できます。
 
 ```javascript
 class DebugWebSocket {
@@ -812,24 +847,28 @@ class DebugWebSocket {
 }
 ```
 
----
+***
 
 ## 制約
 
-| 項目 | 値 | 説明 |
-|------|-------|-------------|
-| アイドルタイムアウト | 10 分 | クライアントは 5 分ごとに ping を送信する必要があります |
-| 同時接続数 | 500 (デフォルト) | AWS Support 経由で増やすことができます |
-| フレームサイズ | 128KB | 大きなエンティティは切り詰めが必要です |
-| レイテンシ | ~1 分 | MongoDB Change Stream のポーリング間隔に依存します |
-| 接続 TTL | 2 時間 | DynamoDB TTL によって自動的にクリーンアップされます |
-| ローカル開発 | サポート対象 | ローカル WebSocket サーバー経由で利用可能 |
+| Item                   | Value         | Description                                           |
+| ---------------------- | ------------- | ----------------------------------------------------- |
+| Idle timeout           | 10 minutes    | Clients must send a ping every 5 minutes              |
+| Concurrent connections | 500 (default) | Can be increased via AWS Support                      |
+| Frame size             | 128KB         | Large entities require truncation                     |
+| Latency                | \~1 minute    | Depends on the MongoDB Change Stream polling interval |
+| Connection TTL         | 2 hours       | Automatically cleaned up by DynamoDB TTL              |
+| Local development      | Supported     | Available via local WebSocket server                  |
 
----
+***
 
 ## 関連ドキュメント
 
-- JavaScript SDK - SDK API リファレンス (ブラウザアプリケーションに推奨)
-- [API 共通仕様](../api-reference/endpoints.md) - REST API ドキュメント
-- Authentication and Authorization - 認証設定
-- Development Guide - ローカル開発とデプロイ
+
+* JavaScript SDK - SDK API リファレンス(ブラウザアプリケーションに推奨)
+  
+* [API Common Specification](../api-reference/endpoints.md) - REST API ドキュメント
+  
+* [Authentication and Authorization](../reference/auth.md) - 認証設定
+  
+* Development Guide - ローカル開発とデプロイ

--- a/docs/ja/reference/auth.md
+++ b/docs/ja/reference/auth.md
@@ -1,11 +1,1921 @@
 ---
-title: "認証ガイド"
-description: "GeonicDB 認証・認可ガイド"
+title: "Authentication Guide"
+description: "GeonicDB authentication and authorization guide"
 outline: deep
 ---
+# 認証と認可のガイド
 
-# 認証ガイド
+このドキュメントは、GeonicDB の認証と認可機能の全体像、セットアップ、および管理について説明します。
 
-::: info 準備中
-このページは GeonicDB 上流ドキュメントから同期されます。次回ドキュメント同期後に全コンテンツが利用可能になります。
-:::
+## 目次
+
+
+* [概要](#overview)
+  
+* [認証アーキテクチャ](#認証アーキテクチャ)
+  
+* [初期セットアップ](#初期セットアップ)
+  
+* [ユーザーとテナントの管理](#user--tenant-management)
+  
+* [API キー認証](#api-キー認証)
+  
+  * [API キートークン交換(Browser SDK)](#api-key-token-exchange-browser-sdk)
+    
+  * [DPoP トークンバインディング(RFC 9449)](#dpop-token-binding-rfc-9449)
+    
+* [OAuth 2.0 M2M 認証](#oauth-20-m2m-認証)
+  
+* [OIDC 外部 IdP 認証](#oidc-外部-idp-認証)
+  
+* [XACML ポリシーベース認可](#xacml-ポリシーベース認可)
+  
+* [認証シナリオリファレンス](#認証シナリオリファレンス)
+  
+* [トラブルシューティング](#トラブルシューティング)
+
+***
+
+## 概要
+
+GeonicDB は JWT ベースの認証と認可機能を提供します。
+
+### ロール設定
+
+| Role           | Description            | Permissions                                                                                                                                                                                           |
+| -------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `super_admin`  | Platform administrator | `/admin/*`, `/auth/*`, `/me/*`, monitoring endpoints (`/statistics`, `/metrics`, `/cache/statistics`) only. **Cannot** access data APIs (`/v2/*`, `/ngsi-ld/*`, `/catalog*`, `/rules*`) — returns 403 |
+| `tenant_admin` | Tenant administrator   | Full access within the assigned tenant (admin + data APIs)                                                                                                                                            |
+| `user`         | General user           | Read-only by default (GET only). Custom XACML policies can grant write access                                                                                                                         |
+| `anonymous`    | Unauthenticated user   | Denied by default. Explicit XACML Permit policy required. No feature flag needed (#748)                                                                                                               |
+
+> **注意**: `super_admin` は SaaS セキュリティのためプラットフォーム管理操作に制限されています。
+> 顧客データの分離が強制されています — Geolonia スタッフは `super_admin` 認証情報を持っていてもテナントのエンティティデータにアクセスできません。
+> 詳細は [#674](https://github.com/geolonia/geonicdb/issues/674) を参照してください。
+
+### 認証フロー
+
+```text
+┌─────────┐     POST /auth/login      ┌─────────┐
+│  Client │ ─────────────────────────▶│  Server │
+└─────────┘                           └─────────┘
+     │                                      │
+     │◀──── accessToken + refreshToken ─────│
+     │                                      │
+     │   Authorization: Bearer <token>      │
+     │ ────────────────────────────────────▶│
+     │                                      │
+     │◀─────────── API Response ────────────│
+     │                                      │
+     │     POST /auth/logout               │
+     │ ────────────────────────────────────▶│
+     │        (invalidate all tokens)        │
+     │◀──────────── 204 ───────────────────│
+```
+
+***
+
+## 認証アーキテクチャ
+
+GeonicDB の認証と認可は、以下のレイヤーで構成されています。
+
+```text
+Request
+  ↓
+[1. Token Extraction] Retrieve token from Authorization: DPoP/Bearer <token> or X-Api-Key header
+  ↓
+[2. Authentication (AuthN)] Token verification (attempted in the following order)
+  │               2a. Authorization: Bearer <token> → Internal JWT / OIDC verification
+  │               2b. X-Api-Key header → API Key verification (SHA-256 hash lookup)
+  │                   → Origin check
+  │               2c. Internal JWT (HS256) verification → authentication completes immediately on success
+  │               2d. OIDC external IdP verification (only when OIDC_ENABLED=true)
+  │                   → Signature verification via OIDC Discovery + JWKS (RS256/ES256)
+  │                   → Search GeonicDB DB user by email address
+  ↓                → requireAuth() / requireAdminAuth() / requireSuperAdminAuth()
+[3. IP Restriction]  Admin endpoints only: restriction via ADMIN_ALLOWED_IPS
+  ↓
+[4. Tenant Isolation] Match Fiware-Service header against user's tenantId
+  ↓                → checkTenantAccess()
+[5. Authorization (AuthZ)] XACML policy-based authorization (when AUTH_ENABLED=true)
+  ↓                → XacmlService.evaluate()
+[6. Endpoint Processing]
+```
+
+### 環境変数
+
+| Variable                        | Default                                       | Description                                                                                     |
+| ------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `AUTH_ENABLED`                  | `false`                                       | Enable JWT authentication                                                                       |
+| `JWT_SECRET`                    | `development-secret-key-change-in-production` | Secret for JWT signing                                                                          |
+| `JWT_EXPIRES_IN`                | `1h`                                          | Access token expiration                                                                         |
+| `JWT_REFRESH_EXPIRES_IN`        | `7d`                                          | Refresh token expiration                                                                        |
+| `SUPER_ADMIN_EMAIL`             | -                                             | Super Admin email address via environment variable                                              |
+| `SUPER_ADMIN_PASSWORD`          | -                                             | Super Admin password via environment variable                                                   |
+| `ADMIN_ALLOWED_IPS`             | -                                             | Allowed IPs for Admin API access (CIDR)                                                         |
+| `OAUTH_ENABLED`                 | ~~`false`~~                                   | **Deprecated**: OAuth 2.0 is always enabled when `AUTH_ENABLED=true`. This variable is ignored. |
+| `OIDC_ENABLED`                  | `false`                                       | Enable OIDC external IdP authentication                                                         |
+| `OIDC_ISSUER`                   | -                                             | OIDC Issuer URL                                                                                 |
+| `OIDC_AUDIENCE`                 | -                                             | OIDC Audience (aud claim)                                                                       |
+| `TOKEN_INVALIDATION_TABLE_NAME` | -                                             | DynamoDB table name for token invalidation (in-memory when not set)                             |
+
+***
+
+## 初期セットアップ
+
+### 1. 環境変数の設定
+
+認証を有効にするために、以下の環境変数を設定します。
+
+```bash
+# Required settings
+export AUTH_ENABLED=true
+export JWT_SECRET=your-very-secure-secret-key-at-least-32-characters
+
+# Super Admin settings (required for initial setup)
+export SUPER_ADMIN_EMAIL=admin@example.com
+export SUPER_ADMIN_PASSWORD=YourSecurePassword123!
+
+# Optional settings
+export JWT_EXPIRES_IN=1h              # Access token expiration (default: 1h)
+export JWT_REFRESH_EXPIRES_IN=7d      # Refresh token expiration (default: 7d)
+export ADMIN_ALLOWED_IPS=10.0.0.0/8,192.168.1.0/24  # Admin API access restriction
+```
+
+### 2. ローカル開発環境の起動
+
+```bash
+# Start the server with environment variables set
+AUTH_ENABLED=true \
+JWT_SECRET=development-secret-key-32chars \
+SUPER_ADMIN_EMAIL=admin@localhost \
+SUPER_ADMIN_PASSWORD=adminpass123 \
+npm start
+```
+
+### 3. AWS Lambda へのデプロイ
+
+SAM テンプレートに以下のパラメータを設定します:
+
+```yaml
+Parameters:
+  AuthEnabled:
+    Type: String
+    Default: "true"
+  JwtSecret:
+    Type: String
+    NoEcho: true  # Hide secret value
+  SuperAdminEmail:
+    Type: String
+  SuperAdminPassword:
+    Type: String
+    NoEcho: true
+```
+
+### スーパー管理者の登録
+
+スーパー管理者を登録する方法は 2 つあります。
+
+#### 方法 1:環境変数による設定(推奨)
+
+環境変数を使用して最初のスーパー管理者を設定します。
+
+```bash
+export SUPER_ADMIN_EMAIL=admin@example.com
+export SUPER_ADMIN_PASSWORD=YourSecurePassword123!
+```
+
+**特徴:**
+
+* データベースに保存されない(メモリ上のみ)
+  
+* サーバー再起動後も同じ認証情報で利用可能
+  
+* パスワード変更には環境変数の更新とサーバーの再起動が必要
+
+#### 方法 2:管理 API による追加登録
+
+既存のスーパー管理者としてログイン後、管理 API を使用して新しいスーパー管理者を作成できます。
+
+```bash
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "admin@example.com",
+    "password": "YourSecurePassword123!"
+  }'
+```
+
+***
+
+## ユーザー & テナント管理
+
+詳細については、管理 API ドキュメントを参照してください。
+
+### CADDE 設定管理(super\_admin のみ)
+
+| Endpoint       | Method | Description                          |
+| -------------- | ------ | ------------------------------------ |
+| `/admin/cadde` | GET    | Get CADDE configuration              |
+| `/admin/cadde` | PUT    | Update CADDE configuration (upsert)  |
+| `/admin/cadde` | DELETE | Delete CADDE configuration (disable) |
+
+### テナント管理
+
+| Endpoint                                    | Method | Description                                        |
+| ------------------------------------------- | ------ | -------------------------------------------------- |
+| `/admin/tenants`                            | GET    | Get tenant list                                    |
+| `/admin/tenants`                            | POST   | Create tenant                                      |
+| `/admin/tenants/{tenantId}`                 | GET    | Get tenant                                         |
+| `/admin/tenants/{tenantId}`                 | PATCH  | Update tenant                                      |
+| `/admin/tenants/{tenantId}`                 | DELETE | Delete tenant (`?shred=true` for Crypto-Shredding) |
+| `/admin/tenants/{tenantId}/deletion-report` | GET    | Get deletion report (Crypto-Shredding)             |
+| `/admin/tenants/{tenantId}/activate`        | POST   | Activate tenant                                    |
+| `/admin/tenants/{tenantId}/deactivate`      | POST   | Deactivate tenant                                  |
+| `/admin/tenants/{tenantId}/ip-restrictions` | GET    | Get tenant IP restrictions                         |
+| `/admin/tenants/{tenantId}/ip-restrictions` | PUT    | Update tenant IP restrictions                      |
+| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | Delete tenant IP restrictions                      |
+
+### ユーザー管理
+
+| Endpoint                           | Method | Description      |
+| ---------------------------------- | ------ | ---------------- |
+| `/admin/users`                     | GET    | Get user list    |
+| `/admin/users`                     | POST   | Create user      |
+| `/admin/users/{userId}`            | GET    | Get user         |
+| `/admin/users/{userId}`            | PATCH  | Update user      |
+| `/admin/users/{userId}`            | DELETE | Delete user      |
+| `/admin/users/{userId}/activate`   | POST   | Activate user    |
+| `/admin/users/{userId}/deactivate` | POST   | Deactivate user  |
+| `/admin/users/{userId}/unlock`     | POST   | Clear login lock |
+
+#### テナント存在検証
+
+`tenantId` を持つユーザーを作成または更新する際、システムは指定されたテナントが存在することを検証します。テナントが存在しない場合、`400 Bad Request` エラーが返されます。
+
+
+* **POST /admin/users**: `tenantId` は既存のテナントを参照する必要があります(`super_admin` ユーザーを除く。これらはテナントを持ちません)
+  
+* **PATCH /admin/users/{userId}**: `tenantId` を変更する際、対象のテナントが存在する必要があります。`tenantId` を `null` に設定することは検証なしで許可されます。
+
+### テナントメンバーシップ管理
+
+FIWARE Keyrock Organization モデルに準拠し、単一のユーザーは複数のテナントに所属できます。メンバーシップはユーザー作成時に自動的に作成されます。
+
+| Endpoint                                   | Method | Description                    | Authorization                               |
+| ------------------------------------------ | ------ | ------------------------------ | ------------------------------------------- |
+| `/admin/tenants/{tenantId}/users`          | GET    | List tenant members            | `tenant_admin` (own tenant) / `super_admin` |
+| `/admin/tenants/{tenantId}/users/{userId}` | PUT    | Add user to tenant             | `tenant_admin` (own tenant) / `super_admin` |
+| `/admin/tenants/{tenantId}/users/{userId}` | DELETE | Remove user from tenant        | `tenant_admin` (own tenant) / `super_admin` |
+| `/admin/users/{userId}/tenants`            | GET    | List tenants a user belongs to | Self / `super_admin`                        |
+
+#### テナントスコープログイン
+
+ログイン時に `tenantId` を指定することで、そのテナントにスコープされた JWT トークンを取得できます。テナントはリクエストボディまたは HTTP ヘッダーで指定できます。
+
+```bash
+# Login with tenantId in request body
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "user@example.com",
+    "password": "password12345",
+    "tenantId": "target-tenant-id"
+  }'
+
+# Login with NGSILD-Tenant header (resolved by tenant name)
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -H "NGSILD-Tenant: my_tenant" \
+  -d '{
+    "email": "user@example.com",
+    "password": "password12345"
+  }'
+```
+
+**テナント解決の優先順位:**
+
+1. `body.tenantId` — 直接テナント ID 指定(最優先)
+   
+2. `NGSILD-Tenant` / `Fiware-Service` ヘッダー — テナント名で解決
+   
+3. プライマリテナント(`user.tenantId`)— どちらも指定されていない場合のフォールバック
+
+**動作:**
+
+* `tenantId` 指定時:メンバーシップを確認した後、そのテナントにスコープされたトークンを発行
+  
+* `NGSILD-Tenant` / `Fiware-Service` ヘッダー指定時:テナント名で解決します。テナント名が見つからない場合、または無効な形式の場合(`^[a-z0-9_]+$` に一致する必要があります)は `400 Bad Request` を返します
+  
+* テナント指定なし:プライマリテナント(`user.tenantId`)のトークンを発行します。ユーザーが複数のテナントに所属している場合、レスポンスに `availableTenants` リストが含まれます
+  
+* ユーザーが所属していないテナントを指定:`403 Forbidden`
+
+#### メンバーシップのライフサイクル
+
+
+* **ユーザー作成時**:`POST /admin/users` により自動的にメンバーシップが作成されます
+  
+* **追加登録**:`PUT /admin/tenants/{tenantId}/users/{userId}` により別のテナントに追加
+  
+* **テナント削除時**:すべてのテナント関連データがカスケード削除されます(entities、subscriptions、registrations、temporalEntities、snapshots、rules、policies、OAuth clients、data models、users、memberships など — 全 16 コレクション)
+  
+* **ユーザー削除時**:ユーザーに関連付けられたすべてのメンバーシップが自動的に削除されます
+
+### テナント毎の CORS 許可オリジン (#1069)
+
+GeonicDB はリクエストの `Origin` ヘッダーをテナントレベルのホワイトリストと照合して検証します。これは API-Key の `allowedOrigins` の上にレイヤー化され、匿名、JWT、API-Key リクエストの全てに適用されます。GeonicDB はマルチテナント Context Broker であるため、許可オリジンは環境変数で固定することが**できません** — 実行時に管理 API を通じてテナント毎に設定する必要があります。
+
+#### エンドポイント
+
+標準のテナント設定エンドポイントを使用します:
+
+```http
+PATCH /admin/tenants/{tenantId}
+Content-Type: application/json
+Authorization: Bearer <super_admin token>
+
+{
+  "settings": {
+    "allowedOrigins": ["https://app.example.com", "https://admin.example.com"]
+  }
+}
+```
+
+#### `allowedOrigins` のセマンティクス
+
+| Value                              | Behavior                                                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Field absent                       | All origins allowed (backward compat — existing tenants unaffected).                                    |
+| `[]` (explicit empty array)        | All origins denied.                                                                                     |
+| `["*"]`                            | All origins allowed. Requests without `Origin` header (curl / S2S / CLI) also pass.                     |
+| `["https://app.example.com", ...]` | Exact match only (max 50 entries; protocol + host + port). Requests without `Origin` header are denied. |
+
+#### 適用
+
+
+* **プリフライト (OPTIONS)** はオリジン検証されません (CORS 仕様: テナントヘッダーはプリフライトにありません)。常にリクエストの `Origin` をエコーバックし、204 を返します。
+  
+* **実際のリクエスト** は `optionalAuth(event, tenantService)` (データ API) または `requireAuth(event)` (管理 / `/auth/logout`) を通過します。オリジンが一致しない場合、リクエストは `403 Forbidden` で拒否され、ボディは `Origin not allowed for this tenant` となります。
+  
+* 403 レスポンスには依然として `Access-Control-Allow-Origin` のエコーバック + `Vary: Origin` が含まれるため、ブラウザは実際のエラーをクライアントに表示します (そうでなければ開発者には一般的な Network エラーが表示されます)。
+  
+* `super_admin` ユーザー (`tenantId: null`) はオリジン検証をスキップします — 彼らはテナントスコープの上位で動作します。
+
+#### API Key の `allowedOrigins` とのレイヤー化
+
+API Key が使用される場合、両方のチェックが適用されます:
+
+
+1. **テナントレベル**: `tenant.settings.allowedOrigins` を満たす必要があります。
+   
+2. **API-Key レベル**: `apiKey.allowedOrigins` を満たす必要があります (既存の動作、変更なし)。
+
+最も制限的なものが優先されます。
+
+### テナントごとの IP 制限
+
+テナントごとに固有の IP アドレス制限を設定できます。グローバル設定(`ADMIN_ALLOWED_IPS`)に加えて、テナントレベルでのきめ細かいアクセス制御が可能です。
+
+#### エンドポイント
+
+| Endpoint                                    | Method | Description                                       |
+| ------------------------------------------- | ------ | ------------------------------------------------- |
+| `/admin/tenants/{tenantId}/ip-restrictions` | GET    | Get IP restriction settings                       |
+| `/admin/tenants/{tenantId}/ip-restrictions` | PUT    | Update IP restriction settings                    |
+| `/admin/tenants/{tenantId}/ip-restrictions` | DELETE | Delete IP restriction settings (reset to default) |
+
+#### スコープ
+
+| Scope   | Description                                        |
+| ------- | -------------------------------------------------- |
+| `admin` | Restrict access to the Admin API (`/admin/*`) only |
+| `all`   | Restrict access to all API endpoints               |
+
+#### フォールバック動作
+
+テナントに IP 制限が設定されていない場合、グローバル設定(`ADMIN_ALLOWED_IPS` 環境変数)が適用されます。テナントレベルの設定が存在する場合は、それが優先されます。
+
+#### リクエスト例
+
+**IP 制限設定の取得:**
+
+```bash
+curl -X GET http://localhost:3000/admin/tenants/{tenantId}/ip-restrictions \
+  -H "Authorization: Bearer <accessToken>"
+```
+
+**レスポンス例:**
+
+```json
+{
+  "tenantId": "abc123",
+  "tenantName": "my-tenant",
+  "ipRestrictions": {
+    "enabled": false,
+    "allowedIps": [],
+    "scope": "admin"
+  },
+  "globalFallback": null
+}
+```
+
+**IP 制限設定の更新:**
+
+```bash
+curl -X PUT http://localhost:3000/admin/tenants/{tenantId}/ip-restrictions \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "allowedIps": ["192.168.1.0/24", "10.0.0.1"],
+    "scope": "admin"
+  }'
+```
+
+**IP 制限設定の削除:**
+
+```bash
+curl -X DELETE http://localhost:3000/admin/tenants/{tenantId}/ip-restrictions \
+  -H "Authorization: Bearer <accessToken>"
+```
+
+***
+
+## API キー認証
+
+GeonicDB は、JWT/OAuth トークンに代わる軽量な認証方式として API キーベースの認証をサポートしています。API キーは、公開統合、ブラウザベースのアプリケーション、および完全な OAuth 認証情報が不要なシナリオに適しています。
+
+### 概要
+
+API キーは、オリジンとレート制限の組み込み制限を持つシンプルな認証メカニズムを提供し、`policyId` を介したオプションの XACML ポリシーバインディングが可能です。
+
+### 認証ヘッダー
+
+```http
+X-Api-Key: <UUID or gdb_-prefixed key>
+```
+
+**優先順位**: `Authorization: Bearer` と `X-Api-Key` ヘッダーの両方が存在する場合、Bearer トークンが優先されます。API キーは、Bearer トークンが提供されていない場合にのみフォールバックとして使用されます。
+
+### キー形式
+
+
+* **新しいキー**: プレーン UUID(`randomUUID()`)— 例:`550e8400-e29b-41d4-a716-446655440000`
+  
+* **レガシーキー**: `gdb_` プレフィックスを持つ既存のキーは引き続き動作します(後方互換性あり)
+  
+* **ストレージ**: データベースにはキーの SHA-256 ハッシュのみが保存されます。平文のキーは、作成時とリフレッシュ時にのみ返されます。
+  
+* **マスキング**: リストと取得のレスポンスでは、実際のキーの代わりに `"key": "******"` が返されます
+
+### 制限事項
+
+| Field              | Description                                                                                                                                                                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Origin**         | `allowedOrigins` — list of permitted URL origins (or `*` for any). At least 1 required. Max 20 entries. Enforced at runtime.                                                                                                                          |
+| **Policy Binding** | `policyId` — optional. Binds the key to an existing XACML policy. The bound policy's target is bypassed during evaluation (only rules are evaluated). Without `policyId`, the key falls back to tenant policies + role default (api\_key = All Deny). |
+| **Rate Limit**     | `rateLimit.perMinute` — requests per minute (1–1000, default: 60).                                                                                                                                                                                    |
+
+### API キー管理(管理者)
+
+管理者は任意のユーザーの API キーを管理できます。
+
+| Endpoint                          | Method | Description                                              |
+| --------------------------------- | ------ | -------------------------------------------------------- |
+| `/admin/api-keys`                 | POST   | Create API key (returns raw key in response)             |
+| `/admin/api-keys`                 | GET    | List API keys (paginated, `X-Total-Count` header)        |
+| `/admin/api-keys/{keyId}`         | GET    | Get API key details                                      |
+| `/admin/api-keys/{keyId}`         | PATCH  | Update API key                                           |
+| `/admin/api-keys/{keyId}`         | DELETE | Delete API key                                           |
+| `/admin/api-keys/{keyId}/refresh` | POST   | Refresh (regenerate) API key — returns new plaintext key |
+
+### セルフサービス API キー管理
+
+ユーザーは管理者権限なしで自分の API キーを作成および管理できます。
+
+| Endpoint                       | Method | Description                                                  |
+| ------------------------------ | ------ | ------------------------------------------------------------ |
+| `/me/api-keys`                 | POST   | Create own API key                                           |
+| `/me/api-keys`                 | GET    | List own API keys                                            |
+| `/me/api-keys/{keyId}`         | PATCH  | Update own API key (partial)                                 |
+| `/me/api-keys/{keyId}`         | DELETE | Delete own API key                                           |
+| `/me/api-keys/{keyId}/refresh` | POST   | Refresh (regenerate) own API key — returns new plaintext key |
+
+**制限事項:**
+
+* ユーザーあたり最大 **5 個のキー**
+  
+* `allowedOrigins` は作成時に必須(空でない配列。すべてのオリジンを許可するには `["*"]` を使用)
+  
+* `policyId` はオプション — 指定する場合、参照するポリシーは既に存在し、同じユーザーによって作成されている必要があります
+  
+* `tenantId` は `super_admin` に必須(欠落時は 400 エラー)。`tenant_admin` は省略可能(セッションから自動導出)
+
+**PATCH で更新可能なフィールド**(`PATCH /me/api-keys/{keyId}`):
+
+| Field            | Type                 | Description                                                  |
+| ---------------- | -------------------- | ------------------------------------------------------------ |
+| `name`           | string               | Key name                                                     |
+| `allowedOrigins` | string\[]            | Allowed origins (min 1 entry)                                |
+| `policyId`       | string \| null | Policy binding (must be created by you, or `null` to unbind) |
+| `rateLimit`      | object               | Rate limit override                                          |
+| `dpopRequired`   | boolean              | Require DPoP proof                                           |
+| `isActive`       | boolean              | Activate / deactivate the key                                |
+
+### リクエスト例
+
+#### API キーを作成する
+
+```bash
+curl -X POST http://localhost:3000/admin/api-keys \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Public Dashboard",
+    "allowedOrigins": ["https://dashboard.example.com"],
+    "rateLimit": { "perMinute": 120 }
+  }'
+```
+
+> **注意:** `keyId` は自動生成されます (UUID)。`tenantId` は `super_admin` には必須です。`tenant_admin` は省略可能です (セッションから自動導出されます)。`policyId` はオプションです — 省略した場合、認可はテナントポリシー + ロールのデフォルトにフォールバックします。ID (`keyId`、`policyId`) はテナントごとに一意です。
+
+**レスポンス** (`201 Created`、`Location: /admin/api-keys/{keyId}`):
+
+```json
+{
+  "keyId": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "Public Dashboard",
+  "key": "550e8400-e29b-41d4-a716-446655440000 (plaintext key, shown only at creation and refresh)",
+  "allowedOrigins": ["https://dashboard.example.com"],
+  "policyId": "dashboard-readonly",
+  "rateLimit": { "perMinute": 120 },
+  "isActive": true,
+  "tenantId": "my-tenant-id",
+  "createdBy": "user-uuid",
+  "lastUsedAt": null,
+  "createdAt": "2026-03-07T00:00:00.000Z",
+  "updatedAt": "2026-03-07T00:00:00.000Z"
+}
+```
+
+> **注意:** `keyPrefix` フィールドは削除されました。`key` フィールドは作成時と更新時にのみプレーンテキストとして返されます。リスト / 取得レスポンスでは `"key": "******"` が返されます。
+>
+> **後方互換性:** `gdb_` プレフィックスを持つ既存のキーは有効のままで、引き続き機能します。新しく作成されるキーのみが UUID 形式を使用します。
+
+#### API キーを更新する
+
+```bash
+curl -X POST http://localhost:3000/me/api-keys/{keyId}/refresh \
+  -H "Authorization: Bearer <accessToken>"
+```
+
+キーの値を再生成します。古いキーは直ちに無効化されます。レスポンスには新しいプレーンテキストのキーが含まれます (作成レスポンスと同じ形式)。
+
+#### API キーを使用する
+
+```bash
+curl -X GET http://localhost:3000/v2/entities?type=TemperatureSensor \
+  -H "X-Api-Key: 550e8400-e29b-41d4-a716-446655440000" \
+  -H "Fiware-Service: mytenant"
+```
+
+### デフォルトと制限
+
+| Parameter           | Value                        |
+| ------------------- | ---------------------------- |
+| Max keys per user   | 5                            |
+| Max allowed origins | 20                           |
+| Default rate limit  | 60 requests/minute           |
+| Max rate limit      | 1000 requests/minute         |
+| Key length          | 32 bytes (64 hex characters) |
+
+### ポリシーバインディング (`policyId`
+
+)
+
+デフォルトでは、API キーには `Deny` ポリシー (`__default_api_key`、優先度 -2) が設定されています。権限を付与するには、まず XACML ポリシーを作成し、次に `policyId` フィールドを介して API キーにバインドします。
+
+#### ワークフロー
+
+```bash
+# 1. Create a policy (policyId is auto-generated when omitted)
+curl -X POST http://localhost:3000/admin/policies \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rules": [{ "ruleId": "permit", "effect": "Permit" }]
+  }'
+# Response: { "policyId": "550e8400-...", ... }
+
+# 2. Create API key with policyId binding
+curl -X POST http://localhost:3000/admin/api-keys \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Sensor key",
+    "allowedOrigins": ["*"],
+    "policyId": "<policyId from step 1>"
+  }'
+```
+
+> **注意:** `policyId` と `ruleId` は、省略された場合に自動生成されます (UUID)。ID はテナントごとに一意です — 異なるテナントは同じ ID を独立して使用できます。
+
+`policyId` が指定されている場合、バインドされたポリシーの `target` は評価時にバイパスされ、ポリシーの `rules` のみが評価されます。これにより、単一のポリシーをターゲットの競合なしで複数の認証情報間で共有できます。
+
+#### 動作
+
+| `policyId`            | Behavior                                             |
+| --------------------- | ---------------------------------------------------- |
+| Specified (valid)     | Bound policy rules are evaluated (target bypassed)   |
+| Specified (not found) | 400 error at creation/update                         |
+| `null` or omitted     | Tenant policies + role default (api\_key = All Deny) |
+
+#### ポリシーバインディングの更新
+
+`PATCH /admin/api-keys/{keyId}` を使用して、ポリシーバインディングを変更または削除します (管理者):
+
+```bash
+# Change the bound policy
+curl -X PATCH http://localhost:3000/admin/api-keys/{keyId} \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"policyId": "new-policy"}'
+
+# Remove policy binding (revert to default Deny)
+curl -X PATCH http://localhost:3000/admin/api-keys/{keyId} \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"policyId": null}'
+```
+
+セルフサービスキーの場合は、`PATCH /me/api-keys/{keyId}` を使用します — `policyId` は認証されたユーザーによって作成されたポリシーを参照する必要があります:
+
+```bash
+curl -X PATCH http://localhost:3000/me/api-keys/{keyId} \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"policyId": "my-readonly-policy"}'
+```
+
+### API キートークン交換 (Browser SDK)
+
+ブラウザベースのアプリケーションでは、キー漏洩のリスクがあるため、API キーを `X-Api-Key` ヘッダーで直接使用することはできません。代わりに、GeonicDB は Nonce + Proof of Work を使用して API キーを短命のセッション JWT に変換するトークン交換フローを提供します。
+
+#### フロー
+
+```text
+Browser                              GeonicDB
+  │                                      │
+  │  POST /auth/nonce                    │
+  │  Headers: Origin: <origin>           │
+  │  Body: { api_key }                   │
+  │ ──────────────────────────────────►  │
+  │  { nonce, challenge, difficulty }    │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  [Solve PoW: SHA256(challenge+n)]    │
+  │                                      │
+  │  POST /oauth/token                   │
+  │  Headers: Origin: <origin>           │
+  │  Body: { grant_type: "api_key",      │
+  │          api_key, nonce, proof }     │
+  │ ──────────────────────────────────►  │
+  │  { access_token, token_type,         │
+  │    expires_in, scope }               │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  GET /v2/entities                    │
+  │  Authorization: Bearer <JWT>         │
+  │ ──────────────────────────────────►  │
+```
+
+#### セキュリティレイヤー
+
+
+1. **Origin 検証**: Nonce は HMAC を介してリクエスト Origin に紐付けられます。Origin が一致しない場合は拒否されます
+   
+2. **HMAC Nonce**: ステートレス、サーバーシークレットで署名され、timestamp + Origin + keyId を含みます。TTL は 60 秒です
+   
+3. **Proof of Work**: SHA-256 ベース、difficulty=4 (先頭 4 ビットがゼロ)。外部依存なしで自動化された不正使用を防止します
+   
+4. **短命 JWT**: `api_key_session` タイプ、1 時間で期限切れ、policyId を埋め込みます
+
+#### JavaScript SDK
+
+GeonicDB は、トークン交換フロー全体を自動的に処理する npm パッケージ (`@geolonia/geonicdb-sdk`) として JavaScript SDK を提供します:
+
+```javascript
+import GeonicDB from '@geolonia/geonicdb-sdk';
+
+const db = new GeonicDB({
+  apiKey: 'gdb_your_api_key_here',
+  tenant: 'your-tenant',
+  baseUrl: 'https://your-geonicdb-instance'
+});
+
+db.getEntities({ type: 'TemperatureSensor' }).then(function(entities) {
+  console.log(entities);
+});
+```
+
+SDK は nonce の取得、PoW の解決、トークンのリフレッシュを透過的に処理します。
+
+#### 外部トークンインジェクション
+
+外部で Bearer JWT ログインを使用する場合(例:アプリケーションレベルのログインフロー)、`setCredentials()` を介して SDK にトークンを注入し、`on('tokenRefresh', cb)` でトークンリフレッシュの同期用にコールバックを登録します:
+
+```javascript
+var db = new GeonicDB({ tenant: 'my-tenant', baseUrl: 'https://...' });
+
+// Inject tokens obtained from an external login flow
+db.setCredentials({
+  token: loginResponse.accessToken,
+  tokenType: 'Bearer',
+  expiresIn: loginResponse.expiresIn,
+  refreshToken: loginResponse.refreshToken
+});
+
+// Sync refreshed tokens to application state (e.g., localStorage)
+db.on('tokenRefresh', function(creds) {
+  saveToStorage({ accessToken: creds.token, refreshToken: creds.refreshToken });
+});
+```
+
+> **注意**: `setCredentials()` が `tokenType: 'Bearer'` と `refreshToken` で呼び出された場合、以降のすべての API 呼び出しと `connect()` は DPoW/PoW を完全にバイパスします。トークン更新は `/auth/refresh` を使用するため、PoW の再計算は不要です。
+
+詳細については SDK ドキュメントを参照してください。
+
+### DPoP トークンバインディング (RFC 9449)
+
+GeonicDB は [RFC 9449](https://datatracker.ietf.org/doc/html/rfc9449) に準拠した DPoP (Demonstration of Proof-of-Possession) をサポートし、トークンをクライアントが保持する暗号鍵にバインドします。これによりトークンの盗難とリプレイ攻撃のリスクを排除します — JWT が傍受されたとしても、対応する秘密鍵なしでは使用できません。
+
+#### 動作原理
+
+
+1. **鍵ペアの生成**: クライアントは ECDSA P-256 鍵ペアを生成します (SDK は `crypto.subtle.generateKey` を `extractable: false` で使用)
+   
+2. **DPoP 証明によるトークン交換**: クライアントは `POST /oauth/token` の際に証明 JWT を含む `DPoP` ヘッダーを送信します
+   
+3. **トークンバインディング**: サーバーは証明を検証し、JWK Thumbprint ([RFC 7638](https://datatracker.ietf.org/doc/html/rfc7638)) を発行する JWT の `cnf.jkt` として埋め込みます
+   
+4. **リクエストごとの証明**: 各 API リクエストには新しい DPoP 証明が含まれます;サーバーは証明の `jkt` がトークンの `cnf.jkt` と一致することを検証します
+
+#### DPoP フロー
+
+```text
+Browser                              GeonicDB
+  │                                      │
+  │  [Generate ECDSA P-256 key pair]     │
+  │                                      │
+  │  POST /oauth/token                   │
+  │  Headers: Origin: <origin>           │
+  │           DPoP: <proof JWT>          │
+  │  Body: { grant_type: "api_key",      │
+  │          api_key, nonce, proof }      │
+  │ ──────────────────────────────────►  │
+  │  { access_token (cnf.jkt bound),    │
+  │    token_type: "DPoP", ... }         │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  GET /v2/entities                    │
+  │  Authorization: DPoP <JWT>           │
+  │  DPoP: <new proof JWT>              │
+  │ ──────────────────────────────────►  │
+  │  [Verify proof jkt == token cnf.jkt] │
+```
+
+#### DPoP-Nonce (RFC 9449 Section 8)
+
+GeonicDB は RFC 9449 Section 8 に準拠したサーバー提供のナンスを実装し、事前計算された DPoP 証明を防止します。ナンスハンドシェイクは透過的に行われます:
+
+
+1. クライアントは `nonce` クレームなしで DPoP 証明を送信します
+   
+2. サーバーは `error: "use_dpop_nonce"` と `DPoP-Nonce` レスポンスヘッダーを含む `400` を返します
+   
+3. クライアントは `nonce` クレームにサーバーナンスを含む新しい DPoP 証明を作成します
+   
+4. サーバーはナンスを検証してトークンを発行します;レスポンスには後続のリクエスト用の新しい `DPoP-Nonce` が含まれます
+
+```text
+Browser                              GeonicDB
+  │                                      │
+  │  POST /oauth/token                   │
+  │  DPoP: <proof (no nonce)>            │
+  │ ──────────────────────────────────►  │
+  │  400 { error: "use_dpop_nonce" }     │
+  │  DPoP-Nonce: <server-nonce>          │
+  │ ◄──────────────────────────────────  │
+  │                                      │
+  │  POST /oauth/token                   │
+  │  DPoP: <proof (nonce: server-nonce)> │
+  │ ──────────────────────────────────►  │
+  │  200 { access_token, token_type }    │
+  │  DPoP-Nonce: <next-nonce>            │
+  │ ◄──────────────────────────────────  │
+```
+
+ナンスはステートレス (HMAC ベース) で、TTL は 300 秒です。データベースストレージは不要です。
+
+DPoP バインドトークンを使用した API リクエストもナンスを必要とします。サーバーは成功したレスポンスごとに、また `use_dpop_nonce` メッセージを含む `401` エラーの際に `DPoP-Nonce` ヘッダーを返します。
+
+#### DPoP 証明 JWT 構造
+
+```json
+// Header
+{
+  "typ": "dpop+jwt",
+  "alg": "ES256",
+  "jwk": { "kty": "EC", "crv": "P-256", "x": "...", "y": "..." }
+}
+
+// Payload
+{
+  "jti": "<unique identifier>",
+  "htm": "POST",
+  "htu": "https://api.example.com/oauth/token",
+  "iat": 1710000000,
+  "nonce": "<server-issued DPoP-Nonce>",
+  "ath": "<SHA-256 hash of access token>"  // Only for API requests, not token exchange
+}
+```
+
+| Claim   | Description                                                    |
+| ------- | -------------------------------------------------------------- |
+| `jti`   | Unique proof identifier (replay prevention)                    |
+| `htm`   | HTTP method of the request                                     |
+| `htu`   | HTTP URI of the request (scheme + host + path)                 |
+| `iat`   | Issued-at timestamp (max age: 120 seconds)                     |
+| `nonce` | Server-issued DPoP-Nonce (required when server enforces nonce) |
+| `ath`   | Access token hash (required when using with a bound token)     |
+
+#### `dpopRequired` フラグ
+
+API キーは、作成時に `dpopRequired: true` を設定することで DPoP を強制できます:
+
+```bash
+curl -X POST https://api.example.com/admin/api-keys \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "secure-key", "allowedOrigins": ["https://app.example.com"], "dpopRequired": true}'
+```
+
+`dpopRequired` が `true` の場合、有効な `DPoP` ヘッダーなしでトークン交換を行うと `400 invalid_dpop_proof` が返されます。
+
+#### Bearer フォールバック
+
+トークン交換時に `DPoP` ヘッダーが送信されず(`dpopRequired` が `false` の場合)、サーバーはバインディングなしの標準 `Bearer` トークンを発行します。これにより、DPoP をサポートしていないクライアントとの後方互換性が維持されます。
+
+| DPoP Header    | `dpopRequired` | Result                                      |
+| -------------- | -------------- | ------------------------------------------- |
+| Present, valid | `false`        | `token_type: "DPoP"` with `cnf.jkt` binding |
+| Present, valid | `true`         | `token_type: "DPoP"` with `cnf.jkt` binding |
+| Absent         | `false`        | `token_type: "Bearer"` (no binding)         |
+| Absent         | `true`         | `400 invalid_dpop_proof` (rejected)         |
+
+> **注意**: すべての DPoP バウンドリクエスト(トークン交換と API 呼び出し)は nonce ハンドシェイクに参加します。JavaScript SDK はこれを透過的に処理します。
+
+#### SDK DPoP サポート
+
+JavaScript SDK (`@geolonia/geonicdb-sdk`) は、`crypto.subtle` が利用可能な場合に自動的に DPoP を有効にします:
+
+
+* 初期化時に抽出不可能な ECDSA P-256 鍵ペアを生成
+  
+* トークン交換と API リクエストに DPoP プルーフを添付
+  
+* `crypto.subtle` がない環境では Bearer モードにフォールバック
+  
+* トークン交換と API リクエストの両方で `use_dpop_nonce` リトライを自動的に処理
+  
+* WebSocket 接続は、プルーフ検証のために接続後の `dpop_bind` メッセージを使用
+
+利用可能なすべてのメソッドについては、完全な SDK API リファレンスを参照してください。
+
+#### DPoP と HTTP キャッシュの相互作用 (#1052)
+
+DPoP は HTTP キャッシュフローの 3 つのポイントに影響を与えます:
+
+
+1. **`Vary` に DPoP プルーフ JWT を含めるか?** — いいえ。プルーフにはリクエストごとの `jti` と `iat` が含まれているため、これを `Vary` に追加するとすべてのリクエストがキャッシュミスになります。`Authorization` にバインドされたアクセストークンが重要なキャッシュキーの次元であり、プルーフは別途検証され、本文コンテンツには影響しません。
+   
+2. **`304 Not Modified` での `DPoP-Nonce`** — はい、スルーされます。キャッシュコントロールミドルウェアは、304 レスポンスヘッダー(`evaluateConditionalRequest`)で `DPoP-Nonce` をホワイトリストに登録します。サーバーが nonce をローテーションすると、`304` でも最新の nonce が配信されるため、クライアントが遅れることはありません。このスルーがない場合、`304` を受信したクライアントは古い nonce で再試行し、次のリクエストで `401 + use_dpop_nonce` に遭遇します。
+   
+3. **DPoP 認証失敗** — 古いまたは欠落している DPoP プルーフは、`evaluateConditionalRequest` が実行される前に `requireAuth` で拒否されます([ポリシー伝播遅延](#policy-propagation-delay--http-cache-integrity-1050)でハンドラーの順序を参照)。古い `If-None-Match` は、以前の有効なセッションから `304` を再表示することはできません — レスポンスは `401` であり、決して `304` ではありません。
+
+セキュリティモデルについては、SECURITY.md — DPoP & Cache Integrity を参照してください。
+
+***
+
+## OAuth 2.0 M2M 認証
+
+GeonicDB は、OAuth 2.0 Client Credentials フローを介したマシン間(M2M)認証をサポートしています。
+
+### 概要
+
+OAuth 2.0 Client Credentials フローは、サーバー間通信やバックグラウンドジョブなどのマシン間(M2M)シナリオに最適化された認証方法です。
+
+### OAuth 2.0 を使用するタイミング
+
+
+* **マシン間通信**: API 間の呼び出し
+  
+* **バックグラウンドジョブ**: ユーザーインタラクションなしのバッチ処理
+  
+* **サービス間統合**: マイクロサービス間の認証
+  
+* **CI/CD パイプライン**: 自動化されたデプロイメントとテストでの API アクセス
+  
+* **きめ細かなアクセス制御**: スコープベースの権限管理が必要な場合
+
+### OAuth 2.0 と JWT 認証の違い
+
+| Item                       | OAuth 2.0 Client Credentials                                    | JWT Authentication                                    |
+| -------------------------- | --------------------------------------------------------------- | ----------------------------------------------------- |
+| **Authentication subject** | Client application (machine)                                    | User (human)                                          |
+| **Token acquisition**      | `POST /oauth/token`                                             | `POST /auth/login`                                    |
+| **Credentials**            | Client ID + Client Secret (Basic auth)                          | Email + Password                                      |
+| **Access control**         | Scope-based                                                     | Role-based                                            |
+| **Token expiration**       | Short-lived (default: 1 hour; unlimited with `permanent` scope) | Access token: 1 hour, Refresh token: 7 days           |
+| **Refresh token**          | None (re-request when expired)                                  | Available (can be refreshed via `POST /auth/refresh`) |
+
+### OAuth クライアント管理
+
+| Endpoint                                            | Method | Description              |
+| --------------------------------------------------- | ------ | ------------------------ |
+| `/admin/oauth-clients`                              | GET    | Get OAuth client list    |
+| `/admin/oauth-clients`                              | POST   | Create OAuth client      |
+| `/admin/oauth-clients/{clientId}`                   | GET    | Get OAuth client         |
+| `/admin/oauth-clients/{clientId}`                   | PATCH  | Update OAuth client      |
+| `/admin/oauth-clients/{clientId}`                   | DELETE | Delete OAuth client      |
+| `/admin/oauth-clients/{clientId}/regenerate-secret` | POST   | Regenerate Client Secret |
+
+### セルフサービス OAuth クライアント管理
+
+ユーザーは管理者権限なしで独自の OAuth クライアントを作成および管理できます。セルフサービスで作成されたクライアントはユーザーにスコープされ、ロールベースの制限の対象となります。
+
+| Endpoint                                         | Method | Description                       |
+| ------------------------------------------------ | ------ | --------------------------------- |
+| `/me/oauth-clients`                              | POST   | Create own OAuth client           |
+| `/me/oauth-clients`                              | GET    | List own OAuth clients            |
+| `/me/oauth-clients/{clientId}`                   | PATCH  | Update own OAuth client (partial) |
+| `/me/oauth-clients/{clientId}`                   | DELETE | Delete own OAuth client           |
+| `/me/oauth-clients/{clientId}/regenerate-secret` | POST   | Regenerate own client secret      |
+
+**制限事項:**
+
+* ユーザーあたり最大 **5 クライアント**
+  
+* `policyId` はオプションです — 指定された場合、参照されるポリシーは既に存在し、同じユーザーによって作成されている必要があります。省略された場合、認可はテナントポリシー + ロールデフォルト(`user` のデフォルトは GET のみの Permit)にフォールバックします
+  
+* `clientSecret` は作成時と再生成時にのみ返されます — 安全に保管してください
+
+**PATCH で更新可能なフィールド** (`PATCH /me/oauth-clients/{clientId}`):
+
+| Field         | Type                 | Description                                                  |
+| ------------- | -------------------- | ------------------------------------------------------------ |
+| `name`        | string               | Client name                                                  |
+| `description` | string               | Client description                                           |
+| `policyId`    | string \| null | Policy binding (must be created by you, or `null` to unbind) |
+| `isActive`    | boolean              | Activate / deactivate the client                             |
+
+### トークンリクエスト
+
+```bash
+curl -X POST https://api.example.com/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&scope=read:entities write:entities"
+```
+
+**レスポンス例:**
+
+```json
+{
+  "access_token": "eyJhbGc...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read:entities write:entities"
+}
+```
+
+### レート制限 (#1075)
+
+`POST /oauth/token` は **クライアント IP** ごとおよび **`client_id`** ごとにレート制限されており、`client_id+client_secret` ペアのオフライン総当たり攻撃を防止します。
+
+| Bucket          | Per minute | Per hour | Per day | Burst |
+| --------------- | ---------: | -------: | ------: | ----: |
+| Per IP          |         20 |      100 |     500 |     5 |
+| Per `client_id` |         10 |       60 |     200 |     2 |
+
+両方のバケットがリクエストを許可する必要があります。どちらかを超過すると `429 Too Many
+Requests` が `Retry-After` ヘッダーとともに返されます。同じ IP ごとのスキームは
+`/auth/refresh` と `/auth/nonce` (`PUBLIC_RATE_LIMIT` の `auth` カテゴリ)も保護します。
+完全な設定については [QUOTAS.md — Public (Unauthenticated) Endpoint Rate Limit](../saas/quotas.md#public-unauthenticated-endpoint-rate-limit-1075)
+を参照してください。
+
+### スコープシステム
+
+| Scope                      | Description                                                               | `user` | `tenant_admin` | `super_admin` |
+| -------------------------- | ------------------------------------------------------------------------- | :----: | :------------: | :-----------: |
+| `read:entities`            | Read entities                                                             |    ✅   |        ✅       |       ✅       |
+| `write:entities`           | Write entities (create/update/delete only)                                |    ✅   |        ✅       |       ✅       |
+| `read:subscriptions`       | Read subscriptions                                                        |    ✅   |        ✅       |       ✅       |
+| `write:subscriptions`      | Write subscriptions (create/update/delete only)                           |    ✅   |        ✅       |       ✅       |
+| `read:registrations`       | Read registrations                                                        |    ✅   |        ✅       |       ✅       |
+| `write:registrations`      | Write registrations (create/update/delete only)                           |    ✅   |        ✅       |       ✅       |
+| `read:rules`               | Read rules                                                                |    ✅   |        ✅       |       ✅       |
+| `write:rules`              | Write rules (create/update/delete only)                                   |    ✅   |        ✅       |       ✅       |
+| `read:custom-data-models`  | Read custom data models                                                   |    ✅   |        ✅       |       ✅       |
+| `write:custom-data-models` | Write custom data models (create/update/delete only)                      |    ✅   |        ✅       |       ✅       |
+| `admin:users`              | Access to user management API (`/admin/users`)                            |    ❌   |        ✅       |       ✅       |
+| `admin:policies`           | Access to policy management API (`/admin/policies`, `/admin/policy-sets`) |    ❌   |        ✅       |       ✅       |
+| `admin:oauth-clients`      | Access to OAuth client management API (`/admin/oauth-clients`)            |    ❌   |        ✅       |       ✅       |
+| `admin:metrics`            | Access to metrics API (`/admin/metrics`)                                  |    ❌   |        ✅       |       ✅       |
+| `admin:tenants`            | Access to tenant management API (`/admin/tenants`)                        |    ❌   |        ❌       |       ✅       |
+| `permanent`                | Set token to never expire (no expiration)                                 |    —   |        —       |       —       |
+| `jwt`                      | JWT format token                                                          |    —   |        —       |       —       |
+
+> **スコープ階層**: `write:X` は `read:X` を**暗黙的に含みません** — スコープは独立しています。これにより、公開お問い合わせフォームなどの書き込み専用ユースケースが可能になります。`admin:X` は `read:X` と `write:X` の両方を暗黙的に含みます。`admin:*` スコープを持つ OAuth トークンは Admin API にアクセスでき、通常の JWT ロールベース認証をバイパスします。通常の JWT トークン(`scope` フィールドなし)は、後方互換性のためスコープチェックをスキップします。
+>
+> **セルフサービス(`/me/oauth-clients`)のロール制限**: ユーザーは自分のロールに許可されたスコープのみをリクエストできます。`user` はリソーススコープのみをリクエスト可能です。`tenant_admin` は加えて `admin:tenants` を除く `admin:*` スコープをリクエスト可能です。`super_admin` はすべてのスコープをリクエスト可能です。
+
+***
+
+## OIDC 外部 IdP 認証
+
+GeonicDB は OIDC(OpenID Connect)に準拠した外部 IdP による認証をサポートしています。
+
+### 有効化
+
+```bash
+export AUTH_ENABLED=true
+export OIDC_ENABLED=true
+export OIDC_ISSUER=https://accounts.google.com
+export OIDC_AUDIENCE=your-client-id.apps.googleusercontent.com
+```
+
+### 動作
+
+
+1. クライアントは外部 IdP から ID トークンを取得します
+   
+2. GeonicDB API リクエストに `Authorization: Bearer <id_token>` を含めます
+   
+3. GeonicDB は OIDC Discovery + JWKS を介して署名を検証します
+   
+4. メールアドレス(`email` クレーム)によって GeonicDB DB 内のユーザーを検索します
+   
+5. ユーザーが存在する場合、認証が成功します
+
+### サポートされている IdP
+
+
+* Google
+  
+* Microsoft Entra ID(Azure AD)
+  
+* Auth0
+  
+* その他の OIDC 準拠 IdP
+
+***
+
+## XACML ポリシーベース認可
+
+GeonicDB は XACML 3.0 準拠のポリシーベースアクセス制御をサポートしています。
+
+### ポリシー管理
+
+| Endpoint                                | Method | Description             |
+| --------------------------------------- | ------ | ----------------------- |
+| `/admin/policies`                       | GET    | Get policy list         |
+| `/admin/policies`                       | POST   | Create policy           |
+| `/admin/policies/{policyId}`            | GET    | Get policy              |
+| `/admin/policies/{policyId}`            | PATCH  | Update policy (partial) |
+| `/admin/policies/{policyId}`            | PUT    | Replace policy          |
+| `/admin/policies/{policyId}`            | DELETE | Delete policy           |
+| `/admin/policies/{policyId}/activate`   | POST   | Activate policy         |
+| `/admin/policies/{policyId}/deactivate` | POST   | Deactivate policy       |
+
+### ターゲットマッチングセマンティクス
+
+`subjects`、`resources`、`actions` 配列内:
+
+* **同じ `attributeId`**: OR(いずれかがマッチすれば満たす) — 例:`[{method: POST}, {method: PATCH}]` は POST **または** PATCH にマッチします
+  
+* **異なる `attributeId`**: AND(すべてがマッチする必要がある) — 例:`[{role: user}, {userId: u1}]` は両方が必要です
+  
+* **カテゴリ間**(`subjects` + `resources` + `actions`): AND
+
+### マッチ関数(GeonicDB 拡張を含む)
+
+ポリシーの Target 内の AttributeMatch で利用可能な `matchFunction` の値:
+
+| matchFunction   | Description                              | XACML 3.0                        |
+| --------------- | ---------------------------------------- | -------------------------------- |
+| `string-equal`  | Exact match (default)                    | Standard                         |
+| `string-regexp` | Regular expression match                 | Standard (`string-regexp-match`) |
+| `glob`          | Glob pattern match (`*`, `**` supported) | **GeonicDB extension**           |
+
+**自動 glob 検出(GeonicDB 拡張)**: `matchFunction` が省略された場合、`matchValue` に `*` が含まれていれば自動的に `glob` として処理されます。それ以外の場合は `string-equal` が適用されます。
+
+**XACML XML エクスポート**: `glob` は XACML 3.0 仕様には存在しないため、エクスポート時には正規表現に変換され `string-regexp-match` として出力されます。
+
+### 暗黙的ポリシー階層
+
+GeonicDB は以下の暗黙的ポリシーを適用します(DB ルックアップをスキップ):
+
+| Priority             | Role           | Behavior                                            |
+| -------------------- | -------------- | --------------------------------------------------- |
+| Custom policies (0+) | any            | Custom XACML policies always override defaults      |
+| 0                    | `super_admin`  | Management APIs always Permit. Data APIs Deny (403) |
+| 0                    | `tenant_admin` | Always Permit (all APIs within own tenant)          |
+| -1                   | `user`         | GET → Permit, all other methods → Deny (readonly)   |
+| -2                   | `api_key`      | All Deny (explicit Permit policy required)          |
+| -3                   | `anonymous`    | All Deny (explicit Permit policy required)          |
+
+> **重要**: カスタム XACML ポリシー(優先度 0 以上)は常にロールのデフォルトをオーバーライドします。`user` に書き込みアクセスを付与するには、優先度 ≥ 0 の Permit ポリシーを作成してください。
+>
+> **同点処理**: 優先度が等しい場合、決定論的な結果を得るためにポリシーは `policyId` で辞書順に評価されます。テナントのカスタムポリシー(DB に保存)はロールのデフォルトと結合され、一緒にソートされます。
+
+### リソース属性
+
+ポリシー Target 内の `resources` で以下の属性が利用可能です:
+
+| attributeId            | Description                                                                  | Source                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `path`                 | HTTP request path (e.g. `/v2/entities/Room1`)                                | Request                                                                    |
+| `tenantService`        | Tenant service name (`Fiware-Service` header)                                | Request                                                                    |
+| `servicePath`          | Service path (`Fiware-ServicePath` header, e.g. `/devices`, `/opendata`)     | Request                                                                    |
+| `scope`                | NGSI-LD entity scope (comma-separated, e.g. `/Madrid/parks,/Madrid/gardens`) | Entity context                                                             |
+| `entityId`             | Target entity ID (e.g. `Room1`)                                              | Entity context / Subscription `entities[].id`                              |
+| `entityType`           | Target entity type (e.g. `Room`)                                             | Request (auto-extracted) / Entity context / Subscription `entities[].type` |
+| `entityOwner`          | Entity creator's userId (`createdBy` field)                                  | Entity context                                                             |
+| `entityIdPattern`      | Subscription target id pattern (e.g. `urn:ngsi-ld:Sensor:.*`)                | Subscription `entities[].idPattern`                                        |
+| `notificationEndpoint` | Subscription notification endpoint URI (e.g. `https://hooks.example.com/x`)  | Subscription `notification.endpoint.uri`                                   |
+
+> **注意**: `entityId`、`entityOwner`、`scope` はエンティティレベルの認可チェック(`requireEntityAuthz` 経由)でのみ利用可能です。`entityType` は HTTP リクエストからパスレベルで自動的に抽出されます — `?type=` クエリパラメータまたはリクエストボディの `type` / `@type` フィールドから — これによりエンティティレベルのチェックなしでエンティティタイプベースのアクセス制御が可能になります。`servicePath` は `Fiware-ServicePath` ヘッダーから自動的に抽出され、パスレベルとエンティティレベルの両方のチェックで利用可能です — 階層的なパスマッチングのための glob パターン(例: `/opendata/**`)をサポートします。`scope` は NGSIv2 の `servicePath` に相当する NGSI-LD のエンティティレベルの概念です — エンティティが複数の scope 値を持つ場合(例: `["/Madrid/parks", "/Madrid/gardens"]`)、それらは `string-regexp` または `glob` でのマッチングのためにカンマ区切りの文字列として結合されます。**NGSI-LD サブスクリプション作成(`POST /ngsi-ld/v1/subscriptions`)**: リテラルの `body.type === "Subscription"` は `entityType` には**注入されません** — 代わりに、PIP は `entities[]` から**サブスクリプションターゲット**を抽出し、`notification.endpoint.uri` から**通知先**を抽出します。`entities[]` に複数の要素が含まれる場合、要素ごとに 1 つの AuthzRequest が構築され、リクエストが成功するには**それらすべてが Permit でなければなりません**(全 Permit セマンティクス)。これにより、タイプベースのポリシー(「匿名は `ActivityLog` のみサブスクリプションライブ可能」)と URI ベースのポリシー(「サブスクリプションは `https://*.example.com/**` にのみ通知を POST 可能」、SSRF / データ流出に対する防御)を記述できます。以下の [Subscription PIP 属性](#subscription-pip-属性) を参照してください。
+
+### パスレベル vs エンティティレベルの認可
+
+GeonicDB は 2 段階の認可モデルを使用します。各段階では XACML 評価を使用しますが、**`NotApplicable` のデフォルト決定は設計上異なります**。
+
+| Stage        | Middleware             | Triggered when                                             | NotApplicable behavior |
+| ------------ | ---------------------- | ---------------------------------------------------------- | ---------------------- |
+| Path-level   | `requireAuthz()`       | Every authenticated request                                | **Deny (fail-closed)** |
+| Entity-level | `requireEntityAuthz()` | Entity CRUD with concrete entity (after path-level passes) | **Permit (fail-open)** |
+
+#### パスレベルがフェイルクローズである理由
+
+適用可能なポリシーがない場合、リクエストは拒否されなければなりません。そうでなければ、特権のないユーザーが、どのポリシーも明示的に許可していないパスを呼び出すことができてしまいます。デフォルトのロールポリシー(`__default_user`、`__default_api_key` など)により、パス段階では常に少なくとも 1 つの適用可能なルールが存在することが保証されます。
+
+#### エンティティレベルがフェイルオープンである理由(設計上)
+
+`requireEntityAuthz()` が実行される時点で、パス段階は**すでに Permit を生成しています**。エンティティレベルの評価は、リクエストをゼロから再認可するのではなく、**追加の**制約(例:オーナーのみ、スコープベース)を適用することを目的としています。
+
+エンティティレベルがフェイルクローズの場合、テナントにエンティティを対象としたポリシーがないリクエストは、パスがすでに許可されているにもかかわらず、すべて拒否されます。これにより、CRUD を機能させ続けるために、すべてのテナントがデフォルト許可のエンティティポリシーを記述する必要が生じ、エラーが発生しやすく、レイヤリングの意図に反することになります。
+
+**結果**:属性ベースのきめ細かい制御(例:「ユーザーは自分が作成したエンティティのみを変更できる」)には、エンティティレベルでの**明示的な Deny ルール**が必要です。ルールが存在しない場合は Deny **されません** — ターゲットが一致しない Permit、または明示的な Deny のみが効果を発揮します。
+
+#### 例:オーナーのみの更新の強制
+
+`PATCH /v2/entities/{id}/attrs` をエンティティのオーナーに制限するには、明示的な Deny を記述します:
+
+```json
+{
+  "description": "Users can only modify entities they own",
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "ruleId": "deny-non-owner",
+      "effect": "Deny",
+      "target": {
+        "subjects": [{ "attributeId": "role", "matchValue": "user" }],
+        "actions": [{ "attributeId": "method", "matchValue": "PATCH" }],
+        "resources": [
+          { "attributeId": "path", "matchValue": "/v2/entities/**", "matchFunction": "glob" }
+        ]
+      },
+      "condition": {
+        "function": "string-not-equal",
+        "args": ["${subject.userId}", "${resource.entityOwner}"]
+      }
+    }
+  ]
+}
+```
+
+このような明示的なルールがない場合、エンティティレベルの評価は `NotApplicable` を返し、リクエストは許可されます(パス段階ですでに許可されているため)。
+
+### WebSocket 認可 (WS ⊂ GET)
+
+WebSocket サブスクリプションとブロードキャストは、`GET` のサブセットである **読み取り専用ストリーム** として評価されます。`authorizeWs()` PIP (`src/core/auth/policy/policy.pip.ts`) は、各 WebSocket リクエストを **2回** 評価します — 1回目は `action.method = 'WS'`、2回目は `action.method = 'GET'` で評価し、**両方** の評価が `Permit` を返す場合のみアクセスを許可します。
+
+この不変条件は、ポリシー作成者にとって2つの実用的な結果をもたらします:
+
+
+1. **`GET` を Deny するポリシーは自動的に `WS` も Deny します。** ルールで `WS` を繰り返す必要はありません。2回目の評価が同じ Deny を拾います。
+   
+2. **`WS` のみを対象とするポリシーは通常、設定ミスです。** 2回目の評価が `GET` にフォールバックするため、`WS` のみを拒否しても基礎となるデータは保護されません — クライアントは依然として `GET /v2/entities/...` 経由でそれを読み取ることができます。逆に、`GET` も許可されていない場合、`WS` のみを許可しても意味がありません。
+
+#### 作成ガイダンス
+
+特定のロール/テナントに対してストリーミングを制限したい場合は、`GET` に対してルールを記述してください(または `actions` を完全に省略してルールがすべてのメソッドに適用されるようにします)。`WS` に言及するのは、ルールが *両方* に適用される必要がある場合のみです:
+
+```json
+{
+  "actions": [
+    { "attributeId": "method", "matchValue": "WS" },
+    { "attributeId": "method", "matchValue": "GET" }
+  ]
+}
+```
+
+#### 検出
+
+`PolicyService.validateWsGetSymmetry()` (#1085) は、ルールの `actions` に `method = 'WS'` (`string-equal`) が含まれているが、対応する `'GET'` エントリがない場合に `WARN` ログを出力します。これは `createPolicy`、`updatePolicy`、`updatePolicySystem`、`updatePolicyForUser` (セルフサービス `/me/policies` 更新を含む) を含むすべての書き込みパスで実行されます。後方互換性を維持するためにポリシーは受け入れられますが、警告はルールを見直すシグナルとなります。
+
+```text
+[WARN] PolicyService — Policy rule 'ws-only-deny' targets method='WS' without an explicit 'GET'
+counterpart. WebSocket authorization evaluates both WS and GET, so WS-only rules typically do not
+restrict the data path that GET serves.
+```
+
+#### ブロードキャスト時のエンティティごとの属性 (#1107)
+
+WebSocket ブロードキャスター (`src/handlers/websocket/broadcaster.ts`、`src/core/streaming/local-ws-server.ts`) が変更イベントを接続に配信するかどうかを決定する際、以下のエンティティごとの属性を AuthzRequest に注入します:
+
+| attributeId   | Source                                                      | Use case                                              |
+| ------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
+| `entityType`  | `EntityChangeEvent.entity.type`                             | "Only forward `ActivityLog` events to clients"        |
+| `entityId`    | `EntityChangeEvent.entity.id`                               | "Forward only `urn:ngsi-ld:Room:42` events"           |
+| `entityOwner` | `EntityChangeEvent.entity.owner` (the entity's `createdBy`) | "Forward only events for entities the recipient owns" |
+
+`entityOwner` 属性は、`${subject.userId}` テンプレート展開と組み合わせることで、単一の XACML ポリシーで **ユーザーごとの「自分のみ」配信フィルター** を表現できます:
+
+```jsonc
+// Each user receives only updates to entities they created
+{
+  "policyId": "ws-self-only-feed",
+  "target": {
+    "subjects": [{ "attributeId": "role", "matchValue": "user" }],
+    "resources": [
+      { "attributeId": "path", "matchValue": "/v2/**", "matchFunction": "glob" },
+      { "attributeId": "entityType", "matchValue": "GeoJSON" }
+    ]
+  },
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    // Allow the user to create their own entity (no owner exists at POST time)
+    { "ruleId": "permit-write", "effect": "Permit",
+      "target": { "actions": [
+        { "attributeId": "method", "matchValue": "POST" },
+        { "attributeId": "method", "matchValue": "PATCH" },
+        { "attributeId": "method", "matchValue": "PUT" }
+      ] }
+    },
+    // For WS / GET, only forward entities the subject owns
+    { "ruleId": "permit-self-read", "effect": "Permit",
+      "target": { "resources": [
+        { "attributeId": "entityOwner", "matchValue": "${subject.userId}" }
+      ] }
+    },
+    { "ruleId": "default-deny", "effect": "Deny" }
+  ]
+}
+```
+
+> **キャッシングに関する注意**: ブロードキャスターは、単一のブロードキャスト内で `(role, policyId, userId)` ごとに認可決定をキャッシュします — 所有者ベースのポリシーは、固定された entityType/entityOwner であってもユーザーごとの決定を生成するため、`userId` はキーに含まれている必要があります。同じ userId を持つマルチデバイスユーザーでも、1つのイベント内ではキャッシュされた決定を共有します。
+>
+> **`entity.owner` のソース**: 変更イベントを公開する際に `EntityService` によって透過的に設定されます。これはエンティティの `createdBy` フィールド(`POST` 時に認証されたユーザーによって設定される)から取得されます — `createdBy` を持たないエンティティ(レガシー/バッチ/非認証書き込み)は `owner` なしでイベントを発行し、その場合、所有者ベースのルールはマッチせず、次のルールが適用されます。
+
+### Subscription PIP 属性
+
+`POST /ngsi-ld/v1/subscriptions` (NGSI-LD サブスクリプション作成) の場合、PIP はサブスクリプションボディから引き出された 3 つの追加リソース属性を注入します。**ただし、リテラル `body.type === "Subscription"` は意図的に `entityType` として公開されません**:
+
+| attributeId            | Source field                | Use case                                                                                                  |
+| ---------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `entityType`           | `entities[].type`           | "Anonymous can only subscribe to `ActivityLog`"                                                           |
+| `entityId`             | `entities[].id`             | "Allow subscribing only to `urn:ngsi-ld:Room:1`"                                                          |
+| `entityIdPattern`      | `entities[].idPattern`      | "Allow subscribing only when the pattern matches `urn:ngsi-ld:Sensor:.*`"                                 |
+| `notificationEndpoint` | `notification.endpoint.uri` | "Notifications may only be sent to `https://*.example.com/**`" — defence against SSRF / data exfiltration |
+
+#### 複数エンティティの全 Permit セマンティクス
+
+`entities[]` に複数の要素が含まれている場合、PEP は **要素ごとに 1 つの AuthzRequest** を評価し、**すべての** AuthzRequest が `Permit` を返した場合にのみリクエストが許可されます。1 つでも `Deny` / `NotApplicable` / `Indeterminate` があると、リクエスト全体が `403 Forbidden` にショートサーキットされます。これにより、「最初の要素は問題なく見えるが、残りを忍び込ませる」というバイパスを防ぎます:
+
+```jsonc
+// All elements must satisfy the policy. With a policy that permits only ActivityLog,
+// this body is rejected because { type: "Building" } is not permitted.
+{
+  "type": "Subscription",
+  "entities": [{ "type": "ActivityLog" }, { "type": "Building" }],
+  "notification": { "endpoint": { "uri": "http://localhost:1028/notify" } }
+}
+```
+
+#### 例: 型ベース + URI ベースの制御の組み合わせ
+
+```json
+{
+  "policyId": "anon-subscribe-activity-only",
+  "target": {
+    "subjects": [{ "attributeId": "role", "matchValue": "anonymous" }],
+    "resources": [{ "attributeId": "path", "matchValue": "/ngsi-ld/v1/subscriptions" }],
+    "actions": [{ "attributeId": "method", "matchValue": "POST" }]
+  },
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "ruleId": "allow-activitylog-to-internal-hooks",
+      "effect": "Permit",
+      "target": {
+        "resources": [
+          { "attributeId": "entityType", "matchValue": "ActivityLog" },
+          { "attributeId": "notificationEndpoint", "matchValue": "https://*.example.com/**", "matchFunction": "glob" }
+        ]
+      }
+    },
+    { "ruleId": "deny-rest", "effect": "Deny" }
+  ]
+}
+```
+
+このポリシーは、サブスクリプションのターゲット型が `ActivityLog` *かつ* 通知エンドポイントが `*.example.com` 上にある場合にのみ許可します。`resources` 内の異なる `attributeId` は AND 結合されます([ターゲットマッチングセマンティクス](#ターゲットマッチングセマンティクス)を参照)。
+
+> **スコープ外 (#1104)**: `PATCH /ngsi-ld/v1/subscriptions/{id}` は、この同じ書き換えを**まだ**適用していません — レガシーの単一 AuthzRequest パスがまだ使用されています。したがって、サブスクリプションの更新は、新しいターゲット / 通知エンドポイントではなく、パス / ロールに対してのみ評価されます。脅威モデルで必要な場合は、これをフォローアップとして追跡してください。
+
+### テンプレート変数 (GeonicDB 拡張)
+
+`matchValue` は `${subject.<attributeId>}` テンプレート変数をサポートしており、評価時にリクエストサブジェクトの属性値に解決されます。これにより、ユーザー ID をハードコーディングすることなく「所有者のみ」アクセスのような動的なポリシーを実現できます。
+
+| Template            | Resolves to             |
+| ------------------- | ----------------------- |
+| `${subject.userId}` | Requesting user's ID    |
+| `${subject.email}`  | Requesting user's email |
+| `${subject.role}`   | Requesting user's role  |
+
+#### 例:エンティティ所有者のみのポリシー
+
+```json
+{
+  "description": "Users can only operate on entities they created",
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "effect": "Permit",
+      "target": {
+        "resources": [
+          { "attributeId": "entityOwner", "matchValue": "${subject.userId}" }
+        ]
+      }
+    },
+    {
+      "effect": "Deny"
+    }
+  ]
+}
+```
+
+> `policyId` と `ruleId` は省略された場合に自動生成されます。
+
+このポリシーは、`entityOwner`(エンティティの `createdBy` 値)がリクエストしているユーザーの `userId` と一致する場合にのみアクセスを許可します。それ以外のすべてのリクエストは拒否されます。
+
+#### 例:ServicePathベースのアクセス制御
+
+```json
+{
+  "description": "Allow anonymous read access to /opendata/ service path",
+  "target": {
+    "subjects": [{ "attributeId": "role", "matchValue": "anonymous" }],
+    "resources": [{ "attributeId": "servicePath", "matchValue": "/opendata/**" }],
+    "actions": [{ "attributeId": "method", "matchValue": "GET" }]
+  },
+  "rules": [{ "ruleId": "permit-read", "effect": "Permit" }],
+  "priority": 100
+}
+```
+
+このポリシーは、匿名ユーザーが `/opendata/` ServicePath配下(ネストされた `/opendata/sensors` のようなパスを含む)のエンティティを読み取ることを許可します。glob パターン `/**` は 0 個以上のパスセグメントにマッチします。
+
+#### 例:NGSI-LD スコープベースのアクセス制御
+
+```json
+{
+  "description": "Allow read access only to entities scoped under /Madrid",
+  "ruleCombiningAlgorithm": "first-applicable",
+  "rules": [
+    {
+      "ruleId": "allow-madrid-read",
+      "effect": "Permit",
+      "target": {
+        "resources": [
+          { "attributeId": "scope", "matchValue": "(^|,)/Madrid(/[^,]*)?(,|$)", "matchFunction": "string-regexp" }
+        ],
+        "actions": [{ "attributeId": "method", "matchValue": "GET" }]
+      }
+    },
+    { "ruleId": "deny-all", "effect": "Deny" }
+  ],
+  "priority": 50
+}
+```
+
+このポリシーは、`scope` が `/Madrid` 自体、またはその配下の子パス(例:`["/Madrid/parks"]`)であるエンティティへの読み取りアクセスを許可します。エンティティのスコープは配列として保存され、カンマ区切り文字列(例:`"/Madrid/parks,/Madrid/gardens"`)にシリアライズされるため、意図しない部分一致を避けるために境界を認識する `string-regexp` パターン(`(^|,)` と `(,|$)` アンカーを使用)を推奨します。単一値の完全一致の場合は、`string-equal` が直接機能します(例:`matchValue: "/Madrid"`)。
+
+### デフォルトポリシー
+
+GeonicDB には以下のデフォルトポリシーが設定されています:
+
+
+* **Admin API**:`super_admin` のみアクセス可能
+  
+* **Rules API**:`super_admin` または `tenant_admin` がアクセス可能
+  
+* **NGSI API**:明示的なポリシーが必要(`user` ロール)
+
+### 匿名アクセスポリシー (GeonicDB 拡張機能)
+
+GeonicDB は、テナント管理者が設定することで、データ API への匿名(認証なし)アクセスをサポートします。これは、認証を必要とせずに公開データ(例:気象観測、オープンデータセット)を公開する際に便利です。
+
+#### 前提条件
+
+
+1. **明示的な Permit ポリシーを作成する**:`role=anonymous` を対象として、希望するアクセスレベルを設定します(#748 以降、機能フラグは不要です)
+
+#### セットアップ
+
+```bash
+# Create a policy allowing anonymous read access
+curl -X POST http://localhost:3000/admin/policies \
+  -H "Authorization: Bearer <accessToken>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "description": "Allow anonymous read access to WeatherObserved entities",
+    "target": {
+      "subjects": [{"attributeId": "role", "matchValue": "anonymous"}],
+      "resources": [
+        {"attributeId": "path", "matchValue": "/v2/**", "matchFunction": "glob"},
+        {"attributeId": "entityType", "matchValue": "WeatherObserved"}
+      ]
+    },
+    "ruleCombiningAlgorithm": "first-applicable",
+    "rules": [
+      {"effect": "Permit", "target": {"actions": [{"attributeId": "method", "matchValue": "GET"}]}},
+      {"effect": "Deny"}
+    ]
+  }'
+
+# 3. Anonymous access (no Authorization header)
+curl http://localhost:3000/v2/entities?type=WeatherObserved \
+  -H "Fiware-Service: mytenant"
+```
+
+ブラウザ / Node アプリの場合、SDK は `anonymous: true` オプションを使用して同じフローをサポートします(トークン取得なし、`Authorization` ヘッダーなし)。`docs/SDK.md` を参照してください。
+
+```javascript
+const db = new GeonicDB({
+  baseUrl: 'http://localhost:3000',
+  tenant: 'mytenant',
+  anonymous: true,
+});
+const entities = await db.getEntities({ type: 'WeatherObserved' });
+```
+
+#### セキュリティモデル
+
+
+* **フェイルクローズ**:明示的な Permit ポリシーがない場合、すべての匿名リクエストは拒否されます(403)。
+  
+* **ポリシーなし = 拒否**:匿名アクセスには常に明示的な XACML Permit ポリシーが必要です。
+  
+* **管理 API にはアクセス不可**:匿名ユーザーは、ポリシーに関係なく `/admin/*`、`/auth/*`、または `/me/*` エンドポイントにアクセスできません。
+  
+* **テナント分離**:匿名リクエストには `Fiware-Service` ヘッダーを含める必要があります。匿名ユーザーは指定されたテナントに紐付けられ、他のテナントのデータにはアクセスできません。
+  
+* **取り消し可能**:XACML Permit ポリシーを削除すると、すべての匿名アクセスを即座にブロックできます。
+
+***
+
+## ポリシー伝播遅延と HTTP キャッシュの整合性 (#1050)
+
+XACML ポリシーが `/admin/policies` を介して追加、変更、または削除された場合、Lambda インスタンスがキャッシュされた評価を提供し続ける短い期間が存在します。
+
+### キャッシュ層
+
+
+1. **`PolicyService` インスタンスキャッシュ (TTL: `AUTH.POLICY_CACHE_TTL_MS` = 60s)** — `findActivePoliciesForTenant(tenantId)` の結果の Lambda インスタンスごとのインメモリキャッシュ。同じ Lambda インスタンス内でのポリシーの作成/更新/削除操作時に無効化されますが、他の Lambda インスタンスは TTL の期限切れに依存します。
+   
+2. **データエンドポイントの HTTP / CDN キャッシュなし** — すべてのデータエンドポイントは `Cache-Control: private, no-cache` を返します (#1047)。共有キャッシュはこれらのレスポンスを保存してはならず (MUST NOT)、プライベートキャッシュでさえ再検証しなければなりません (MUST)。そのため、ポリシー変更は、次のリクエストが新しい PolicyService キャッシュを持つ Lambda に到達するとすぐに (≤ 60s) 伝播されます。
+
+### 最悪ケースの伝播遅延
+
+
+* **単一の Lambda インスタンス**: 即座 (同じ書き込みでキャッシュが無効化されます)。
+  
+* **複数の Lambda インスタンス**: すべてのインスタンスが変更を取得するまで最大 `POLICY_CACHE_TTL_MS` (デフォルト 60s)。
+
+これはほとんどの認可変更において許容範囲です。即座の取り消しが必要な場合は、Lambda インスタンスを再起動するか、ユーザーのトークンをローテーションして強制的に再認証を行います。
+
+### ポリシー取り消し後の HTTP キャッシュの整合性
+
+ハンドラーは、[`tests/unit/handlers/api/index.test.ts` 内のユニットテスト](../tests/unit/handlers/api/index.test.ts)の `#1050` リグレッションテストによって固定されたこの順序でミドルウェアを評価します:
+
+```text
+extractAuthContext → optionalAuth → checkTenantAccess → requireAuthz (XACML PEP)
+  → controller (200 + ETag)
+  → evaluateConditionalRequest (200 → 304 if If-None-Match matches)
+```
+
+`requireAuthz` が `ForbiddenError` をスローした場合 (ポリシーが取り消された)、レスポンスは `catch` ブロックを通過し、`4xx` を直接返します — `evaluateConditionalRequest` は**呼び出されません**。したがって、クライアントが取り消し前の古い ETag を使って `If-None-Match` を送信したとしても、サーバーは `403` を返し、決して `304` を返しません。古いビューが再び現れることはありません。
+
+### 運用上の推奨事項
+
+
+* **監査上重要な取り消し**は、トークン無効化 ([Token Invalidation](#token-invalidation) を参照) と組み合わせて、ユーザーを強制的にログアウトさせ、進行中のキャッシュされたレスポンスがクライアントによって信頼されることを防ぐ必要があります。
+  
+* **ポリシーのホットフィックス** (≤ 60s の伝播) は、ほとんどの運用変更に十分です。ポリシー変更を伝える際には、伝播の期待値を文書化してください。
+
+***
+
+## リソーススコープ (非推奨)
+
+> **#748 で削除**: リソーススコープ (JWT 内の `resourceScopes`、`checkResourceScopes()`、`filterByResourceScopes()`) は、XACML 認可の統合の一部として削除されました。代わりに、きめ細かなアクセス制御には XACML ポリシーを使用してください。
+
+***
+
+## テナントごとの機能フラグ (非推奨)
+
+> **#748 で削除**: テナント機能フラグ (`apiKeysEnabled`、`oauthClientsEnabled`、`anonymousAccessEnabled`) は削除されました。認可は現在、ロールベースのデフォルトを持つ XACML ポリシーによって完全に処理されます:
+>
+> * API キー: デフォルト拒否、明示的な XACML 許可ポリシーが必要
+> * OAuth クライアント: 常に利用可能 (機能フラグゲートなし)
+> * 匿名アクセス: デフォルト拒否、明示的な XACML 許可ポリシーが必要 (機能フラグ不要)
+
+***
+
+## 認証シナリオリファレンス
+
+### ロール別アクセス許可サマリー
+
+| API Category                                   | anonymous           | user                                       | tenant\_admin                          | super\_admin      |
+| ---------------------------------------------- | ------------------- | ------------------------------------------ | -------------------------------------- | ----------------- |
+| Public endpoints                               | ✅                   | ✅                                          | ✅                                      | ✅                 |
+| `/statistics`, `/cache/statistics`, `/metrics` | ❌ (401)             | ✅ (auth required)                          | ✅ (auth required)                      | ✅ (auth required) |
+| `/auth/*`                                      | ❌ (401)             | ✅                                          | ✅                                      | ✅                 |
+| `/me/*`                                        | ❌ (401)             | ✅                                          | ✅                                      | ✅                 |
+| `/v2/*`                                        | ⚠️ Policy-dependent | 📖 Read-only (own tenant)                  | ✅ (own tenant)                         | ❌ Denied (403)    |
+| `/ngsi-ld/*`                                   | ⚠️ Policy-dependent | 📖 Read-only (own tenant)                  | ✅ (own tenant)                         | ❌ Denied (403)    |
+| `/catalog/*`                                   | ⚠️ Policy-dependent | 📖 Read-only (own tenant)                  | ✅ (own tenant)                         | ❌ Denied (403)    |
+| `/admin/users`                                 | ❌ (403)             | ❌                                          | ✅ (`user` role within own tenant only) | ✅ (all users)     |
+| `/admin/policies`, `/admin/policy-sets`        | ❌ (403)             | ❌                                          | ✅ (own tenant)                         | ✅ (all tenants)   |
+| `/admin/cadde`                                 | ❌ (403)             | ❌                                          | ❌                                      | ✅                 |
+| `/custom-data-models`                          | ❌ (403)             | 📖 Read-only (own tenant)                  | ✅ (own tenant)                         | ✅ (all tenants)   |
+| `/admin/*` (others)                            | ❌ (403)             | ❌ (OAuth: accessible with `admin:*` scope) | ❌                                      | ✅                 |
+| `/rules`                                       | ⚠️ Policy-dependent | 📖 Read-only (own tenant)                  | ✅ (own tenant)                         | ❌ Denied (403)    |
+| WebSocket                                      | ❌ (403)             | ✅ (own tenant)                             | ✅ (own tenant)                         | ❌ Denied (403)    |
+
+> **⚠️ ポリシー依存**: `role=anonymous` を対象とした明示的な XACML Permit ポリシーが必要です。それがない場合は 403 が返されます。
+
+### 一般的な認証シナリオ
+
+#### シナリオ 1: 認証無効 (`AUTH_ENABLED=false`
+
+)
+
+すべてのエンドポイントは認証なしでアクセス可能です。
+
+#### シナリオ 2: JWT 認証
+
+```bash
+# Login
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "password12345"}'
+
+# API request
+curl -X GET http://localhost:3000/v2/entities \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### シナリオ 3: OAuth 2.0 M2M 認証
+
+```bash
+# Obtain token
+curl -X POST http://localhost:3000/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d "grant_type=client_credentials&scope=read:entities"
+
+# API request
+curl -X GET http://localhost:3000/v2/entities \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### シナリオ 4: API Key 認証
+
+```bash
+# Create an API key (via admin or self-service)
+curl -X POST http://localhost:3000/me/api-keys \
+  -H "Authorization: Bearer <access_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My App Key",
+    "allowedOrigins": ["*"]
+  }'
+
+# API request with API key
+curl -X GET http://localhost:3000/v2/entities \
+  -H "X-Api-Key: gdb_<key_from_creation_response>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### シナリオ 5: OIDC 外部 IdP 認証
+
+```bash
+# Obtain ID token from external IdP (e.g., Google)
+# API request
+curl -X GET http://localhost:3000/v2/entities \
+  -H "Authorization: Bearer <id_token_from_google>" \
+  -H "Fiware-Service: mytenant"
+```
+
+#### シナリオ 6: 匿名アクセス(認証なし)
+
+```bash
+# No Authorization header needed
+# Requires: XACML Permit policy for role=anonymous (no feature flag needed since #748)
+curl -X GET http://localhost:3000/v2/entities?type=WeatherObserved \
+  -H "Fiware-Service: mytenant"
+```
+
+***
+
+## トークン無効化
+
+GeonicDB はユーザーごとのトークン無効化メカニズムを提供します。
+
+### 無効化の仕組み
+
+ユーザーごとにタイムスタンプ (`invalidatedBefore`) が管理されます。「この時刻より前に発行されたトークンは無効」という意味です。トークンの `iat` (発行時刻) がこのタイムスタンプより前の場合、そのトークンは無効と判定されます。
+
+### 無効化が発生するタイミング
+
+| Action                                | Effect                                                                        |
+| ------------------------------------- | ----------------------------------------------------------------------------- |
+| `POST /auth/logout`                   | Immediately invalidates all access tokens and refresh tokens for that user    |
+| `POST /me/password` (password change) | Invalidates all existing tokens after the password change (re-login required) |
+
+### ストレージ
+
+| Environment       | Storage        | Configuration                                                      |
+| ----------------- | -------------- | ------------------------------------------------------------------ |
+| AWS Lambda        | DynamoDB table | Specified via `TOKEN_INVALIDATION_TABLE_NAME` environment variable |
+| Local development | In-memory Map  | Used automatically when environment variable is not set            |
+
+DynamoDB テーブルには TTL (7日間) が設定されており、リフレッシュトークンの有効期限を超えたレコードは自動的に削除されます。
+
+### 注意事項
+
+
+* OAuth 2.0 Client Credentials トークンはトークン無効化の対象外です
+  
+* ログアウト後に再度ログインすると、新しいトークンが発行されます
+
+### WebSocket トークンの再検証
+
+WebSocket 接続の場合、接続確立時に JWT の `exp` (有効期限) が DynamoDB に保存されます。その後のメッセージ受信時に `exp` が再検証され、トークンが期限切れの場合は `401` が返されます (OWASP API2:2023 準拠)。
+
+
+* 接続時: `connect` ハンドラーが `ConnectionRecord` に `tokenExp` を保存します
+  
+* メッセージ受信時: `default` ハンドラーが `tokenExp` と現在時刻を比較します
+
+***
+
+## ブルートフォース保護
+
+GeonicDB には、ログインエンドポイント (`POST /auth/login`) と OAuth トークンエンドポイント (`POST /oauth/token`) に対するブルートフォース攻撃防止機能が含まれています (OWASP API2:2023 準拠)。
+
+### 動作仕様
+
+#### ログインエンドポイント (`POST /auth/login`
+
+)
+
+メールアドレスごとにログイン失敗回数を追跡し、以下のルールで応答します:
+
+| Failure count                  | Response                | Wait time until next attempt  |
+| ------------------------------ | ----------------------- | ----------------------------- |
+| 1st                            | `401 Unauthorized`      | None                          |
+| 2nd                            | `401 Unauthorized`      | 2 seconds (progressive delay) |
+| 3rd                            | `401 Unauthorized`      | 4 seconds (progressive delay) |
+| 4th                            | `401 Unauthorized`      | 8 seconds (progressive delay) |
+| 5th and beyond (locked)        | `429 Too Many Requests` | 60 seconds (lock)             |
+| While locked (even correct PW) | `429 Too Many Requests` | Remaining seconds             |
+| Successful login               | Counter reset           | —                             |
+
+> **注意**: 待機時間内に再試行すると `429 Too Many Requests` が返されます (`Retry-After` ヘッダー付き)。段階的な遅延は次のリクエスト (`checkLoginAllowed`) で適用され、失敗レスポンス自体は `401` です。
+
+#### OAuth トークンエンドポイント (`POST /oauth/token`
+
+)
+
+`client_id` ごとに認証失敗回数を追跡します。動作ルールはログインエンドポイントと同じです (段階的な遅延 + アカウントロック)。
+
+
+* **追跡キー**: `oauth:<clientId>` 形式で `LoginProtectionService` を共有
+  
+* **成功時**: カウンターリセット
+  
+* **非アクティブなクライアント**: 認証失敗として記録
+
+### 設計原則
+
+
+* **メールベース**: IP アドレスは VPN / プロキシで簡単にバイパスできるため、メールアドレスごとに追跡
+  
+* **Lambda 最適化**: `sleep()` 遅延の代わりに `429 + Retry-After` ヘッダーで応答 (Lambda の課金コストを回避するため)
+  
+* **自動クリーンアップ**: 試行記録は MongoDB TTL インデックスにより 1 時間後に自動削除
+  
+* **有効化 / 無効化からの独立**: ブルートフォース保護は自動化されたセキュリティメカニズムであり、管理者による手動の有効化 / 無効化操作とは別に管理されます
+
+### 管理者によるロック解除
+
+アカウントがロックされた場合、管理者は以下のエンドポイントでロックを解除できます:
+
+```bash
+POST /admin/users/{userId}/unlock
+Authorization: Bearer <accessToken>
+```
+
+**レスポンス例:**
+
+```json
+{
+  "userId": "abc123",
+  "email": "user@example.com",
+  "locked": false,
+  "failedCount": 0,
+  "message": "Account login lock has been cleared"
+}
+```
+
+### 設定値
+
+| Parameter                        | Default | Description                                                         |
+| -------------------------------- | ------- | ------------------------------------------------------------------- |
+| `MAX_FAILED_ATTEMPTS`            | 5       | Maximum number of failures before lock                              |
+| `LOCK_DURATION_SECONDS`          | 60      | Lock duration (seconds)                                             |
+| `ATTEMPT_WINDOW_SECONDS`         | 900     | Attempt window (15 minutes)                                         |
+| `PROGRESSIVE_DELAY_BASE_SECONDS` | 2       | Base value for progressive delay (seconds) — delay = base × 2^(n-2) |
+| `ATTEMPT_RECORD_TTL_SECONDS`     | 3600    | Automatic deletion of attempt records (1 hour)                      |
+
+***
+
+## 所有権検証 (GeonicDB 拡張)
+
+GeonicDB は、OWASP API1:2023 (Broken Object Level Authorization) への対策として、Subscription と Registration の所有権検証を提供します。
+
+### 概要
+
+NGSI 仕様では、テナント分離 (`Fiware-Service` ヘッダー) のみでアクセス制御を行いますが、マルチユーザーテナント環境では課題があります。同じテナント内のユーザーが他のユーザーのリソースを操作できてしまいます。GeonicDB は `createdBy` フィールドを導入し、書き込み操作時に所有権を検証します。
+
+### 対象リソース
+
+| Resource                                                               | Target Operations |
+| ---------------------------------------------------------------------- | ----------------- |
+| Subscription (`/v2/subscriptions`, `/ngsi-ld/v1/subscriptions`)        | UPDATE, DELETE    |
+| Registration (`/v2/registrations`, `/ngsi-ld/v1/csourceRegistrations`) | UPDATE, DELETE    |
+
+> **注意**: 読み取り操作 (GET/LIST) は制限されません。NGSI 仕様に準拠したテナント分離のみが適用されます。
+
+### ロールごとの動作
+
+| Role           | Own resource | Other's resource    | createdBy not set                |
+| -------------- | ------------ | ------------------- | -------------------------------- |
+| `super_admin`  | ✅ Operable   | ✅ Operable (bypass) | ✅ Operable                       |
+| `tenant_admin` | ✅ Operable   | ✅ Operable (bypass) | ✅ Operable                       |
+| `user`         | ✅ Operable   | ❌ 403 Forbidden     | ✅ Operable (backward compatible) |
+
+### 動作仕様
+
+
+1. **作成時**: リソースが作成されると、認証されたユーザーの ID が `createdBy` フィールドに自動的に記録されます
+   
+2. **更新/削除時**: リクエストしたユーザーの ID が `createdBy` と照合されます
+   
+   * 一致: 操作が許可されます
+     
+   * 不一致: `403 Forbidden` が返されます
+     
+   * `createdBy` が設定されていない (既存データ): 後方互換性のため操作が許可されます
+     
+3. **管理者バイパス**: `super_admin`/`tenant_admin` は所有権チェックをスキップします
+   
+4. **認証が無効な場合**: `AUTH_ENABLED=false` の場合、所有権チェックはスキップされます
+
+### エラーレスポンス
+
+```json
+{
+  "error": "Forbidden",
+  "description": "You do not have permission to modify this resource"
+}
+```
+
+ステータスコード: `403 Forbidden`
+
+***
+
+## トラブルシューティング
+
+### レート制限エラー (429 Too Many Requests)
+
+**考えられる原因:**
+
+* ログイン失敗回数が多すぎる(ブルートフォース保護)
+  
+* アカウントがロックされている
+
+**解決方法:**
+
+* `Retry-After` ヘッダーに示された秒数待ってから再試行する
+  
+* ロックされている場合は、管理者に `POST /admin/users/{userId}/unlock` 経由でロックを解除してもらう
+
+### 認証エラー (401 Unauthorized)
+
+**考えられる原因:**
+
+* トークンが無効または期限切れ
+  
+* `JWT_SECRET` が正しく設定されていない
+  
+* ユーザーまたはテナントが無効化されている
+  
+* ログアウトまたはパスワード変更後のトークン(すでに無効化済み)
+
+**解決方法:**
+
+```bash
+# Check token expiration
+jwt decode <access_token>
+
+# Re-login
+curl -X POST http://localhost:3000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "user@example.com", "password": "password12345"}'
+```
+
+### 認可エラー (403 Forbidden)
+
+**考えられる原因:**
+
+* ロールが不十分
+  
+* テナントが一致しない
+  
+* XACML ポリシーによって拒否された
+
+**解決方法:**
+
+* ユーザーのロールを確認する
+  
+* `Fiware-Service` ヘッダーがユーザーのテナントと一致することを確認する
+  
+* ポリシー設定を確認する
+
+### 管理 API アクセスエラー
+
+**考えられる原因:**
+
+* `super_admin` ロールではない (JWT 認証を使用している場合)
+  
+* OAuth トークンに必要な `admin:*` スコープがない
+  
+* IP アドレスが `ADMIN_ALLOWED_IPS` に含まれていない
+
+**解決方法:**
+
+```bash
+# Re-login as Super Admin
+# Check IP restrictions
+echo $ADMIN_ALLOWED_IPS
+# For OAuth: check the client's policyId and bound policy
+```
+
+***
+
+## 関連ドキュメント
+
+
+* [API 共通仕様](../api-reference/endpoints.md) - 一般的な API 仕様
+  
+* 開発ガイド - API 仕様(ページネーション、ステータスコード)とデプロイメント
+  
+* [XACML 3.0 仕様](https://docs.oasis-open.org/xacml/3.0/xacml-3.0-core-spec-os-en.html) - 公式 XACML 3.0 仕様

--- a/docs/ja/reference/cli.md
+++ b/docs/ja/reference/cli.md
@@ -5,58 +5,105 @@ outline: deep
 ---
 # CLI リファレンス
 
-`@geolonia/geonicdb-cli` (`geonic` コマンド) は GeonicDB のためのコマンドラインインターフェースです。NGSI-LD エンティティ、サブスクリプション、登録、時系列データ、バッチ操作、管理機能などへのフルアクセスを提供します。
+`@geolonia/geonicdb-cli` (`geonic` コマンド) は GeonicDB のコマンドラインインターフェースです。NGSI-LD エンティティ、サブスクリプション、レジストレーション、時系列データ、バッチ操作、管理機能などへの完全なアクセスを提供します。
 
-- **リポジトリ**: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)
-- **ランタイム**: Node.js >= 20
-- **パッケージ**: `@geolonia/geonicdb-cli`
+
+* **リポジトリ**: [geolonia/geonicdb-cli](https://github.com/geolonia/geonicdb-cli)
+  
+* **ランタイム**: Node.js >= 20
+  
+* **パッケージ**: `@geolonia/geonicdb-cli`
+
 ## 目次
 
-- [インストール](#インストール)
-- [クイックスタート](#クイックスタート)
-- [グローバルオプション](#グローバルオプション)
-- [設定とプロファイル](#設定とプロファイル)
-  - [設定ファイル](#設定ファイル)
-  - [プロファイル管理](#プロファイル管理)
-  - [環境変数](#環境変数)
-  - [オプション解決順序](#オプション解決順序)
-- [認証](#認証)
-  - [メール / パスワードログイン](#メール--パスワードログイン)
-  - [OAuth 2.0 クライアント認証情報](#oauth-20-クライアント認証情報)
-  - [トークン自動更新](#トークン自動更新)
-  - [ログアウト](#ログアウト)
-- [入力形式](#入力形式)
-- [出力形式](#出力形式)
-- [ドライラン](#ドライラン)
-- [更新通知](#更新通知)
-- [コマンドリファレンス](#コマンドリファレンス)
-  - [entities](#entities)
-  - [entities attrs](#entities-attrs)
-  - [entityOperations (batch)](#entityoperations-batch)
-  - [subscriptions (sub)](#subscriptions-sub)
-  - [registrations (reg)](#registrations-reg)
-  - [types](#types)
-  - [temporal](#temporal)
-  - [snapshots](#snapshots)
-  - [rules](#rules)
-  - [custom-data-models (models)](#custom-data-models-models)
-  - [catalog](#catalog)
-  - [admin](#admin)
-    - [admin tenants](#admin-tenants)
-    - [admin users](#admin-users)
-    - [admin policies](#admin-policies)
-    - [admin oauth-clients](#admin-oauth-clients)
-    - [admin api-keys](#admin-api-keys)
-    - [admin cadde](#admin-cadde)
-  - [health](#health)
-  - [version](#version)
-  - [me](#me)
-    - [me oauth-clients](#me-oauth-clients)
-    - [me api-keys](#me-api-keys)
-  - [help](#help)
-- [シェル補完](#シェル補完)
 
----
+* [インストール](#インストール)
+  
+* [クイックスタート](#クイックスタート)
+  
+* [グローバルオプション](#グローバルオプション)
+  
+* [設定とプロファイル](#設定とプロファイル)
+  
+  * [設定ファイル](#設定ファイル)
+    
+  * [プロファイル管理](#プロファイル管理)
+    
+  * [環境変数](#環境変数)
+    
+  * [オプション解決順序](#オプション解決順序)
+    
+* [認証](#認証)
+  
+  * [メール / パスワードログイン](#email--password-login)
+    
+  * [OAuth 2.0 Client Credentials](#oauth-20-client-credentials)
+    
+  * [トークン自動更新](#トークン自動更新)
+    
+  * [ログアウト](#ログアウト)
+    
+* [入力形式](#入力形式)
+  
+* [出力形式](#出力形式)
+  
+* [ドライラン](#ドライラン)
+  
+* [更新通知](#更新通知)
+  
+* [コマンドリファレンス](#コマンドリファレンス)
+  
+  * [entities](#entities)
+    
+  * [entities attrs](#entities-attrs)
+    
+  * [entityOperations (batch)](#entityoperations-batch)
+    
+  * [subscriptions (sub)](#subscriptions-sub)
+    
+  * [registrations (reg)](#registrations-reg)
+    
+  * [types](#types)
+    
+  * [temporal](#temporal)
+    
+  * [snapshots](#snapshots)
+    
+  * [rules](#rules)
+    
+  * [custom-data-models (models)](#custom-data-models-models)
+    
+  * [catalog](#catalog)
+    
+  * [admin](#admin)
+    
+    * [admin tenants](#admin-tenants)
+      
+    * [admin users](#admin-users)
+      
+    * [admin policies](#admin-policies)
+      
+    * [admin oauth-clients](#admin-oauth-clients)
+      
+    * [admin api-keys](#admin-api-keys)
+      
+    * [admin cadde](#admin-cadde)
+      
+  * [health](#health)
+    
+  * [version](#version)
+    
+  * [me](#me)
+    
+    * [me oauth-clients](#me-oauth-clients)
+      
+    * [me api-keys](#me-api-keys)
+      
+  * [help](#help)
+    
+* [シェル補完](#シェル補完)
+
+***
 
 ## インストール
 
@@ -64,11 +111,12 @@ outline: deep
 npm install -g @geolonia/geonicdb-cli
 ```
 
-または npx で直接実行:
+または npx で直接実行する:
 
 ```bash
 npx @geolonia/geonicdb-cli <command>
 ```
+
 ## クイックスタート
 
 ```bash
@@ -92,31 +140,31 @@ geonic entities list --type Room
 geonic entities get urn:ngsi-ld:Room:001
 ```
 
----
+***
 
 ## グローバルオプション
 
-すべてのコマンドで使用可能です。優先順位のルールについては [オプション解決順序](#オプションの解決順序) を参照してください。
+すべてのコマンドで利用可能です。優先順位ルールについては [Option Resolution Order](#option-resolution-order) を参照してください。
 
-| オプション | 説明 |
-|--------|-------------|
-| `-u, --url <url>` | GeonicDB サーバーのベース URL |
-| `-s, --service <name>` | テナント名 (`NGSILD-Tenant` ヘッダー) |
-| `--token <token>` | 認証トークン |
-| `-p, --profile <name>` | 使用する名前付きプロファイル |
-| `--api-key <key>` | API キー認証 |
-| `-f, --format <fmt>` | 出力形式: `json`、`table`、`geojson` |
-| `--no-color` | 色付き出力を無効化 |
-| `-v, --verbose` | HTTP リクエスト/レスポンスの詳細を stderr に表示 (機密値はマスクされます) |
-| `--dry-run` | リクエストを実行せずに同等の `curl` コマンドを出力 |
+| Option                 | Description                                                                |
+| ---------------------- | -------------------------------------------------------------------------- |
+| `-u, --url <url>`      | GeonicDB server base URL                                                   |
+| `-s, --service <name>` | Tenant name (`NGSILD-Tenant` header)                                       |
+| `--token <token>`      | Authentication token                                                       |
+| `-p, --profile <name>` | Named profile to use                                                       |
+| `--api-key <key>`      | API key authentication                                                     |
+| `-f, --format <fmt>`   | Output format: `json`, `table`, `geojson`                                  |
+| `--no-color`           | Disable colored output                                                     |
+| `-v, --verbose`        | Show HTTP request/response details on stderr (sensitive values are masked) |
+| `--dry-run`            | Print the equivalent `curl` command without executing the request          |
 
----
+***
 
 ## 設定とプロファイル
 
 ### 設定ファイル
 
-CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CONFIG_DIR` 環境変数でディレクトリを上書きできます。
+CLI は設定を `~/.config/geonic/config.json` に保存します。`GEONIC_CONFIG_DIR` 環境変数でディレクトリを上書きできます。
 
 ```json
 {
@@ -135,91 +183,86 @@ CLI は `~/.config/geonic/config.json` に設定を保存します。`GEONIC_CON
 }
 ```
 
-**設定キー**: `url`, `service`, `token`, `refreshToken`, `format`, `apiKey`, `clientId`, `clientSecret`
-#
+**設定キー**: `url`、`service`、`token`、`refreshToken`、`format`、`apiKey`、`clientId`、`clientSecret`
 
-### `geonic config set <key> <value>`
-設定値を保存します。機密性の高い値(`token`, `refreshToken`, `apiKey`, `clientId`, `clientSecret`)は出力時にマスクされます。
+#### `geonic config set <key> <value>`
 
-#
+設定値を保存します。機密値(`token`、`refreshToken`、`apiKey`、`clientId`、`clientSecret`)は出力時にマスクされます。
 
-### `geonic config get <key>`
+#### `geonic config get <key>`
+
 設定値を取得します。
 
-#
+#### `geonic config list`
 
-### `geonic config list`
 現在のプロファイルのすべての設定値を表示します。
 
-#
+#### `geonic config delete <key>`
 
-### `geonic config delete <key>`
 設定値を削除します。
 
 ### プロファイル管理
 
-複数の接続プロファイル(例:本番環境、ステージング環境、開発環境)を管理します。デフォルトのプロファイルは `default` という名前で、削除できません。
+複数の接続プロファイル(例:本番、ステージング、開発)を管理します。デフォルトのプロファイルは `default` という名前で、削除できません。
 
-#
+#### `geonic profile list`
 
-### `geonic profile list`
-すべてのプロファイルをリスト表示します。アクティブなプロファイルは `*` でマークされます。
+すべてのプロファイルを一覧表示します。アクティブなプロファイルには `*` が付きます。
 
-#
+#### `geonic profile use <name>`
 
-### `geonic profile use <name>`
 アクティブなプロファイルを切り替えます。
 
-#
+#### `geonic profile create <name>`
 
-### `geonic profile create <name>`
 新しい空のプロファイルを作成します。
 
-#
+#### `geonic profile delete <name>`
 
-### `geonic profile delete <name>`
 プロファイルを削除します。`default` プロファイルは削除できません。
 
-#
+#### `geonic profile show [name]`
 
-### `geonic profile show [name]`
-プロファイル設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密性の高い値はマスクされます。
+プロファイルの設定を表示します。デフォルトではアクティブなプロファイルが対象です。機密値はマスクされます。
 
 ### 環境変数
 
-| 変数 | 説明 |
-|----------|-------------|
-| `GDB_EMAIL` | ログイン用メールアドレス |
-| `GDB_PASSWORD` | ログイン用パスワード |
-| `GDB_OAUTH_CLIENT_ID` | OAuth Client Credentials のクライアント ID |
-| `GDB_OAUTH_CLIENT_SECRET` | OAuth Client Credentials のクライアントシークレット |
-| `GDB_API_KEY` | API キー(`--api-key` と同等) |
-| `GEONIC_CONFIG_DIR` | 設定ディレクトリパスを上書き |
-| `NO_UPDATE_NOTIFIER` | 更新通知を無効化 |
+| Variable                  | Description                            |
+| ------------------------- | -------------------------------------- |
+| `GDB_EMAIL`               | Email address for login                |
+| `GDB_PASSWORD`            | Password for login                     |
+| `GDB_OAUTH_CLIENT_ID`     | OAuth Client Credentials client ID     |
+| `GDB_OAUTH_CLIENT_SECRET` | OAuth Client Credentials client secret |
+| `GDB_API_KEY`             | API key (equivalent to `--api-key`)    |
+| `GEONIC_CONFIG_DIR`       | Override config directory path         |
+| `NO_UPDATE_NOTIFIER`      | Disable the update notifier            |
 
-### オプションの解決順序
+### オプション解決順序
 
-値は次の順序で解決されます(優先度の高い順):
+値は以下の順序で解決されます(優先度の高い順):
 
-1. CLI フラグ(`--url`, `--token` など)
+
+1. CLI フラグ(`--url`、`--token` など)
+   
 2. 設定ファイル(プロファイル設定)
+   
 3. デフォルト値
 
----
+***
 
 ## 認証
 
-### メール / パスワード ログイン
+### メールアドレス / パスワードログイン
 
 ```bash
 geonic auth login
 ```
 
-ターミナルで実行する場合、CLI はメールアドレスとパスワードを対話形式で入力するよう促します。非対話環境では、`GDB_EMAIL` と `GDB_PASSWORD` 環境変数を設定してください。
+ターミナルで実行する場合、CLI はメールアドレスとパスワードを対話的に入力するよう求めます。非対話環境では、`GDB_EMAIL` と `GDB_PASSWORD` 環境変数を設定してください。
 
 CLI は `POST /auth/login` を呼び出し、受信した `accessToken` と `refreshToken` を設定ファイルに保存します。
 
-### OAuth 2.0 クライアント認証情報
+### OAuth 2.0 Client Credentials
 
 ```bash
 geonic auth login --client-credentials \
@@ -228,21 +271,21 @@ geonic auth login --client-credentials \
   --scope "read write"
 ```
 
-OAuth 2.0 クライアント認証情報フロー (`POST /oauth/token`) を使用します。クライアント ID とシークレットは、`GDB_OAUTH_CLIENT_ID` と `GDB_OAUTH_CLIENT_SECRET` 環境変数でも設定可能です。
+OAuth 2.0 Client Credentials フロー(`POST /oauth/token`)を使用します。Client ID と secret は `GDB_OAUTH_CLIENT_ID` と `GDB_OAUTH_CLIENT_SECRET` 環境変数でも設定できます。
 
-| オプション | 説明 |
-|--------|-------------|
-| `--client-credentials` | クライアント認証情報フローを使用 |
-| `--client-id <id>` | OAuth クライアント ID |
-| `--client-secret <secret>` | OAuth クライアント シークレット |
-| `--scope <scopes>` | OAuth スコープ (スペース区切り) |
-| `--tenant-id <id>` | スコープ認証用のテナント ID |
+| Option                     | Description                         |
+| -------------------------- | ----------------------------------- |
+| `--client-credentials`     | Use Client Credentials flow         |
+| `--client-id <id>`         | OAuth client ID                     |
+| `--client-secret <secret>` | OAuth client secret                 |
+| `--scope <scopes>`         | OAuth scopes (space-separated)      |
+| `--tenant-id <id>`         | Tenant ID for scoped authentication |
 
-### トークンの自動更新
+### トークン自動更新
 
-リクエストが 401 Unauthorized を返し、`refreshToken` が利用可能な場合、CLI は自動的に `POST /auth/refresh` 経由でトークンを更新し、リクエストを再試行します。
+リクエストが 401 Unauthorized を返し、`refreshToken` が利用可能な場合、CLI は `POST /auth/refresh` 経由でトークンを自動的に更新し、リクエストを再試行します。
 
-設定ファイルに `clientId` と `clientSecret` が保存されている場合 (例: `geonic me oauth-clients create --save` 経由)、CLI はトークンの有効期限が切れたときに自動的にクライアント認証情報フローを使用して再認証します。
+`clientId` と `clientSecret` が設定に保存されている場合(例:`geonic me oauth-clients create --save` 経由)、CLI はトークンの有効期限が切れると Client Credentials フローを使用して自動的に再認証します。
 
 ### ログアウト
 
@@ -250,13 +293,13 @@ OAuth 2.0 クライアント認証情報フロー (`POST /oauth/token`) を使�
 geonic auth logout
 ```
 
-保存されたトークンをクリアし、ベストエフォートでサーバーにログアウト通知を送信します。
+保存されたトークンをクリアし、サーバーにベストエフォートのログアウト通知を送信します。
 
----
+***
 
-## 入力フォーマット
+## 入力形式
 
-`[json]` 引数を受け付けるコマンドは、複数の入力方法をサポートしています。CLI は入力元を自動検出します:
+`[json]` 引数を受け入れるコマンドは、複数の入力方法をサポートしています。CLI は入力元を自動検出します:
 
 ### インライン JSON / JSON5
 
@@ -264,19 +307,19 @@ geonic auth logout
 geonic entities create '{"id": "urn:ngsi-ld:Room:001", "type": "Room"}'
 ```
 
-JSON5 をサポート: クォートなしのキー、シングルクォート、末尾のカンマ、コメントが使用可能です。
+JSON5 がサポートされています:引用符なしのキー、シングルクォート、末尾のカンマ、コメント。
 
 ```bash
 geonic entities create '{id: "urn:ngsi-ld:Room:001", type: "Room",}'
 ```
 
-### ファイル入力 (`@` プレフィックス)
+### ファイル入力(`@` プレフィックス)
 
 ```bash
 geonic entities create @entity.json
 ```
 
-### 標準入力 (パイプ)
+### 標準入力(パイプ)
 
 ```bash
 cat entity.json | geonic entities create
@@ -290,27 +333,27 @@ cat entity.json | geonic entities create -
 
 ### 対話モード
 
-CLI がターミナルに接続されていて、JSON 引数が提供されていない場合、対話形式の `json>` プロンプトが開きます。ブラケットがバランスしたときに入力が自動送信されます。
+CLI がターミナルに接続されており、JSON 引数が提供されていない場合、対話的な `json>` プロンプトが開きます。括弧のバランスが取れると入力は自動的に送信されます。
 
----
+***
 
-## 出力フォーマット
+## 出力形式
 
 `--format` または `geonic config set format <fmt>` で設定します。
 
-| フォーマット | 説明 |
-|--------|-------------|
-| `json` (デフォルト) | 整形された JSON |
-| `table` | ASCII テーブル (配列は列、オブジェクトはキー・バリュー ペアとして表示) |
-| `geojson` | GeoJSON FeatureCollection (`location` 属性をジオメトリに変換) |
+| Format           | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `json` (default) | Pretty-printed JSON                                                   |
+| `table`          | ASCII table (arrays as columns, objects as key-value pairs)           |
+| `geojson`        | GeoJSON FeatureCollection (converts `location` attribute to geometry) |
 
-`--count` を使用する場合、`NGSILD-Results-Count` レスポンスヘッダーが `Count: N` として表示されます。
+`--count` を使用すると、`NGSILD-Results-Count` レスポンスヘッダーが `Count: N` として表示されます。
 
----
+***
 
 ## ドライラン
 
-任意のコマンドで `--dry-run` を使用すると、リクエストを実行する代わりに、同等の `curl` コマンドを出力します。出力はコピーしてターミナルで直接実行できます。
+任意のコマンドで `--dry-run` を使用すると、リクエストを実行する代わりに同等の `curl` コマンドが表示されます。出力はコピーしてターミナルで直接実行できます。
 
 ```bash
 $ geonic entities list --type Sensor --dry-run
@@ -333,40 +376,40 @@ curl \
   'http://localhost:3000/ngsi-ld/v1/entities'
 ```
 
----
+***
 
 ## 更新通知
 
-CLI は 24 時間ごとに新しいバージョンをチェックし、アップデートが利用可能な場合に通知ボックスを表示します。チェックは CI 環境および非 TTY ターミナルではスキップされます。`NO_UPDATE_NOTIFIER=1` を設定することで無効化できます。
+CLI は 24 時間ごとに新しいバージョンをチェックし、アップデートが利用可能な場合は通知ボックスを表示します。このチェックは CI 環境および非 TTY ターミナルではスキップされます。`NO_UPDATE_NOTIFIER=1` を設定することで無効化できます。
 
----
+***
 
 ## コマンドリファレンス
 
 ### `entities`
+
 NGSI-LD コンテキストエンティティ (`/ngsi-ld/v1/entities`) を管理します。
 
-#
+#### `geonic entities list`
 
-### `geonic entities list`
-オプションのフィルタを使用してエンティティをリストします。
+オプションのフィルターを使用してエンティティをリストします。
 
-| オプション | 説明 |
-|--------|-------------|
-| `--type <type>` | エンティティタイプでフィルタ |
-| `--id-pattern <pat>` | エンティティ ID パターンでフィルタ (正規表現) |
-| `--query <q>` | NGSI クエリ式 (例: `temperature>30`) |
-| `--attrs <a,b>` | 返す属性のカンマ区切りリスト |
-| `--georel <rel>` | ジオリレーションシップ (例: `near;maxDistance==1000`) |
-| `--geometry <geo>` | ジオメトリタイプ (例: `Point`、`Polygon`) |
-| `--coords <coords>` | ジオクエリの座標 |
-| `--spatial-id <zfxy>` | 空間 ID フィルタ (ZFXY タイル形式、例: `15/0/29101/12903`) |
-| `--limit <n>` | 最大結果数 |
-| `--offset <n>` | スキップする結果数 |
-| `--order-by <field>` | ソートフィールド |
-| `--count` | レスポンスに合計カウントを含める |
-| `--count-only` | エンティティをリストせず合計カウントのみを表示 |
-| `--key-values` | 簡略化されたキー・バリュー形式で返す |
+| Option                | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `--type <type>`       | Filter by entity type                                          |
+| `--id-pattern <pat>`  | Filter by entity ID pattern (regex)                            |
+| `--query <q>`         | NGSI query expression (e.g., `temperature>30`)                 |
+| `--attrs <a,b>`       | Comma-separated list of attributes to return                   |
+| `--georel <rel>`      | Geo-relation (e.g., `near;maxDistance==1000`)                  |
+| `--geometry <geo>`    | Geometry type (e.g., `Point`, `Polygon`)                       |
+| `--coords <coords>`   | Coordinates for geo-query                                      |
+| `--spatial-id <zfxy>` | Spatial ID filter (ZFXY tile format, e.g., `15/0/29101/12903`) |
+| `--limit <n>`         | Maximum number of results                                      |
+| `--offset <n>`        | Number of results to skip                                      |
+| `--order-by <field>`  | Sort field                                                     |
+| `--count`             | Include total count in response                                |
+| `--count-only`        | Only show the total count without listing entities             |
+| `--key-values`        | Return simplified key-value format                             |
 
 ```bash
 # List all Room entities
@@ -382,18 +425,16 @@ geonic entities list --query "temperature>25" --limit 10 --offset 0 --count
 geonic entities list --type Sensor --count-only
 ```
 
-#
+#### `geonic entities get <id>`
 
-### `geonic entities get <id>`
-ID で単一のエンティティを取得します。
+ID により単一のエンティティを取得します。
 
-| オプション | 説明 |
-|--------|-------------|
-| `--key-values` | 簡略化されたキー・バリュー形式で返す |
+| Option         | Description                        |
+| -------------- | ---------------------------------- |
+| `--key-values` | Return simplified key-value format |
 
-#
+#### `geonic entities create [json]`
 
-### `geonic entities create [json]`
 新しいエンティティを作成します。
 
 ```bash
@@ -408,42 +449,39 @@ geonic entities create '{
 }'
 ```
 
-#
+#### `geonic entities update <id> [json]`
 
-### `geonic entities update <id> [json]`
-エンティティ属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
+エンティティの属性を部分的に更新します (`PATCH /entities/{id}/attrs`)。
 
 ```bash
 geonic entities update urn:ngsi-ld:Room:001 '{"temperature": {"type": "Property", "value": 25.0}}'
 ```
 
-#
+#### `geonic entities replace <id> [json]`
 
-### `geonic entities replace <id> [json]`
-すべてのエンティティ属性を置き換えます (`PUT /entities/{id}/attrs`)。
+エンティティの全ての属性を置き換えます (`PUT /entities/{id}/attrs`)。
 
-#
+#### `geonic entities upsert [json]`
 
-### `geonic entities upsert [json]`
 エンティティを作成または更新します (`POST /entityOperations/upsert`)。
 
-#
+#### `geonic entities delete <id>`
 
-### `geonic entities delete <id>`
 エンティティを削除します。
 
----
+***
 
 ### `entities attrs`
+
 エンティティの個別の属性を管理します。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic entities attrs list <entityId>` | すべての属性をリスト |
-| `geonic entities attrs get <entityId> <attrName>` | 特定の属性を取得 |
-| `geonic entities attrs add <entityId> [json]` | 属性を追加 |
-| `geonic entities attrs update <entityId> <attrName> [json]` | 特定の属性を更新 |
-| `geonic entities attrs delete <entityId> <attrName>` | 特定の属性を削除 |
+| Command                                                     | Description                 |
+| ----------------------------------------------------------- | --------------------------- |
+| `geonic entities attrs list <entityId>`                     | List all attributes         |
+| `geonic entities attrs get <entityId> <attrName>`           | Get a specific attribute    |
+| `geonic entities attrs add <entityId> [json]`               | Add attributes              |
+| `geonic entities attrs update <entityId> <attrName> [json]` | Update a specific attribute |
+| `geonic entities attrs delete <entityId> <attrName>`        | Delete a specific attribute |
 
 ```bash
 # Get the temperature attribute
@@ -453,21 +491,20 @@ geonic entities attrs get urn:ngsi-ld:Room:001 temperature
 geonic entities attrs update urn:ngsi-ld:Room:001 temperature '{"type": "Property", "value": 26.0}'
 ```
 
----
+***
 
-### `entityOperations`
- (バッチ)
+### `entityOperations` (batch)
 
-エンティティのバッチ操作 (`/ngsi-ld/v1/entityOperations`)。エイリアス: `batch`。
+エンティティのバッチ操作 (`/ngsi-ld/v1/entityOperations`)。エイリアス:`batch`。
 
-| コマンド | HTTP | 説明 |
-|---------|------|-------------|
-| `geonic batch create [json]` | POST `/entityOperations/create` | 複数のエンティティを作成 |
-| `geonic batch upsert [json]` | POST `/entityOperations/upsert` | 複数のエンティティを作成または更新 |
-| `geonic batch update [json]` | POST `/entityOperations/update` | 複数のエンティティを更新 |
-| `geonic batch delete [json]` | POST `/entityOperations/delete` | 複数のエンティティを削除 |
-| `geonic batch query [json]` | POST `/entityOperations/query` | POST でエンティティをクエリ |
-| `geonic batch merge [json]` | POST `/entityOperations/merge` | 複数のエンティティをマージ |
+| Command                      | HTTP                            | Description                        |
+| ---------------------------- | ------------------------------- | ---------------------------------- |
+| `geonic batch create [json]` | POST `/entityOperations/create` | Create multiple entities           |
+| `geonic batch upsert [json]` | POST `/entityOperations/upsert` | Create or update multiple entities |
+| `geonic batch update [json]` | POST `/entityOperations/update` | Update multiple entities           |
+| `geonic batch delete [json]` | POST `/entityOperations/delete` | Delete multiple entities           |
+| `geonic batch query [json]`  | POST `/entityOperations/query`  | Query entities by POST             |
+| `geonic batch merge [json]`  | POST `/entityOperations/merge`  | Merge multiple entities            |
 
 ```bash
 # Batch create entities from a file
@@ -477,22 +514,22 @@ geonic batch create @entities.json
 cat entities.json | geonic batch upsert
 ```
 
----
+***
 
-### `subscriptions`
- (sub)
+### `subscriptions` (sub)
 
-コンテキストサブスクリプション (`/ngsi-ld/v1/subscriptions`) を管理します。エイリアス: `sub`。
+コンテキストサブスクリプションを管理 (`/ngsi-ld/v1/subscriptions`)。エイリアス:`sub`。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic sub list` | サブスクリプションの一覧表示 |
-| `geonic sub get <id>` | サブスクリプションの取得 |
-| `geonic sub create [json]` | サブスクリプションの作成 |
-| `geonic sub update <id> [json]` | サブスクリプションの更新 |
-| `geonic sub delete <id>` | サブスクリプションの削除 |
+| Command                         | Description           |
+| ------------------------------- | --------------------- |
+| `geonic sub list`               | List subscriptions    |
+| `geonic sub get <id>`           | Get a subscription    |
+| `geonic sub create [json]`      | Create a subscription |
+| `geonic sub update <id> [json]` | Update a subscription |
+| `geonic sub delete <id>`        | Delete a subscription |
 
-**`sub list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
+**`sub list` オプション**:`--limit <n>`、`--offset <n>`、`--count`
+
 ```bash
 geonic sub create '{
   "type": "Subscription",
@@ -504,57 +541,58 @@ geonic sub create '{
 }'
 ```
 
----
+***
 
-### `registrations`
- (reg)
+### `registrations` (reg)
 
-コンテキストソース登録 (`/ngsi-ld/v1/csourceRegistrations`) を管理します。エイリアス: `reg`。
+コンテキストソース登録を管理 (`/ngsi-ld/v1/csourceRegistrations`)。エイリアス:`reg`。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic reg list` | 登録の一覧表示 |
-| `geonic reg get <id>` | 登録の取得 |
-| `geonic reg create [json]` | 登録の作成 |
-| `geonic reg update <id> [json]` | 登録の更新 |
-| `geonic reg delete <id>` | 登録の削除 |
+| Command                         | Description           |
+| ------------------------------- | --------------------- |
+| `geonic reg list`               | List registrations    |
+| `geonic reg get <id>`           | Get a registration    |
+| `geonic reg create [json]`      | Create a registration |
+| `geonic reg update <id> [json]` | Update a registration |
+| `geonic reg delete <id>`        | Delete a registration |
 
-**`reg list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
----
+**`reg list` オプション**:`--limit <n>`、`--offset <n>`、`--count`
+
+***
 
 ### `types`
-利用可能なエンティティタイプを照会します (`/ngsi-ld/v1/types`)。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic types list` | すべてのエンティティタイプの一覧表示 |
-| `geonic types get <typeName>` | 特定のタイプの詳細を取得 |
+利用可能なエンティティタイプをクエリ (`/ngsi-ld/v1/types`)。
 
----
+| Command                       | Description                     |
+| ----------------------------- | ------------------------------- |
+| `geonic types list`           | List all entity types           |
+| `geonic types get <typeName>` | Get details for a specific type |
+
+***
 
 ### `temporal`
-時系列エンティティデータを管理します (`/ngsi-ld/v1/temporal`)。
 
-#
+時系列(時系列)エンティティデータを管理します(`/ngsi-ld/v1/temporal`)。
 
-### `geonic temporal entities list`
-時系列エンティティの一覧を取得します。
+#### `geonic temporal entities list`
 
-| オプション | 説明 |
-|--------|-------------|
-| `--type <type>` | エンティティタイプでフィルタリング |
-| `--attrs <a,b>` | 返却する属性 |
-| `--query <q>` | NGSI クエリ式 |
-| `--georel <rel>` | 地理的関係 |
-| `--geometry <geo>` | ジオメトリタイプ |
-| `--coords <coords>` | 座標 |
-| `--time-rel <rel>` | 時間的関係: `before`、`after`、`between` |
-| `--time-at <time>` | 開始時刻 (ISO 8601) |
-| `--end-time-at <time>` | 終了時刻 (ISO 8601) |
-| `--last-n <n>` | 最新の N 個の時系列値を返却 |
-| `--limit <n>` | 結果の最大数 |
-| `--offset <n>` | スキップする結果の数 |
-| `--count` | 合計カウントを含める |
+時系列エンティティを一覧表示します。
+
+| Option                 | Description                                     |
+| ---------------------- | ----------------------------------------------- |
+| `--type <type>`        | Filter by entity type                           |
+| `--attrs <a,b>`        | Attributes to return                            |
+| `--query <q>`          | NGSI query expression                           |
+| `--georel <rel>`       | Geo-relation                                    |
+| `--geometry <geo>`     | Geometry type                                   |
+| `--coords <coords>`    | Coordinates                                     |
+| `--time-rel <rel>`     | Temporal relation: `before`, `after`, `between` |
+| `--time-at <time>`     | Start time (ISO 8601)                           |
+| `--end-time-at <time>` | End time (ISO 8601)                             |
+| `--last-n <n>`         | Return last N temporal values                   |
+| `--limit <n>`          | Maximum number of results                       |
+| `--offset <n>`         | Number of results to skip                       |
+| `--count`              | Include total count                             |
 
 ```bash
 # Get temperature history for the last hour
@@ -564,31 +602,28 @@ geonic temporal entities get urn:ngsi-ld:Room:001 \
   --time-at 2026-01-01T00:00:00Z
 ```
 
-#
+#### `geonic temporal entities get <id>`
 
-### `geonic temporal entities get <id>`
 エンティティの時系列表現を取得します。
 
-**オプション**: `--attrs`、`--time-rel`、`--time-at`、`--end-time-at`、`--last-n`
-#
+**オプション**: `--attrs`, `--time-rel`, `--time-at`, `--end-time-at`, `--last-n`
 
-### `geonic temporal entities create [json]`
+#### `geonic temporal entities create [json]`
+
 時系列エンティティを作成します。
 
-#
+#### `geonic temporal entities delete <id>`
 
-### `geonic temporal entities delete <id>`
 時系列エンティティを削除します。
 
-#
+#### `geonic temporal entityOperations query [json]`
 
-### `geonic temporal entityOperations query [json]`
-集約サポート付きで POST による時系列エンティティのクエリを実行します。
+集約サポート付きで POST によって時系列エンティティをクエリします。
 
-| オプション | 説明 |
-|--------|-------------|
-| `--aggr-methods <methods>` | 集約メソッド (例: `totalCount,sum,avg`) |
-| `--aggr-period <period>` | 集約期間 (ISO 8601、例: `PT1H`) |
+| Option                     | Description                                          |
+| -------------------------- | ---------------------------------------------------- |
+| `--aggr-methods <methods>` | Aggregation methods (e.g., `totalCount,sum,avg`)     |
+| `--aggr-period <period>`   | Aggregation period duration (ISO 8601, e.g., `PT1H`) |
 
 ```bash
 # Hourly average temperature
@@ -597,136 +632,135 @@ geonic temporal entityOperations query @query.json \
   --aggr-period PT1H
 ```
 
----
+***
 
 ### `snapshots`
+
 エンティティスナップショットを管理します。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic snapshots list` | スナップショットの一覧を取得 |
-| `geonic snapshots get <id>` | スナップショットを取得 |
-| `geonic snapshots create` | 新しいスナップショットを作成 |
-| `geonic snapshots delete <id>` | スナップショットを削除 |
-| `geonic snapshots clone <id>` | スナップショットをクローン |
+| Command                        | Description           |
+| ------------------------------ | --------------------- |
+| `geonic snapshots list`        | List snapshots        |
+| `geonic snapshots get <id>`    | Get a snapshot        |
+| `geonic snapshots create`      | Create a new snapshot |
+| `geonic snapshots delete <id>` | Delete a snapshot     |
+| `geonic snapshots clone <id>`  | Clone a snapshot      |
 
-**`snapshots list` のオプション**: `--limit <n>`、`--offset <n>`
----
+**`snapshots list` オプション**: `--limit <n>`, `--offset <n>`
+
+***
 
 ### `rules`
-ReactiveCore ルールを管理します。詳細は ReactiveCore Rules を参照してください。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic rules list` | すべてのルールを一覧表示 |
-| `geonic rules get <id>` | ルールを取得 |
-| `geonic rules create [json]` | ルールを作成 |
-| `geonic rules update <id> [json]` | ルールを更新 |
-| `geonic rules delete <id>` | ルールを削除 |
-| `geonic rules activate <id>` | ルールを有効化 |
-| `geonic rules deactivate <id>` | ルールを無効化 |
+ReactiveCore Rules を管理します。詳細については [ReactiveCore Rules](../features/reactivcore-rules.md) を参照してください。
 
----
+| Command                           | Description       |
+| --------------------------------- | ----------------- |
+| `geonic rules list`               | List all rules    |
+| `geonic rules get <id>`           | Get a rule        |
+| `geonic rules create [json]`      | Create a rule     |
+| `geonic rules update <id> [json]` | Update a rule     |
+| `geonic rules delete <id>`        | Delete a rule     |
+| `geonic rules activate <id>`      | Activate a rule   |
+| `geonic rules deactivate <id>`    | Deactivate a rule |
+
+***
 
 ### `custom-data-models` (models)
 
 カスタムデータモデルを管理します。エイリアス: `models`。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic models list` | すべてのデータモデルを一覧表示 |
-| `geonic models get <id>` | データモデルを取得 |
-| `geonic models create [json]` | データモデルを作成 |
-| `geonic models update <id> [json]` | データモデルを更新 |
-| `geonic models delete <id>` | データモデルを削除 |
+| Command                            | Description          |
+| ---------------------------------- | -------------------- |
+| `geonic models list`               | List all data models |
+| `geonic models get <id>`           | Get a data model     |
+| `geonic models create [json]`      | Create a data model  |
+| `geonic models update <id> [json]` | Update a data model  |
+| `geonic models delete <id>`        | Delete a data model  |
 
----
+***
 
-### DCAT-AP
+### `catalog`
 
-DCAT-AP データカタログを参照します。
+DCAT-AP データカタログを閲覧します。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic catalog get` | カタログを取得する |
-| `geonic catalog datasets list` | データセットを一覧表示する |
-| `geonic catalog datasets get <id>` | データセットを取得する |
-| `geonic catalog datasets sample <id>` | データセットからサンプルを取得する |
+| Command                               | Description                 |
+| ------------------------------------- | --------------------------- |
+| `geonic catalog get`                  | Get the catalog             |
+| `geonic catalog datasets list`        | List datasets               |
+| `geonic catalog datasets get <id>`    | Get a dataset               |
+| `geonic catalog datasets sample <id>` | Get a sample from a dataset |
 
----
+***
 
 ### `admin`
-管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は認証・認可ガイドを参照してください。
 
-#
+管理操作。`tenant_admin` または `super_admin` ロールが必要です。詳細は [Authentication & Authorization Guide](./auth.md) を参照してください。
 
-### `admin tenants`
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic admin tenants list` | テナント一覧を取得 |
-| `geonic admin tenants get <id>` | テナントを取得 |
-| `geonic admin tenants create [json]` | テナントを作成 |
-| `geonic admin tenants update <id> [json]` | テナントを更新 |
-| `geonic admin tenants delete <id>` | テナントを削除 |
-| `geonic admin tenants activate <id>` | テナントを有効化 |
-| `geonic admin tenants deactivate <id>` | テナントを無効化 |
+#### `admin tenants`
 
-#
+| Command                                   | Description         |
+| ----------------------------------------- | ------------------- |
+| `geonic admin tenants list`               | List tenants        |
+| `geonic admin tenants get <id>`           | Get a tenant        |
+| `geonic admin tenants create [json]`      | Create a tenant     |
+| `geonic admin tenants update <id> [json]` | Update a tenant     |
+| `geonic admin tenants delete <id>`        | Delete a tenant     |
+| `geonic admin tenants activate <id>`      | Activate a tenant   |
+| `geonic admin tenants deactivate <id>`    | Deactivate a tenant |
 
-### `admin users`
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic admin users list` | ユーザー一覧を取得 |
-| `geonic admin users get <id>` | ユーザーを取得 |
-| `geonic admin users create [json]` | ユーザーを作成 |
-| `geonic admin users update <id> [json]` | ユーザーを更新 |
-| `geonic admin users delete <id>` | ユーザーを削除 |
-| `geonic admin users activate <id>` | ユーザーを有効化 |
-| `geonic admin users deactivate <id>` | ユーザーを無効化 |
-| `geonic admin users unlock <id>` | ロックされたユーザーをアンロック |
+#### `admin users`
 
-#
+| Command                                 | Description          |
+| --------------------------------------- | -------------------- |
+| `geonic admin users list`               | List users           |
+| `geonic admin users get <id>`           | Get a user           |
+| `geonic admin users create [json]`      | Create a user        |
+| `geonic admin users update <id> [json]` | Update a user        |
+| `geonic admin users delete <id>`        | Delete a user        |
+| `geonic admin users activate <id>`      | Activate a user      |
+| `geonic admin users deactivate <id>`    | Deactivate a user    |
+| `geonic admin users unlock <id>`        | Unlock a locked user |
 
-### `admin policies`
-XACML ポリシー管理。詳細は XACML ポリシーベース認可を参照してください。
+#### `admin policies`
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic admin policies list` | ポリシー一覧を取得 |
-| `geonic admin policies get <id>` | ポリシーを取得 |
-| `geonic admin policies create [json]` | ポリシーを作成 |
-| `geonic admin policies update <id> [json]` | ポリシーを更新 |
-| `geonic admin policies delete <id>` | ポリシーを削除 |
-| `geonic admin policies activate <id>` | ポリシーを有効化 |
-| `geonic admin policies deactivate <id>` | ポリシーを無効化 |
+XACML ポリシー管理。詳細は [XACML Policy-Based Authorization](./auth.md#xacml-policy-based-authorization) を参照してください。
 
-#
+| Command                                    | Description         |
+| ------------------------------------------ | ------------------- |
+| `geonic admin policies list`               | List policies       |
+| `geonic admin policies get <id>`           | Get a policy        |
+| `geonic admin policies create [json]`      | Create a policy     |
+| `geonic admin policies update <id> [json]` | Update a policy     |
+| `geonic admin policies delete <id>`        | Delete a policy     |
+| `geonic admin policies activate <id>`      | Activate a policy   |
+| `geonic admin policies deactivate <id>`    | Deactivate a policy |
 
-### `admin oauth-clients`
-OAuth 2.0 クライアント管理。詳細は OAuth 2.0 M2M 認証を参照してください。
+#### `admin oauth-clients`
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic admin oauth-clients list` | OAuth クライアント一覧を取得 |
-| `geonic admin oauth-clients get <id>` | OAuth クライアントを取得 |
-| `geonic admin oauth-clients create [json]` | OAuth クライアントを作成 |
-| `geonic admin oauth-clients update <id> [json]` | OAuth クライアントを更新 |
-| `geonic admin oauth-clients delete <id>` | OAuth クライアントを削除 |
+OAuth 2.0 クライアント管理。詳細は [OAuth 2.0 M2M Authentication](./auth.md#oauth-20-m2m-authentication) を参照してください。
 
-#
+| Command                                         | Description            |
+| ----------------------------------------------- | ---------------------- |
+| `geonic admin oauth-clients list`               | List OAuth clients     |
+| `geonic admin oauth-clients get <id>`           | Get an OAuth client    |
+| `geonic admin oauth-clients create [json]`      | Create an OAuth client |
+| `geonic admin oauth-clients update <id> [json]` | Update an OAuth client |
+| `geonic admin oauth-clients delete <id>`        | Delete an OAuth client |
 
-### `admin api-keys`
-API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は API キー認証を参照してください。
+#### `admin api-keys`
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic admin api-keys list` | API キー一覧を取得 |
-| `geonic admin api-keys get <id>` | API キーを取得 |
-| `geonic admin api-keys create [json]` | API キーを作成 |
-| `geonic admin api-keys update <id> [json]` | API キーを更新 |
-| `geonic admin api-keys delete <id>` | API キーを削除 |
+API キー管理。`tenant_admin` または `super_admin` ロールが必要です。詳細は [API Key Authentication](./auth.md#api-key-authentication) を参照してください。
 
-**`admin api-keys list` オプション**: `--limit <n>`、`--offset <n>`、`--count`、`--tenant-id <id>` (super_admin のみ)
+| Command                                    | Description       |
+| ------------------------------------------ | ----------------- |
+| `geonic admin api-keys list`               | List API keys     |
+| `geonic admin api-keys get <id>`           | Get an API key    |
+| `geonic admin api-keys create [json]`      | Create an API key |
+| `geonic admin api-keys update <id> [json]` | Update an API key |
+| `geonic admin api-keys delete <id>`        | Delete an API key |
+
+**`admin api-keys list` オプション**: `--limit <n>`、`--offset <n>`、`--count`、`--tenant-id <id>` (super\_admin のみ)
 
 ```bash
 # Create an API key with policy binding
@@ -745,72 +779,73 @@ geonic admin api-keys list --tenant-id my-tenant
 geonic admin api-keys update gdb_abc123 '{"name": "renamed-key", "isActive": false}'
 ```
 
-**作成スキーマ**:
+**スキーマの作成**:
 
-| フィールド | 型 | 必須 | 説明 |
-|-------|------|----------|-------------|
-| `name` | string | はい | キー名 (1~100 文字) |
-| `tenantId` | string | はい (super_admin) | 対象テナント ID。super_admin には必須。tenant_admin の場合はオプション (省略時は自身のテナント) |
-| `allowedOrigins` | string[] | はい | CORS オリジン (最小 1、最大 20)。すべて許可する場合は `["*"]` を使用 |
-| `policyId` | string | いいえ | 既存の XACML ポリシーにバインド (ターゲットはバイパスされます)。省略した場合、認可はテナントポリシー、次にロールのデフォルトにフォールバック (`api_key` のデフォルトは拒否) |
-| `rateLimit` | object | いいえ | `{ perMinute: number }` (1~1000、デフォルト: 60) |
+| Field            | Type      | Required           | Description                                                                                                                                                 |
+| ---------------- | --------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`           | string    | Yes                | Key name (1–100 chars)                                                                                                                                      |
+| `tenantId`       | string    | Yes (super\_admin) | Target tenant ID. Required for super\_admin. Optional for tenant\_admin (defaults to their own tenant)                                                      |
+| `allowedOrigins` | string\[] | Yes                | CORS origins (min 1, max 20). Use `["*"]` for all                                                                                                           |
+| `policyId`       | string    | No                 | Bind to an existing XACML policy (target bypassed). If omitted, authorization falls back to tenant policies, then role defaults (`api_key` default is Deny) |
+| `rateLimit`      | object    | No                 | `{ perMinute: number }` (1–1000, default: 60)                                                                                                               |
 
-> **注意**: 平文の API キーは作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
+> **注**: 平文の API キーは作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
 
-#
+#### `admin cadde`
 
-### `admin cadde`
 CADDE (Connector Architecture for Decentralized Data Exchange) 設定管理。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic admin cadde get` | CADDE 設定を取得 |
-| `geonic admin cadde set [json]` | CADDE 設定を設定 |
-| `geonic admin cadde delete` | CADDE 設定を削除 |
+| Command                         | Description           |
+| ------------------------------- | --------------------- |
+| `geonic admin cadde get`        | Get CADDE settings    |
+| `geonic admin cadde set [json]` | Set CADDE settings    |
+| `geonic admin cadde delete`     | Delete CADDE settings |
 
----
+***
 
 ### `health`
+
 ```bash
 geonic health
 ```
 
-サーバーのヘルス状態を確認します (`GET /health`)。
+サーバーのヘルスステータスを確認します(`GET /health`)。
 
 ### `version`
+
 ```bash
 geonic version
 ```
 
-CLI のバージョンとサーバーのバージョンを表示します (`GET /version`)。
+CLI バージョンとサーバーバージョンを表示します(`GET /version`)。
 
 ### `me`
+
 現在認証されているユーザーを表示し、ユーザーリソースを管理します。
 
 ```bash
 geonic me
 ```
 
-現在のユーザー情報、JWT トークンの有効期限 (期限切れの場合は赤、5 分以内に期限切れの場合は黄色)、およびアクティブなプロファイル名を表示します。
+現在のユーザー情報、JWT トークンの有効期限(期限切れの場合は赤、5 分以内に期限切れの場合は黄色)、およびアクティブなプロファイル名を表示します。
 
-#
+#### `me oauth-clients`
 
-### `me oauth-clients`
-自分の OAuth クライアントを管理します (`/me/oauth-clients`)。`admin oauth-clients` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のクライアントを管理できます。
+自分自身の OAuth クライアント(`/me/oauth-clients`)を管理します。`admin oauth-clients` とは異なり、管理者権限は必要ありません — 認証されたユーザーは誰でも自分自身のクライアントを管理できます。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic me oauth-clients list` | OAuth クライアント一覧を表示 |
-| `geonic me oauth-clients create [json]` | 新しい OAuth クライアントを作成 |
-| `geonic me oauth-clients delete <id>` | OAuth クライアントを削除 |
+| Command                                 | Description               |
+| --------------------------------------- | ------------------------- |
+| `geonic me oauth-clients list`          | List your OAuth clients   |
+| `geonic me oauth-clients create [json]` | Create a new OAuth client |
+| `geonic me oauth-clients delete <id>`   | Delete an OAuth client    |
 
-**`me oauth-clients create` のオプション**:
+**`me oauth-clients create` オプション**:
 
-| オプション | 説明 |
-|--------|-------------|
-| `--name <name>` | クライアント名 |
-| `--policy <policyId>` | 既存の XACML ポリシーにバインド (ターゲットはバイパスされる)。省略した場合、認可はテナントポリシー、次にロールのデフォルト (`user` のデフォルトは GET のみ) にフォールバックされます |
-| `--save` | 認証情報を設定ファイルに保存し、自動再認証を有効化 |
+| Option                | Description                                                                                                                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--name <name>`       | Client name                                                                                                                                                  |
+| `--policy <policyId>` | Bind to an existing XACML policy (target bypassed). If omitted, authorization falls back to tenant policies, then role defaults (`user` default is GET-only) |
+| `--save`              | Save credentials to config for automatic re-authentication                                                                                                   |
 
 ```bash
 # Create an OAuth client with flags
@@ -823,20 +858,20 @@ geonic me oauth-clients create --name my-ci-bot --save
 geonic me oauth-clients create '{"name":"my-bot","policyId":"bot-access"}'
 ```
 
-`--save` が使用された場合、CLI は即座に Client Credentials グラントを実行し、`clientId`、`clientSecret`、および取得した `token` を設定ファイルに保存します。以降のトークン期限切れは自動的に処理されます。
+`--save` を使用すると、CLI は即座に Client Credentials グラントを実行し、`clientId`、`clientSecret`、および結果として得られる `token` を設定ファイルに保存します。その後のトークンの有効期限切れは自動的に処理されます。
 
-#
+#### `me api-keys`
 
-### `me api-keys`
-自分の API キーを管理します (`/me/api-keys`)。`admin api-keys` とは異なり、管理者権限は不要で、認証されたユーザーは誰でも自分のキーを管理できます。1 ユーザーあたり 5 つのキーに制限されています。
+自分自身の API キー(`/me/api-keys`)を管理します。`admin api-keys` とは異なり、管理者権限は必要ありません — 認証されたユーザーは誰でも自分自身のキーを管理できます。ユーザーあたり 5 個のキーに制限されています。
 
-| コマンド | 説明 |
-|---------|-------------|
-| `geonic me api-keys list` | API キー一覧を表示 |
-| `geonic me api-keys create [json]` | 新しい API キーを作成 |
-| `geonic me api-keys delete <key-id>` | API キーを削除 |
+| Command                              | Description          |
+| ------------------------------------ | -------------------- |
+| `geonic me api-keys list`            | List your API keys   |
+| `geonic me api-keys create [json]`   | Create a new API key |
+| `geonic me api-keys delete <key-id>` | Delete an API key    |
 
-**`me api-keys list` のオプション**: `--limit <n>`、`--offset <n>`、`--count`
+**`me api-keys list` オプション**: `--limit <n>`、`--offset <n>`、`--count`
+
 ```bash
 # Create a personal API key
 geonic me api-keys create '{
@@ -852,10 +887,11 @@ geonic me api-keys list
 geonic me api-keys delete gdb_abc123
 ```
 
-> **注意**: 平文の API キーは、作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
+> **注意**: 平文の API キーは作成レスポンスの `key` フィールドで一度だけ返されます。安全に保管してください。
 
 ### `help`
-WP-CLI スタイルのヘルプで、段階的に詳細を表示します。
+
+段階的に詳細が表示される WP-CLI スタイルのヘルプです。
 
 ```bash
 geonic help                    # All commands overview
@@ -864,9 +900,9 @@ geonic help entities list      # Subcommand details with options and examples
 geonic help admin tenants      # Nested command help
 ```
 
-`--help` フラグは、すべてのコマンドでも使用できます。
+`--help` フラグはすべてのコマンドでも使用できます。
 
----
+***
 
 ## シェル補完
 
@@ -876,7 +912,7 @@ geonic help admin tenants      # Nested command help
 eval "$(geonic cli completions bash)"
 ```
 
-永続化するには `~/.bashrc` に追加してください。
+`~/.bashrc` に追加して永続化します。
 
 ### Zsh
 
@@ -884,11 +920,11 @@ eval "$(geonic cli completions bash)"
 eval "$(geonic cli completions zsh)"
 ```
 
-永続化するには `~/.zshrc` に追加してください。
+`~/.zshrc` に追加して永続化します。
 
-補完機能は、サブコマンド名、オプションフラグ、および `--format` の値候補 (`json`、`table`、`geojson`) をサポートしています。
+補完はサブコマンド名、オプションフラグ、および `--format` の値候補(`json`、`table`、`geojson`)をサポートしています。
 
----
+***
 
 ## コマンドツリー
 

--- a/docs/ja/saas/quotas.md
+++ b/docs/ja/saas/quotas.md
@@ -1,11 +1,912 @@
 ---
-title: "クォータ & プラン"
-description: "GeonicDB クォータシステムとプラン"
+title: "Quotas & Plans"
+description: "GeonicDB quota system and plans"
 outline: deep
 ---
+# GeonicDB クォータシステム
 
-# クォータ & プラン
+GeonicDB は、テナントごとのレート制限とストレージクォータを管理するための包括的なクォータシステムを提供します。
 
-::: info 準備中
-このページは GeonicDB 上流ドキュメントから同期されます。次回ドキュメント同期後に全コンテンツが利用可能になります。
-:::
+## 概要
+
+クォータシステムは、3 つの主要コンポーネントで構成されています:
+
+
+1. **レート制限システム** - DynamoDB ベースのトークンバケットアルゴリズムを使用した API リクエスト制限
+   
+2. **ストレージクォータシステム** - MongoDB に基づくエンティティ/サブスクリプション/レジストレーション/時系列データの数量制限
+   
+3. **監視・管理システム** - 使用状況の追跡、アラート配信、および管理 API
+
+## クォータプラン
+
+GeonicDB は、4 つの標準プランとカスタムプランを提供しています:
+
+### FREE プラン(評価および開発用)
+
+**レート制限:**
+
+* 1 分あたり: 60 リクエスト (1 req/sec)
+  
+* 1 時間あたり: 1,000 リクエスト
+  
+* 1 日あたり: 10,000 リクエスト
+  
+* バースト許容量: 10 リクエスト
+
+**ストレージクォータ:**
+
+* エンティティ: 1,000
+  
+* サブスクリプション: 10
+  
+* レジストレーション: 5
+  
+* 時系列データポイント: 10,000
+
+**制限:**
+
+* 最大リクエストボディサイズ: 512KB
+  
+* 最大レスポンスボディサイズ: 5MB
+  
+* 最大バッチ操作サイズ: 50
+
+### STANDARD プラン(小規模本番環境用)
+
+**レート制限:**
+
+* 1 分あたり: 600 リクエスト (10 req/sec)
+  
+* 1 時間あたり: 10,000 リクエスト
+  
+* 1 日あたり: 100,000 リクエスト
+  
+* バースト許容量: 100 リクエスト
+
+**ストレージクォータ:**
+
+* エンティティ: 10,000
+  
+* サブスクリプション: 100
+  
+* レジストレーション: 50
+  
+* 時系列データポイント: 100,000
+
+**制限:**
+
+* 最大リクエストボディサイズ: 1MB
+  
+* 最大レスポンスボディサイズ: 10MB
+  
+* 最大バッチ操作サイズ: 100
+
+### PREMIUM プラン(中規模本番環境)
+
+**レート制限:**
+
+* 毎分: 3,000 リクエスト (50 req/sec)
+  
+* 毎時: 50,000 リクエスト
+  
+* 毎日: 500,000 リクエスト
+  
+* バースト許容量: 500 リクエスト
+
+**ストレージクォータ:**
+
+* エンティティ: 100,000
+  
+* サブスクリプション: 500
+  
+* レジストレーション: 200
+  
+* 時系列データポイント: 1,000,000
+
+**制限:**
+
+* 最大リクエストボディサイズ: 5MB
+  
+* 最大レスポンスボディサイズ: 50MB
+  
+* 最大バッチ操作サイズ: 500
+
+### ENTERPRISE プラン(大規模本番環境)
+
+**レート制限:**
+
+* 毎分: 12,000 リクエスト (200 req/sec)
+  
+* 毎時: 200,000 リクエスト
+  
+* 毎日: 2,000,000 リクエスト
+  
+* バースト許容量: 2,000 リクエスト
+
+**ストレージクォータ:**
+
+* エンティティ: 1,000,000
+  
+* サブスクリプション: 2,000
+  
+* レジストレーション: 1,000
+  
+* 時系列データポイント: 10,000,000
+
+**制限:**
+
+* 最大リクエストボディサイズ: 10MB
+  
+* 最大レスポンスボディサイズ: 100MB
+  
+* 最大バッチ操作サイズ: 1,000
+
+### CUSTOM プラン
+
+任意の値を設定できるカスタムプランです。管理 API を使用して個別に設定します。
+
+## レート制限
+
+### トークンバケットアルゴリズム
+
+GeonicDB は、3 つのスライディングウィンドウ (分/時間/日) で動作するトークンバケットアルゴリズムを使用しています:
+
+
+1. トークンは、エンドポイントの重みに基づいてリクエストごとに消費されます
+   
+2. リクエストは、3 つすべてのウィンドウに十分なトークンがある場合にのみ許可されます
+   
+3. トークンは、各時間ウィンドウの移行時に自動的に補充されます
+
+### エンドポイントの重み
+
+異なるエンドポイントには、処理コストに基づいて異なる重みが割り当てられます:
+
+| Operation           | Weight    | Example                                    |
+| ------------------- | --------- | ------------------------------------------ |
+| GET                 | 1         | `GET /v2/entities`                         |
+| POST (single)       | 3         | `POST /v2/entities`                        |
+| PATCH/PUT           | 2         | `PATCH /v2/entities/{id}`                  |
+| DELETE              | 2         | `DELETE /v2/entities/{id}`                 |
+| Batch operations    | 5 × count | `POST /v2/op/update` with 10 entities = 50 |
+| Temporal operations | 2         | `POST /ngsi-ld/v1/temporal/entities`       |
+
+### バースト許容量
+
+各プランには、短期間の突発的なトラフィックスパイクに対処するためのバースト許容量があります。これにより、一時的に制限を超えることが可能になります。
+
+### レスポンスヘッダー
+
+レート制限が有効になっている場合、NGSIv2、NGSI-LD、および Catalog API エンドポイントからのレスポンスには、現在のレート制限ステータスを示すヘッダーが含まれます:
+
+```http
+X-RateLimit-Limit-Minute: 600
+X-RateLimit-Remaining-Minute: 450
+X-RateLimit-Reset-Minute: 1707648000
+
+X-RateLimit-Limit-Hour: 10000
+X-RateLimit-Remaining-Hour: 8500
+X-RateLimit-Reset-Hour: 1707651600
+
+X-RateLimit-Limit-Day: 100000
+X-RateLimit-Remaining-Day: 95000
+X-RateLimit-Reset-Day: 1707734400
+```
+
+### レート制限を超えた場合の動作
+
+レート制限を超えた場合:
+
+
+* **HTTP ステータスコード**: `429 Too Many Requests`
+  
+* **Retry-After ヘッダー**: 次のリクエストが許可されるまでの秒数
+  
+* **エラーメッセージ**: `{"error": "TooManyRequests", "description": "Rate limit exceeded"}`
+
+### 公開 (認証なし) エンドポイントのレート制限 (#1075)
+
+認証なしでアクセス可能な公開エンドポイントは、テナントごとの `QUOTAS.PLANS` とは独立した IP ベースのトークンバケットによって保護されています。これにより、OAuth の `client_id+secret` ブルートフォースや、大規模な JSON 生成 (`/openapi.json` など) による DoS がブロックされます。
+
+| Category                  | Endpoints                                                                                                                                       | Per minute | Per hour | Per day | Burst |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------: | -------: | ------: | ----: |
+| `metadata`                | `/openapi.json`, `/api.json`, `/tools.json`, `/llms.txt`, `/.well-known/ai-plugin.json`, `/.well-known/agent-card.json`, `/.well-known/ngsi-ld` |         30 |      300 |   1,000 |    10 |
+| `oauth` (per IP)          | `/oauth/token`                                                                                                                                  |         20 |      100 |     500 |     5 |
+| `oauth` (per `client_id`) | `/oauth/token`                                                                                                                                  |         10 |       60 |     200 |     2 |
+| `auth`                    | `/auth/refresh`, `/auth/nonce`                                                                                                                  |         30 |      200 |   1,000 |     5 |
+
+注記:
+
+
+* `/auth/login` はこの制限の**対象外**です。これは `LoginProtectionService` (メール + IP ベースの段階的ロックアウト) によって保護されています。
+  
+* `/health`、`/health/live`、`/health/ready`、`/version` はこの制限の**対象外**です (ヘルスチェックポーリング用)。
+  
+* バケットストア (DynamoDB / MongoDB) が利用できない場合、リクエストは通過が許可されます。公開サーフェスをオフラインにしないよう、インフラストラクチャエラー時にはフェイルクローズしません。
+  
+* デフォルト値は `src/config/defaults.ts` の `PUBLIC_RATE_LIMIT` に集約されています。
+
+## ストレージクォータ
+
+### リソースタイプ
+
+クォータは 4 種類のリソースに対して設定されます:
+
+
+1. **Entities** - NGSIv2/NGSI-LD エンティティの総数
+   
+2. **Subscriptions** - アクティブなサブスクリプションの総数
+   
+3. **Registrations** - コンテキストソース登録の総数
+   
+4. **Temporal data points** - 時系列データポイントの総数
+
+### 事前チェック
+
+ストレージクォータは作成操作の**前に**チェックされます:
+
+
+* バッチ操作の場合、すべてのエンティティがクォータ内に収まる場合のみ実行が進行します
+  
+* 1 つでもクォータを超える場合、操作全体が拒否されます(全か無か)
+
+### レスポンスヘッダー
+
+NGSIv2、NGSI-LD、および Catalog API エンドポイントには、現在のストレージ使用状況を示すヘッダーが含まれます:
+
+```http
+X-Storage-Quota-Entities-Used: 5000
+X-Storage-Quota-Entities-Limit: 10000
+X-Storage-Quota-Subscriptions-Used: 50
+X-Storage-Quota-Subscriptions-Limit: 100
+X-Storage-Quota-Registrations-Used: 25
+X-Storage-Quota-Registrations-Limit: 50
+X-Storage-Quota-TemporalDataPoints-Used: 50000
+X-Storage-Quota-TemporalDataPoints-Limit: 100000
+```
+
+**対象エンドポイント**: これらのヘッダーは、NGSIv2、NGSI-LD、および Catalog API のすべてのエンドポイントによって返されます。管理 API (`/admin/tenants/{tenantId}/quotas`) を使用すると、より詳細なクォータ情報を取得できます。詳細は [Authentication & Authorization](../reference/auth.md#quota-management) を参照してください。
+
+### ストレージクォータを超えた場合の動作
+
+ストレージクォータを超えた場合:
+
+
+* **HTTP ステータスコード**: `507 Insufficient Storage`
+  
+* **エラーメッセージ**: リソースタイプと現在の使用状況が含まれます
+  
+* **例**: `{"error": "InsufficientStorage", "description": "Entity quota exceeded (10000/10000)", "details": {"resourceType": "entities", "current": 10000, "limit": 10000}}`
+
+## モニタリングとアラート
+
+### 使用状況スナップショット
+
+システムは定期的に使用状況スナップショットを DynamoDB に記録します:
+
+
+* レート制限使用率(分/時/日)
+  
+* ストレージリソース使用率
+  
+* タイムスタンプとテナント情報
+  
+* 90 日間保持(TTL)
+
+### アラート閾値
+
+各テナントには2つのアラートレベルがあります:
+
+
+* **警告**: デフォルトで使用率 80%
+  
+* **重大**: デフォルトで使用率 95%
+
+### アラート配信
+
+設定された閾値を超えた場合:
+
+
+1. アラートメッセージがログに記録されます
+   
+2. Webhook URL が設定されている場合、HTTP POST 経由でアラートが送信されます
+   
+3. 同じアラートは 1 時間以内に再送信されません(デバウンス機能)
+
+### Webhook ペイロード
+
+```json
+{
+  "id": "rateLimit.perMinute.warning.tenant1#/",
+  "tenantService": "tenant1#/",
+  "alertType": "rateLimit",
+  "resourceType": "perMinute",
+  "severity": "warning",
+  "message": "Rate limit perMinute usage is high (85%)",
+  "currentValue": 510,
+  "limitValue": 600,
+  "utilizationPercent": 85,
+  "timestamp": 1707645123456
+}
+```
+
+## 管理 API
+
+### クォータ情報の取得
+
+```http
+GET /admin/tenants/{tenantId}/quotas
+```
+
+**レスポンス:**
+
+```json
+{
+  "tenantId": "tenant-1",
+  "tenantName": "tenant1",
+  "quotaPlan": "STANDARD",
+  "customQuotas": null,
+  "alertThresholds": {
+    "rateLimitWarning": 80,
+    "rateLimitCritical": 95,
+    "storageWarning": 80,
+    "storageCritical": 95
+  },
+  "currentUsage": {
+    "rateLimit": {
+      "minute": { "limit": 600, "used": 150, "remaining": 450, "usagePercent": 25, "resetAt": 1707648000 },
+      "hour": { "limit": 10000, "used": 1500, "remaining": 8500, "usagePercent": 15, "resetAt": 1707651600 },
+      "day": { "limit": 100000, "used": 5000, "remaining": 95000, "usagePercent": 5, "resetAt": 1707734400 }
+    },
+    "storage": {
+      "entities": { "used": 5000, "limit": 10000, "usagePercent": 50 },
+      "subscriptions": { "used": 50, "limit": 100, "usagePercent": 50 },
+      "registrations": { "used": 25, "limit": 50, "usagePercent": 50 },
+      "temporalDataPoints": { "used": 50000, "limit": 100000, "usagePercent": 50 }
+    }
+  }
+}
+```
+
+### クォータ設定の更新
+
+```http
+PUT /admin/tenants/{tenantId}/quotas
+```
+
+**リクエストボディ:**
+
+```json
+{
+  "quotaPlan": "PREMIUM",
+  "alertThresholds": {
+    "rateLimitWarning": 85,
+    "rateLimitCritical": 98,
+    "storageWarning": 85,
+    "storageCritical": 98
+  }
+}
+```
+
+### カスタムクォータの設定
+
+```http
+PUT /admin/tenants/{tenantId}/quotas
+```
+
+**リクエストボディ:**
+
+```json
+{
+  "quotaPlan": "CUSTOM",
+  "customQuotas": {
+    "rateLimit": {
+      "perMinute": 1200,
+      "perHour": 20000,
+      "perDay": 200000,
+      "burstAllowance": 200
+    },
+    "storage": {
+      "maxEntities": 50000,
+      "maxSubscriptions": 200,
+      "maxRegistrations": 100,
+      "maxTemporalDataPoints": 500000
+    },
+    "limits": {
+      "maxRequestBodyBytes": 2097152,
+      "maxResponseBodyBytes": 20971520,
+      "maxBatchSize": 200
+    }
+  }
+}
+```
+
+### 使用履歴の取得
+
+```http
+GET /admin/tenants/{tenantId}/usage?startDate=2026-02-01&endDate=2026-02-10&limit=100
+```
+
+**レスポンス:**
+
+```json
+{
+  "tenantId": "tenant-1",
+  "tenantName": "tenant1",
+  "startDate": "2026-02-01",
+  "endDate": "2026-02-10",
+  "snapshots": [
+    {
+      "tenantService": "tenant1#/",
+      "timestamp": 1707645123456,
+      "date": "2026-02-10",
+      "rateLimit": { ... },
+      "storage": { ... }
+    }
+  ]
+}
+```
+
+## 環境変数
+
+### SAM テンプレート
+
+```yaml
+Parameters:
+  RateLimitEnabled:
+    Type: String
+    Default: 'true'
+    Description: Enable rate limiting for API requests
+
+  QuotaAlertWebhookUrl:
+    Type: String
+    Default: ''
+    Description: Webhook URL for quota violation alerts
+```
+
+### 環境変数
+
+
+* `RATE_LIMIT_ENABLED`: レート制限の有効化/無効化(デフォルト: `true`)
+  
+* `RATE_LIMIT_TABLE_NAME`: DynamoDB レート制限テーブル名
+  
+* `USAGE_STATS_TABLE_NAME`: DynamoDB 使用統計テーブル名
+  
+* `QUOTA_ALERT_WEBHOOK_URL`: アラート配信用の Webhook URL(オプション)
+
+## アクセス制御
+
+### 権限レベル
+
+
+* **super\_admin**: すべてのテナントのクォータを閲覧および変更可能
+  
+* **tenant\_admin**: 自分のテナントのクォータを閲覧および変更可能
+  
+* **user**: クォータ管理 API へのアクセス権なし
+
+### 認証
+
+すべてのクォータ管理 API は認証が必要です:
+
+```http
+Authorization: Bearer <JWT_TOKEN>
+```
+
+## ベストプラクティス
+
+### クォータプランの選択
+
+
+1. **開発/テスト**: FREE プランから始める
+   
+2. **小規模本番環境**: STANDARD プラン
+   
+3. **中規模本番環境**: PREMIUM プラン
+   
+4. **大規模本番環境**: ENTERPRISE プラン
+   
+5. **特別な要件**: CUSTOM プランで個別に設定
+
+### アラート設定
+
+
+* **Warning**: 容量拡張を検討する閾値(デフォルト 80%)
+  
+* **Critical**: 即座の対応が必要な閾値(デフォルト 95%)
+  
+* リアルタイム通知を受信するための Webhook URL を設定
+
+### モニタリング
+
+
+* レスポンスヘッダーを定期的に確認
+  
+* 使用履歴 API でトレンドを分析
+  
+* アラートログを監視
+
+## トラブルシューティング
+
+### 429 Too Many Requests
+
+**原因**: レート制限を超過しました
+
+**解決方法**:
+
+1. `Retry-After` ヘッダーで指定された秒数待ちます
+   
+2. リクエスト頻度を削減します
+   
+3. バッチ操作を活用してリクエスト数を削減します
+   
+4. プランのアップグレードを検討してください
+
+### 507 Insufficient Storage
+
+**原因**: ストレージクォータを超過しました
+
+**解決方法**:
+
+1. 不要なエンティティ / サブスクリプション / レジストレーションを削除します
+   
+2. 時系列データの保持期間を短縮します
+   
+3. プランのアップグレードを検討してください
+
+### クォータヘッダーが表示されない
+
+**原因**: レート制限が無効になっている可能性があります
+
+**解決方法**:
+
+1. `RATE_LIMIT_ENABLED` 環境変数を確認します
+   
+2. SAM テンプレートのパラメータを確認します
+   
+3. DynamoDB テーブルが正しくデプロイされていることを確認します
+
+## 入力検証の制限
+
+GeonicDB は、不正使用を防止しシステムの安定性を確保するため、入力長とカウント制限を適用しています。
+
+### 認証とログイン保護
+
+#### アカウント単位のログイン保護
+
+既存のアカウント単位のブルートフォース保護 ([AUTH.md](../reference/auth.md) を参照):
+
+
+* アカウント単位の最大ログイン失敗回数:**15 分**以内に**5 回**
+  
+* アカウントロック期間:閾値到達後**15 分間**
+  
+* 段階的遅延:**2 秒**から始まる指数バックオフ (2^(n-2))
+
+#### IP 単位のログイン保護 (#900)
+
+単一の IP から複数のアカウントに対するパスワードスプレー攻撃を防止します:
+
+| Parameter                      | Value                       |
+| ------------------------------ | --------------------------- |
+| Maximum failed attempts per IP | **20** within **5 minutes** |
+| IP lock duration               | **15 minutes**              |
+| Record TTL                     | **1 hour** (auto-deleted)   |
+
+
+* **HTTP ステータス**: `429 Too Many Requests` と `Retry-After: 900`
+  
+* ログイン成功時は IP カウンターをリセットしません(タイミングベースの列挙を防止)
+  
+* エラーメッセージ:`"Too many failed login attempts from this IP. Please try again later."`
+
+### テナントリソース制限
+
+#### テナントあたりのユーザー数 (#901)
+
+| Parameter                | Default |
+| ------------------------ | ------- |
+| Maximum users per tenant | **100** |
+
+
+* ユーザー作成時のみチェック
+  
+* `tenant.settings.maxUsers` によるテナントごとのオーバーライド
+  
+* **HTTP ステータス**: `400 Bad Request`
+  
+* エラーメッセージ: `"User limit reached for this tenant (current: N, limit: M)"`
+
+#### テナントあたりのポリシー数 (#912)
+
+| Parameter                   | Default |
+| --------------------------- | ------- |
+| Maximum policies per tenant | **50**  |
+
+
+* `tenant.settings.maxPolicies` によるテナントごとのオーバーライド
+  
+* **HTTP ステータス**: `400 Bad Request`
+  
+* エラーメッセージ: `"Policy limit reached for this tenant (current: N, limit: M)"`
+
+#### 管理者ユーザー操作のレート制限 (#905)
+
+Admin API における作成-削除サイクル攻撃を防止します:
+
+| Parameter                     | Value                                |
+| ----------------------------- | ------------------------------------ |
+| Window                        | **10 minutes**                       |
+| Maximum operations per window | **1,000** (create + delete combined) |
+
+
+* `createUser` および `deleteUser` に対してテナントごとに適用
+  
+* `super_admin` は対象外
+  
+* **HTTP ステータス**: `429 Too Many Requests`
+  
+* エラーメッセージ: `"Too many user management operations. Limit: 1000 per 10 minutes."`
+
+### XACML ポリシー入力制限 (#912)
+
+| Field                                 | Max Length       |
+| ------------------------------------- | ---------------- |
+| `policyId` / `policySetId` / `ruleId` | 256 characters   |
+| `description`                         | 2,000 characters |
+| `attributeId`                         | 256 characters   |
+| `matchValue`                          | 2,000 characters |
+| `expression` (condition)              | 5,000 characters |
+| `timezone`, `startTime`, `endTime`    | 50 characters    |
+| IP/CIDR entry in `allowedIps`         | 50 characters    |
+
+| Collection              | Max Count |
+| ----------------------- | --------- |
+| Rules per policy        | 100       |
+| Conditions per rule     | 50        |
+| Policies per policy set | 100       |
+
+### メールアドレスの検証 (#903)
+
+
+* 最大長: **254 文字** (RFC 5321 準拠)
+  
+* 適用対象: ユーザー作成、ユーザー更新、ログイン
+  
+* **HTTP ステータス**: `400 Bad Request`
+
+### サブスクリプションエンドポイント URI/URL (#913)
+
+
+* 最大長: **2,048 文字**
+  
+* 適用対象: NGSI-LD `notification.endpoint.uri`、NGSIv2 `notification.http.url` / `notification.httpCustom.url` / `notification.mqtt.url`
+  
+* **HTTP ステータス**: `400 Bad Request`
+
+### 入力検証制限(全般)
+
+GeonicDB はすべての API エンドポイントにわたって包括的な入力検証を実施します。いずれかの制限を超えると `400 Bad Request` が返されます。
+
+#### 文字列長制限
+
+| Category           | Example Fields                               | Max Length |
+| ------------------ | -------------------------------------------- | ---------- |
+| Entity ID          | `entityId`, `id`                             | 256        |
+| Entity Type        | `type`                                       | 256        |
+| Attribute Name     | `attrName`, attribute keys                   | 256        |
+| Generic ID         | `subscriptionId`, `registrationId`, `ruleId` | 256        |
+| Name fields        | `name`, `subscriptionName`                   | 256        |
+| Description fields | `description`                                | 2,000      |
+| URL fields         | `endpoint`, `provider.http.url`              | 2,048      |
+| Query strings      | `q`, `mq`, `scopeQ`, `csf`                   | 2,000      |
+| Regex patterns     | `idPattern`, `typePattern`                   | 200        |
+| georel             | `georel`                                     | 100        |
+| geometry           | `geometry`                                   | 50         |
+| coords             | `coords`, `coordinates`                      | 2,000      |
+| orderBy            | `orderBy`                                    | 500        |
+| options            | `options`                                    | 200        |
+| lang               | `lang`                                       | 50         |
+| scope              | `scope` (string)                             | 500        |
+| unitCode           | `unitCode`                                   | 50         |
+
+#### 配列要素数制限
+
+| Array Field                             | Max Elements           |
+| --------------------------------------- | ---------------------- |
+| `attrs`, `pick`, `omit`, `expandValues` | 50                     |
+| `watchedAttributes`                     | 100                    |
+| `notification.attrs` / `exceptAttrs`    | 100                    |
+| `subject.entities` / `entities`         | 100                    |
+| Batch operation `entities`              | 100 (MAX\_BATCH\_SIZE) |
+| `propertyNames` / `relationshipNames`   | 100                    |
+| `receiverInfo` / `notifierInfo`         | 50                     |
+| `contextSourceInfo`                     | 50                     |
+| `operationGroup`                        | 20                     |
+| `scope` (array)                         | 20                     |
+| `@context` (array)                      | 10                     |
+
+#### 数値上限
+
+| Field        | Max Value                     |
+| ------------ | ----------------------------- |
+| `throttling` | 86,400 (24 hours, in seconds) |
+| `timeout`    | 30,000 (30 seconds, in ms)    |
+| `lastN`      | 1,000                         |
+
+#### ヘッダー検証
+
+| Header                           | Max Length |
+| -------------------------------- | ---------- |
+| Bearer / DPoP token              | 8,192      |
+| Link (@context URL)              | 2,048      |
+| Fiware-ServicePath (per element) | 256        |
+| Tenant name (Fiware-Service)     | 64         |
+
+#### パスパラメータ検証
+
+URL パス内のリソース ID も長さの検証が行われます。
+
+| Parameter        | Max Length | Applicable APIs          |
+| ---------------- | ---------- | ------------------------ |
+| `entityId`       | 256        | NGSIv2, NGSI-LD          |
+| `attrName`       | 256        | NGSIv2, NGSI-LD          |
+| `subscriptionId` | 256        | NGSIv2, NGSI-LD          |
+| `registrationId` | 256        | NGSIv2, NGSI-LD          |
+| `instanceId`     | 256        | NGSI-LD Temporal         |
+| `entityMapId`    | 256        | NGSI-LD Entity Maps      |
+| `contextId`      | 256        | NGSI-LD JSON-LD Contexts |
+| `snapshotId`     | 256        | NGSI-LD Snapshots        |
+| `ruleId`         | 256        | Rules API                |
+| `typeName`       | 256        | NGSIv2/NGSI-LD Types     |
+| `datasetId`      | 256        | Catalog API              |
+
+#### AttributeValue ネスト深度制限
+
+
+* 最大深度:**10**
+  
+* 制限を超えると、プリミティブ型(文字列、数値、真偽値、null)のみが受け入れられます
+  
+* **HTTP ステータス**:ネストが制限を超えた場合は `400 Bad Request`
+
+#### MQTT 通知フィールド
+
+| Field             | Max Length |
+| ----------------- | ---------- |
+| `topic`           | 1,024      |
+| `user` / `passwd` | 256        |
+
+#### HTTP カスタム通知フィールド
+
+| Field              | Max Length    |
+| ------------------ | ------------- |
+| Header key         | 256           |
+| Header value       | 4,096         |
+| Query string value | 2,048         |
+| `payload`          | 51,200 (50KB) |
+
+#### Admin API 検証
+
+| Field                                                                   | Max Length / Value          |
+| ----------------------------------------------------------------------- | --------------------------- |
+| Tenant `name`                                                           | 64                          |
+| Tenant `maxUsers`                                                       | 10,000                      |
+| Tenant `description`                                                    | 2,000                       |
+| Tenant `allowedServices`                                                | 50 elements, each 256 chars |
+| User `password`                                                         | 128 (also minimum 12)       |
+| Policy `priority`                                                       | 0–1,000                     |
+| Policy `subjects` / `resources` / `actions` array                       | 50 elements each            |
+| API key `policyId` / `tenantId`                                         | 256                         |
+| API key origin                                                          | 2,048                       |
+| OAuth client `name`                                                     | 256                         |
+| OAuth client `description`                                              | 2,000                       |
+| Path parameters (`tenantId`, `userId`, `policyId`, `keyId`, `clientId`) | 256                         |
+
+#### Auth & OAuth API 検証
+
+| Field                   | Max Length |
+| ----------------------- | ---------- |
+| Login `password`        | 128        |
+| Login `tenantId`        | 256        |
+| Refresh token           | 8,192      |
+| Password reset `token`  | 2,048      |
+| OAuth `scope`           | 2,000      |
+| OAuth `client_secret`   | 512        |
+| OAuth `nonce` / `proof` | 512        |
+
+#### カスタムクォータの上限
+
+Admin API 経由でカスタムクォータを設定する場合、以下の最大値が適用されます:
+
+| Field                           | Max Value           |
+| ------------------------------- | ------------------- |
+| `rateLimit.perMinute`           | 1,000,000           |
+| `rateLimit.perHour`             | 10,000,000          |
+| `rateLimit.perDay`              | 100,000,000         |
+| `rateLimit.burstAllowance`      | 100,000             |
+| `storage.maxEntities`           | 100,000,000         |
+| `storage.maxSubscriptions`      | 1,000,000           |
+| `storage.maxRegistrations`      | 1,000,000           |
+| `storage.maxTemporalDataPoints` | 1,000,000,000       |
+| `limits.maxRequestBodyBytes`    | 100MB (104,857,600) |
+| `limits.maxResponseBodyBytes`   | 1GB (1,073,741,824) |
+| `limits.maxBatchSize`           | 10,000              |
+
+#### Rules API 検証
+
+| Field                                          | Max Length / Value |
+| ---------------------------------------------- | ------------------ |
+| Rule `name`                                    | 256                |
+| Rule `description`                             | 2,000              |
+| Rule `priority`                                | 0–1,000            |
+| Rule `cooldownSeconds`                         | 86,400 (24h)       |
+| Condition `attributeName`                      | 256                |
+| Condition `pattern`                            | 200                |
+| Condition `timezone` / `startTime` / `endTime` | 50                 |
+| Action `entityId`                              | 256                |
+| Action `entityType`                            | 256                |
+| Action `url` (webhook)                         | 2,048              |
+| Action `message`                               | 2,000              |
+| `conditions` / `actions` array                 | 50 elements each   |
+| `entityTypes` array                            | 100 elements       |
+
+#### Custom Data Models API 検証
+
+| Field                                | Max Length / Value |
+| ------------------------------------ | ------------------ |
+| Model `type`                         | 256                |
+| Model `domain`                       | 256                |
+| Model `description`                  | 2,000              |
+| Property `valueType`                 | 256                |
+| Property `description`               | 2,000              |
+| Validation `minLength` / `maxLength` | 10,000             |
+| Validation `enum` array              | 100 elements       |
+
+#### Catalog / CADDE / Vocabulary API 検証
+
+| Field                                  | Max Length          |
+| -------------------------------------- | ------------------- |
+| Catalog `q` (keyword)                  | 2,000               |
+| Catalog `id` (package/dataset)         | 256                 |
+| CADDE query params (`type`, `id`, `q`) | Same as NGSI limits |
+| Vocabulary `tenantId`                  | 64                  |
+| Vocabulary `term`                      | 256                 |
+
+#### MCP Admin Tools 検証
+
+MCP ツールは、ツール入力層で HTTP Admin API と同じ制限を適用します:
+
+| Field                        | Validation                        |
+| ---------------------------- | --------------------------------- |
+| `email`                      | Valid email format, max 254 chars |
+| `password`                   | 12–128 chars                      |
+| `id` / `policyId` / `tenant` | Max 256 chars                     |
+| `description`                | Max 2,000 chars                   |
+| `priority`                   | 0–1,000                           |
+
+すべての制限違反は次を返します:
+
+* **HTTP ステータス**: `400 Bad Request`
+  
+* **エラー形式**: `{ "error": "BadRequest", "description": "field exceeds maximum length of N" }`
+
+### Storage Quota 修正: `/v2/op/update` (#902)
+
+バッチ操作 (`/v2/op/update`) のストレージクォータチェックが、エンティティ作成操作を正しく識別するようになりました:
+
+
+* **`append` / `appendStrict`**: エンティティ作成としてカウント — ストレージクォータを消費
+  
+* **`update` / `delete` / `replace`**: エンティティ作成としてカウントされない — ストレージクォータへの影響なし
+
+以前は、すべての `/v2/op/update` リクエストが `actionType` に関係なく、エンティティ作成クォータに対して誤ってカウントされていました。
+
+## 関連ドキュメント
+
+
+* 開発・デプロイメントガイド - インフラストラクチャセットアップ
+  
+* [認証・認可](../reference/auth.md) - テナント/ユーザー管理、アクセス制御


### PR DESCRIPTION
## Automated Sync & Translation

**Trigger**: workflow_dispatch
**GeonicDB SHA**: N/A (manual dispatch)
**Base branch**: main

### Changed files
docs/en/api-reference/endpoints.md
docs/en/api-reference/ngsild.md
docs/en/api-reference/ngsiv2.md
docs/en/changelog/unreleased.md
docs/en/faq.md
docs/en/features/ngsi-subscriptions.md
docs/en/features/reactivcore-rules.md
docs/en/features/subscriptions.md
docs/en/reference/auth.md
docs/en/reference/cli.md
docs/en/saas/quotas.md

### Process
1. Synced English source docs from geolonia/geonicdb → docs/en/
2. Translated English docs to Japanese via yuuhitsu → docs/ja/
3. Build verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * NGSI Subscriptions、ReactiveCore Rules、認証・認可リファレンスガイド、SaaS クォータなどの包括的なドキュメントを追加
  * 既存ドキュメントの可読性向上とリンク修正を実施
  * 日本語ドキュメントを充実化し、多言語対応を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->