### PR TITLE
feat(sdk): add ./react and ./ngsi-v2 subpath documentation (en/ja)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- [feat] cmd_576 Phase B' — SDK `./react` and `./ngsi-v2` subpath documentation added (en/ja): `useLdEntities`, `useTemporalData`, `GeonicDbMap`, `NgsiV2Client` API reference. Corresponds to geonicdb#1260 which adds these subpaths to `@geolonia/geonicdb-sdk`. (Closes #228)
 - [feat] cmd_447 Phase 1.1 — MAPPING_TABLE 4 entry 追加 (AUTH/QUOTAS/REACTIVCORE_RULES/SUBSCRIPTIONS) + VitePress sidebar en/ja 更新 + SaaS-rewrite rules 4件追加 (R-AUTH-SETUP/R-RULES-ENABLE)。翻訳は cmd_450 で別途実施 (Closes #213)
 - [chore] cmd_415 — sync-and-translate.yml に `base_branch` 入力追加（任意ブランチへの sync PR 作成対応、dogfood テスト用）(Closes #199)
 - [feat] cmd_387 — vitepress-plugin-mermaid 導入（architecture ページ Mermaid グラフ表示対応）(Closes #179)

--- a/docs/en/sdk/index.md
+++ b/docs/en/sdk/index.md
@@ -122,7 +122,7 @@ function TemporalChart({ client }) {
 
 ### `GeonicDbMap`
 
-Display entities on a map using [@geolonia/embed](https://geolonia.com/maplibre-gl-js/):
+Display entities on a map using [@geolonia/embed](https://github.com/geolonia/embed):
 
 ```tsx
 import { GeonicDbMap } from '@geolonia/geonicdb-sdk/react';

--- a/docs/en/sdk/index.md
+++ b/docs/en/sdk/index.md
@@ -1,0 +1,202 @@
+---
+title: "JavaScript SDK"
+description: "@geolonia/geonicdb-sdk — NGSI-LD client, React hooks, and NGSIv2 client"
+outline: deep
+---
+
+# JavaScript SDK
+
+`@geolonia/geonicdb-sdk` provides a TypeScript/JavaScript client for the GeonicDB NGSI-LD Context Broker, along with optional React hooks and an NGSIv2 client.
+
+## Installation
+
+```bash
+npm install @geolonia/geonicdb-sdk
+```
+
+For React hooks and the map component, React 18 or 19 is required as a peer dependency:
+
+```bash
+npm install @geolonia/geonicdb-sdk react react-dom
+```
+
+## Import Subpaths
+
+The SDK is split into three subpaths to keep bundles lean:
+
+| Subpath | Contents | React required |
+|---------|----------|---------------|
+| `@geolonia/geonicdb-sdk` | NGSI-LD client (core), DPoP, WebSocket | No |
+| `@geolonia/geonicdb-sdk/react` | React hooks + GeonicDbMap component | Yes (optional peerDep) |
+| `@geolonia/geonicdb-sdk/ngsi-v2` | NGSIv2 basic client | No |
+
+## Core (`@geolonia/geonicdb-sdk`)
+
+```typescript
+import GeonicDB from '@geolonia/geonicdb-sdk';
+
+const db = new GeonicDB({
+  apiKey: 'your-api-key',
+  tenant: 'your-tenant',
+  baseUrl: 'https://your-geonicdb.example.com',
+});
+
+// Login (DPoP applied automatically when supported)
+await db.login('user@example.com', 'password');
+
+// Query entities
+const rooms = await db.getEntities({ type: 'Room' });
+
+// Create entity
+await db.createEntity({
+  id: 'urn:ngsi-ld:Room:001',
+  type: 'Room',
+  temperature: { type: 'Property', value: 22.5 },
+});
+```
+
+See [Authentication Reference](/en/reference/auth) for the full API.
+
+## React Hooks (`@geolonia/geonicdb-sdk/react`)
+
+Import from the `./react` subpath to use hooks without pulling React into non-React consumers.
+
+### `useLdEntities`
+
+Fetch NGSI-LD entities reactively:
+
+```tsx
+import GeonicDB from '@geolonia/geonicdb-sdk';
+import { useLdEntities } from '@geolonia/geonicdb-sdk/react';
+
+const db = new GeonicDB({ apiKey: '...', tenant: '...', baseUrl: '...' });
+
+function RoomList() {
+  const { entities, loading, error, refetch } = useLdEntities(db, {
+    type: 'Room',
+    limit: 50,
+  });
+
+  if (loading) return <p>Loading…</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <ul>
+      {entities.map(e => <li key={e.id}>{e.id}</li>)}
+    </ul>
+  );
+}
+```
+
+**Options:**
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `type` | `string` | Filter by entity type |
+| `limit` | `number` | Maximum number of results |
+| `attrs` | `string[]` | Attributes to return |
+| `q` | `string` | NGSI-LD query filter |
+| `scopeQ` | `string` | Scope filter |
+
+**Returns:** `{ entities, loading, error, refetch }`
+
+### `useTemporalData`
+
+Fetch NGSI-LD temporal (time-series) data:
+
+```tsx
+import { useTemporalData } from '@geolonia/geonicdb-sdk/react';
+
+function TemporalChart({ client }) {
+  const { data, loading, error } = useTemporalData(client, {
+    type: 'TemperatureSensor',
+    timerel: 'between',
+    timeAt: '2026-01-01T00:00:00Z',
+    endTimeAt: '2026-01-02T00:00:00Z',
+  });
+
+  if (loading) return <p>Loading…</p>;
+  return <pre>{JSON.stringify(data, null, 2)}</pre>;
+}
+```
+
+### `GeonicDbMap`
+
+Display entities on a map using [@geolonia/embed](https://geolonia.com/maplibre-gl-js/):
+
+```tsx
+import { GeonicDbMap } from '@geolonia/geonicdb-sdk/react';
+import { useLdEntities } from '@geolonia/geonicdb-sdk/react';
+
+function EntityMap({ client }) {
+  const { entities } = useLdEntities(client, { type: 'GeoFeature' });
+
+  return (
+    <GeonicDbMap
+      entities={entities}
+      center={[139.7671, 35.6812]}
+      zoom={12}
+      onEntityClick={(e) => console.log(e.id)}
+      fitToMarkers
+    />
+  );
+}
+```
+
+**Props:**
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `entities` | `(LdEntity \| NgsiEntity)[]` | `[]` | Entities to display |
+| `center` | `[number, number]` | Tokyo | Initial center `[lng, lat]` |
+| `zoom` | `number` | `13` | Initial zoom level |
+| `styleUrl` | `string` | `'geolonia/basic'` | Map style URL |
+| `onEntityClick` | `(entity) => void` | — | Click handler |
+| `onMapClick` | `([lng, lat]) => void` | — | Map click handler |
+| `showPopups` | `boolean` | `true` | Show hover popups |
+| `fitToMarkers` | `boolean` | `false` | Auto-fit bounds to markers |
+
+> **Note:** `GeonicDbMap` uses `@geolonia/embed` via dynamic import. Add it to your project separately if needed: `npm install @geolonia/embed`.
+
+## NGSIv2 Client (`@geolonia/geonicdb-sdk/ngsi-v2`)
+
+For NGSIv2-compatible brokers, use the dedicated client:
+
+```typescript
+import { createNgsiV2Client } from '@geolonia/geonicdb-sdk/ngsi-v2';
+
+const client = createNgsiV2Client({
+  baseUrl: 'https://orion.example.com',
+  service: 'mytenant',    // Fiware-Service header
+  servicePath: '/mypath', // Fiware-ServicePath header
+});
+
+// List entities
+const rooms = await client.getEntities({ type: 'Room', limit: 20 });
+
+// Get single entity
+const room = await client.getEntity('Room1');
+
+// Create entity
+await client.createEntity({
+  id: 'Room2',
+  type: 'Room',
+  temperature: { type: 'Number', value: 23 },
+});
+
+// Update attributes
+await client.updateEntityAttributes('Room2', {
+  temperature: { type: 'Number', value: 24 },
+});
+
+// Delete entity
+await client.deleteEntity('Room2');
+```
+
+**`NgsiV2ClientConfig`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `baseUrl` | `string` | Base URL of the NGSIv2 broker |
+| `service` | `string?` | FIWARE service (tenant) |
+| `servicePath` | `string?` | FIWARE service path |

--- a/docs/ja/sdk/index.md
+++ b/docs/ja/sdk/index.md
@@ -118,7 +118,7 @@ function TemporalChart({ client }) {
 
 ### `GeonicDbMap`
 
-[@geolonia/embed](https://geolonia.com/maplibre-gl-js/) を使ってエンティティをマップ上に表示します。
+[@geolonia/embed](https://github.com/geolonia/embed) を使ってエンティティをマップ上に表示します。
 
 ```tsx
 import { GeonicDbMap, useLdEntities } from '@geolonia/geonicdb-sdk/react';

--- a/docs/ja/sdk/index.md
+++ b/docs/ja/sdk/index.md
@@ -1,0 +1,161 @@
+---
+title: "JavaScript SDK"
+description: "@geolonia/geonicdb-sdk — NGSI-LD クライアント、React hooks、NGSIv2 クライアント"
+outline: deep
+---
+
+# JavaScript SDK
+
+`@geolonia/geonicdb-sdk` は GeonicDB NGSI-LD コンテキストブローカー向けの TypeScript/JavaScript クライアントです。React hooks および NGSIv2 クライアントもオプションで提供します。
+
+## インストール
+
+```bash
+npm install @geolonia/geonicdb-sdk
+```
+
+React hooks とマップコンポーネントを使用する場合は、React 18 または 19 が必要です。
+
+```bash
+npm install @geolonia/geonicdb-sdk react react-dom
+```
+
+## サブパス
+
+SDK はバンドルサイズを最適化するため 3 つのサブパスに分割されています。
+
+| サブパス | 内容 | React 必須 |
+|---------|------|------------|
+| `@geolonia/geonicdb-sdk` | NGSI-LD クライアント（コア）、DPoP、WebSocket | 不要 |
+| `@geolonia/geonicdb-sdk/react` | React hooks + GeonicDbMap コンポーネント | 必要（optional peerDep） |
+| `@geolonia/geonicdb-sdk/ngsi-v2` | NGSIv2 基本クライアント | 不要 |
+
+## コア (`@geolonia/geonicdb-sdk`)
+
+```typescript
+import GeonicDB from '@geolonia/geonicdb-sdk';
+
+const db = new GeonicDB({
+  apiKey: 'your-api-key',
+  tenant: 'your-tenant',
+  baseUrl: 'https://your-geonicdb.example.com',
+});
+
+// ログイン（DPoP は対応環境で自動適用）
+await db.login('user@example.com', 'password');
+
+// エンティティ取得
+const rooms = await db.getEntities({ type: 'Room' });
+
+// エンティティ作成
+await db.createEntity({
+  id: 'urn:ngsi-ld:Room:001',
+  type: 'Room',
+  temperature: { type: 'Property', value: 22.5 },
+});
+```
+
+## React Hooks (`@geolonia/geonicdb-sdk/react`)
+
+### `useLdEntities`
+
+NGSI-LD エンティティをリアクティブに取得します。
+
+```tsx
+import GeonicDB from '@geolonia/geonicdb-sdk';
+import { useLdEntities } from '@geolonia/geonicdb-sdk/react';
+
+const db = new GeonicDB({ apiKey: '...', tenant: '...', baseUrl: '...' });
+
+function RoomList() {
+  const { entities, loading, error, refetch } = useLdEntities(db, {
+    type: 'Room',
+    limit: 50,
+  });
+
+  if (loading) return <p>読み込み中...</p>;
+  if (error) return <p>エラー: {error.message}</p>;
+
+  return (
+    <ul>
+      {entities.map(e => <li key={e.id}>{e.id}</li>)}
+    </ul>
+  );
+}
+```
+
+**オプション:**
+
+| オプション | 型 | 説明 |
+|-----------|-----|------|
+| `type` | `string` | エンティティ型でフィルタ |
+| `limit` | `number` | 最大取得件数 |
+| `attrs` | `string[]` | 取得する属性のリスト |
+| `q` | `string` | NGSI-LD クエリフィルタ |
+| `scopeQ` | `string` | スコープフィルタ |
+
+**戻り値:** `{ entities, loading, error, refetch }`
+
+### `useTemporalData`
+
+NGSI-LD 時系列データを取得します。
+
+```tsx
+import { useTemporalData } from '@geolonia/geonicdb-sdk/react';
+
+function TemporalChart({ client }) {
+  const { data, loading, error } = useTemporalData(client, {
+    type: 'TemperatureSensor',
+    timerel: 'between',
+    timeAt: '2026-01-01T00:00:00Z',
+    endTimeAt: '2026-01-02T00:00:00Z',
+  });
+
+  if (loading) return <p>読み込み中...</p>;
+  return <pre>{JSON.stringify(data, null, 2)}</pre>;
+}
+```
+
+### `GeonicDbMap`
+
+[@geolonia/embed](https://geolonia.com/maplibre-gl-js/) を使ってエンティティをマップ上に表示します。
+
+```tsx
+import { GeonicDbMap, useLdEntities } from '@geolonia/geonicdb-sdk/react';
+
+function EntityMap({ client }) {
+  const { entities } = useLdEntities(client, { type: 'GeoFeature' });
+
+  return (
+    <GeonicDbMap
+      entities={entities}
+      center={[139.7671, 35.6812]}
+      zoom={12}
+      onEntityClick={(e) => console.log(e.id)}
+      fitToMarkers
+    />
+  );
+}
+```
+
+> **注意:** `GeonicDbMap` は `@geolonia/embed` を動的 import で読み込みます。使用する場合は `npm install @geolonia/embed` が必要です。
+
+## NGSIv2 クライアント (`@geolonia/geonicdb-sdk/ngsi-v2`)
+
+NGSIv2 互換ブローカー向けのクライアントです。
+
+```typescript
+import { createNgsiV2Client } from '@geolonia/geonicdb-sdk/ngsi-v2';
+
+const client = createNgsiV2Client({
+  baseUrl: 'https://orion.example.com',
+  service: 'mytenant',
+  servicePath: '/mypath',
+});
+
+const rooms = await client.getEntities({ type: 'Room', limit: 20 });
+const room = await client.getEntity('Room1');
+await client.createEntity({ id: 'Room2', type: 'Room', temperature: { type: 'Number', value: 23 } });
+await client.updateEntityAttributes('Room2', { temperature: { type: 'Number', value: 24 } });
+await client.deleteEntity('Room2');
+```

--- a/docs/ja/sdk/index.md
+++ b/docs/ja/sdk/index.md
@@ -142,7 +142,7 @@ function EntityMap({ client }) {
 
 ## NGSIv2 クライアント (`@geolonia/geonicdb-sdk/ngsi-v2`)
 
-NGSIv2 互換ブローカー向けのクライアントです。
+NGSIv2 互換 Context Broker 向けのクライアントです。
 
 ```typescript
 import { createNgsiV2Client } from '@geolonia/geonicdb-sdk/ngsi-v2';


### PR DESCRIPTION
## Summary

- Add `docs/en/sdk/index.md` and `docs/ja/sdk/index.md` with full API reference for the new SDK subpaths
- Documents `useLdEntities`, `useTemporalData`, `GeonicDbMap`, and `NgsiV2Client`
- Updates `CHANGELOG.md` with the new entry

## Related

Corresponds to geolonia/geonicdb#1260 which adds `./react` and `./ngsi-v2` subpaths to `@geolonia/geonicdb-sdk`.

Closes #228

## Test plan

- [ ] Verify docs render correctly in VitePress locally
- [ ] Verify en/ja sidebar navigation works after wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * JavaScript SDK の新しいドキュメントページを英語・日本語で追加しました。
  * SDK サブパス（コア／React Hooks／NGSIv2）の概要、インストール手順、React 必要条件、各種サンプル（`useLdEntities`、`useTemporalData`、地図コンポーネント、NGSIv2 CRUD）と設定項目を掲載しました。
  * 併せてリリースノート（未公開分）に関連する追記を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->